### PR TITLE
Introduce custom exception hierarchy, replace std::expected<T,string>

### DIFF
--- a/include/improc/core/format_traits.hpp
+++ b/include/improc/core/format_traits.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <opencv2/core.hpp>
+#include <string_view>
 
 namespace improc::core {
 
@@ -13,10 +14,10 @@ struct Float32C3 {};
 
 template<typename Format> struct FormatTraits;  // intentionally undefined — unknown format = compile error
 
-template<> struct FormatTraits<BGR>      { static constexpr int cv_type = CV_8UC3;  static constexpr int channels = 3; };
-template<> struct FormatTraits<Gray>     { static constexpr int cv_type = CV_8UC1;  static constexpr int channels = 1; };
-template<> struct FormatTraits<BGRA>     { static constexpr int cv_type = CV_8UC4;  static constexpr int channels = 4; };
-template<> struct FormatTraits<Float32>  { static constexpr int cv_type = CV_32FC1; static constexpr int channels = 1; };
-template<> struct FormatTraits<Float32C3> { static constexpr int cv_type = CV_32FC3; static constexpr int channels = 3; };
+template<> struct FormatTraits<BGR>       { static constexpr int cv_type = CV_8UC3;  static constexpr int channels = 3; static constexpr std::string_view name = "BGR (CV_8UC3)";       };
+template<> struct FormatTraits<Gray>      { static constexpr int cv_type = CV_8UC1;  static constexpr int channels = 1; static constexpr std::string_view name = "Gray (CV_8UC1)";      };
+template<> struct FormatTraits<BGRA>      { static constexpr int cv_type = CV_8UC4;  static constexpr int channels = 4; static constexpr std::string_view name = "BGRA (CV_8UC4)";      };
+template<> struct FormatTraits<Float32>   { static constexpr int cv_type = CV_32FC1; static constexpr int channels = 1; static constexpr std::string_view name = "Float32 (CV_32FC1)";  };
+template<> struct FormatTraits<Float32C3> { static constexpr int cv_type = CV_32FC3; static constexpr int channels = 3; static constexpr std::string_view name = "Float32C3 (CV_32FC3)"; };
 
 } // namespace improc::core

--- a/include/improc/core/image.hpp
+++ b/include/improc/core/image.hpp
@@ -2,10 +2,9 @@
 #pragma once
 
 #include <opencv2/core.hpp>
-#include <stdexcept>
-#include <format>
 #include "improc/core/format_traits.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -13,14 +12,13 @@ template<AnyFormat Format>
 class Image {
 public:
     explicit Image(cv::Mat mat) : mat_(std::move(mat)) {
-        if (mat_.empty()) {
-            throw std::invalid_argument("Image: mat must not be empty");
-        }
-        if (mat_.type() != FormatTraits<Format>::cv_type) {
-            throw std::invalid_argument(
-                std::format("Image: expected cv_type {}, got {}",
-                    FormatTraits<Format>::cv_type, mat_.type()));
-        }
+        if (mat_.empty())
+            throw ParameterError{"mat", "must not be empty", "Image constructor"};
+        if (mat_.type() != FormatTraits<Format>::cv_type)
+            throw FormatError{
+                std::string(FormatTraits<Format>::name),
+                cv_type_to_name(mat_.type()),
+                "Image constructor"};
     }
 
     Image clone() const { return Image(mat_.clone()); }

--- a/include/improc/core/ops/blur.hpp
+++ b/include/improc/core/ops/blur.hpp
@@ -1,23 +1,24 @@
 // include/improc/core/ops/blur.hpp
 #pragma once
 
-#include <stdexcept>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
 struct GaussianBlur {
     GaussianBlur& kernel_size(int k) {
         if (k <= 0 || k % 2 == 0)
-            throw std::invalid_argument("GaussianBlur: kernel_size must be odd and positive");
+            throw ParameterError{"kernel_size",
+                std::format("must be odd and positive, got {}", k), "GaussianBlur"};
         kernel_size_ = k;
         return *this;
     }
     GaussianBlur& sigma(double s) {
         if (s < 0.0)
-            throw std::invalid_argument("GaussianBlur: sigma must be >= 0");
+            throw ParameterError{"sigma", "must be >= 0", "GaussianBlur"};
         sigma_ = s;
         return *this;
     }
@@ -37,7 +38,8 @@ private:
 struct MedianBlur {
     MedianBlur& kernel_size(int k) {
         if (k <= 0 || k % 2 == 0)
-            throw std::invalid_argument("MedianBlur: kernel_size must be odd and positive");
+            throw ParameterError{"kernel_size",
+                std::format("must be odd and positive, got {}", k), "MedianBlur"};
         kernel_size_ = k;
         return *this;
     }

--- a/include/improc/core/ops/crop.hpp
+++ b/include/improc/core/ops/crop.hpp
@@ -2,11 +2,11 @@
 #pragma once
 
 #include <optional>
-#include <stdexcept>
 #include <format>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -14,28 +14,26 @@ struct Crop {
     Crop& x(int v)      { x_ = v; return *this; }
     Crop& y(int v)      { y_ = v; return *this; }
     Crop& width(int v) {
-        if (v <= 0) throw std::invalid_argument("Crop: width must be positive");
+        if (v <= 0) throw ParameterError{"width", "must be positive", "Crop"};
         width_ = v; return *this;
     }
     Crop& height(int v) {
-        if (v <= 0) throw std::invalid_argument("Crop: height must be positive");
+        if (v <= 0) throw ParameterError{"height", "must be positive", "Crop"};
         height_ = v; return *this;
     }
 
     template<AnyFormat Format>
     Image<Format> operator()(Image<Format> img) const {
-        if (!x_ || !y_ || !width_ || !height_) {
-            throw std::invalid_argument("Crop: all of x, y, width, height must be set");
-        }
+        if (!x_ || !y_ || !width_ || !height_)
+            throw ParameterError{"x/y/width/height", "all four must be set", "Crop"};
         cv::Rect roi(*x_, *y_, *width_, *height_);
-        if (roi.width <= 0 || roi.height <= 0 ||
-            roi.x < 0 || roi.y < 0 ||
+        if (roi.x < 0 || roi.y < 0 ||
             roi.x + roi.width  > img.cols() ||
-            roi.y + roi.height > img.rows()) {
-            throw std::invalid_argument(
-                std::format("Crop: ROI ({},{},{},{}) out of bounds ({}x{})",
-                    roi.x, roi.y, roi.width, roi.height, img.cols(), img.rows()));
-        }
+            roi.y + roi.height > img.rows())
+            throw ParameterError{"ROI",
+                std::format("({},{},{},{}) out of bounds for image {}x{}",
+                    roi.x, roi.y, roi.width, roi.height, img.cols(), img.rows()),
+                "Crop"};
         return Image<Format>(img.mat()(roi).clone());
     }
 

--- a/include/improc/core/ops/flip.hpp
+++ b/include/improc/core/ops/flip.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <stdexcept>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
 #include "improc/core/ops/axis.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -18,7 +18,7 @@ struct Flip {
             case Axis::Horizontal: flip_code =  1; break;
             case Axis::Vertical:   flip_code =  0; break;
             case Axis::Both:       flip_code = -1; break;
-            default: throw std::invalid_argument("Flip: unknown Axis value");
+            default: throw ParameterError{"axis", "unknown Axis value", "Flip"};
         }
         cv::Mat dst;
         cv::flip(img.mat(), dst, flip_code);

--- a/include/improc/core/ops/morphology.hpp
+++ b/include/improc/core/ops/morphology.hpp
@@ -1,11 +1,11 @@
 // include/improc/core/ops/morphology.hpp
 #pragma once
 
-#include <stdexcept>
 #include <utility>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -25,11 +25,12 @@ inline int morph_shape_to_cv(MorphShape s) {
 struct Dilate {
     Dilate& kernel_size(int k) {
         if (k <= 0 || k % 2 == 0)
-            throw std::invalid_argument("Dilate: kernel_size must be odd and positive");
+            throw ParameterError{"kernel_size",
+                std::format("must be odd and positive, got {}", k), "Dilate"};
         kernel_size_ = k; return *this;
     }
     Dilate& iterations(int n) {
-        if (n <= 0) throw std::invalid_argument("Dilate: iterations must be positive");
+        if (n <= 0) throw ParameterError{"iterations", "must be positive", "Dilate"};
         iterations_ = n; return *this;
     }
     Dilate& shape(MorphShape s) { shape_ = s; return *this; }
@@ -53,11 +54,12 @@ private:
 struct Erode {
     Erode& kernel_size(int k) {
         if (k <= 0 || k % 2 == 0)
-            throw std::invalid_argument("Erode: kernel_size must be odd and positive");
+            throw ParameterError{"kernel_size",
+                std::format("must be odd and positive, got {}", k), "Erode"};
         kernel_size_ = k; return *this;
     }
     Erode& iterations(int n) {
-        if (n <= 0) throw std::invalid_argument("Erode: iterations must be positive");
+        if (n <= 0) throw ParameterError{"iterations", "must be positive", "Erode"};
         iterations_ = n; return *this;
     }
     Erode& shape(MorphShape s) { shape_ = s; return *this; }

--- a/include/improc/core/ops/pad.hpp
+++ b/include/improc/core/ops/pad.hpp
@@ -1,12 +1,11 @@
 // include/improc/core/ops/pad.hpp
 #pragma once
 
-#include <stdexcept>
-#include <string>
 #include <utility>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -25,19 +24,19 @@ inline int pad_mode_to_cv(PadMode m) {
 
 struct Pad {
     Pad& top(int v) {
-        if (v < 0) throw std::invalid_argument("Pad: top must be >= 0");
+        if (v < 0) throw ParameterError{"top", "must be >= 0", "Pad"};
         top_ = v; return *this;
     }
     Pad& bottom(int v) {
-        if (v < 0) throw std::invalid_argument("Pad: bottom must be >= 0");
+        if (v < 0) throw ParameterError{"bottom", "must be >= 0", "Pad"};
         bottom_ = v; return *this;
     }
     Pad& left(int v) {
-        if (v < 0) throw std::invalid_argument("Pad: left must be >= 0");
+        if (v < 0) throw ParameterError{"left", "must be >= 0", "Pad"};
         left_ = v; return *this;
     }
     Pad& right(int v) {
-        if (v < 0) throw std::invalid_argument("Pad: right must be >= 0");
+        if (v < 0) throw ParameterError{"right", "must be >= 0", "Pad"};
         right_ = v; return *this;
     }
     Pad& mode(PadMode m)      { mode_  = m; return *this; }
@@ -46,14 +45,14 @@ struct Pad {
     template<AnyFormat Format>
     Image<Format> operator()(Image<Format> img) const {
         if (top_ == 0 && bottom_ == 0 && left_ == 0 && right_ == 0)
-            throw std::invalid_argument("Pad: at least one side must be > 0");
+            throw ParameterError{"top/bottom/left/right", "at least one side must be > 0", "Pad"};
         cv::Mat dst;
         try {
             cv::copyMakeBorder(img.mat(), dst,
                                top_, bottom_, left_, right_,
                                detail::pad_mode_to_cv(mode_), value_);
         } catch (const cv::Exception& e) {
-            throw std::runtime_error("Pad: " + std::string(e.what()));
+            throw ParameterError{"mode", std::string(e.what()), "Pad"};
         }
         return Image<Format>(std::move(dst));
     }
@@ -88,7 +87,7 @@ struct PadToSquare {
                                top, bottom, left, right,
                                detail::pad_mode_to_cv(mode_), value_);
         } catch (const cv::Exception& e) {
-            throw std::runtime_error("PadToSquare: " + std::string(e.what()));
+            throw ParameterError{"mode", std::string(e.what()), "PadToSquare"};
         }
         return Image<Format>(std::move(dst));
     }

--- a/include/improc/core/ops/resize.hpp
+++ b/include/improc/core/ops/resize.hpp
@@ -2,22 +2,22 @@
 #pragma once
 
 #include <optional>
-#include <stdexcept>
 #include <cmath>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
 struct Resize {
     Resize& width(int w) {
-        if (w <= 0) throw std::invalid_argument("Resize: width must be positive");
+        if (w <= 0) throw ParameterError{"width", "must be positive", "Resize"};
         width_  = w;
         return *this;
     }
     Resize& height(int h) {
-        if (h <= 0) throw std::invalid_argument("Resize: height must be positive");
+        if (h <= 0) throw ParameterError{"height", "must be positive", "Resize"};
         height_ = h;
         return *this;
     }
@@ -25,7 +25,7 @@ struct Resize {
     template<AnyFormat Format>
     Image<Format> operator()(Image<Format> img) const {
         if (!width_ && !height_) {
-            throw std::invalid_argument("Resize: at least one of width or height must be set");
+            throw ParameterError{"width/height", "at least one must be set", "Resize"};
         }
 
         int w = width_.value_or(0);

--- a/include/improc/core/ops/rotate.hpp
+++ b/include/improc/core/ops/rotate.hpp
@@ -1,26 +1,25 @@
 #pragma once
 
 #include <optional>
-#include <stdexcept>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
 struct Rotate {
     Rotate& angle(double deg) { angle_ = deg; return *this; }
     Rotate& scale(double s) {
-        if (s <= 0.0) throw std::invalid_argument("Rotate: scale must be positive");
+        if (s <= 0.0) throw ParameterError{"scale", "must be positive", "Rotate"};
         scale_ = s;
         return *this;
     }
 
     template<AnyFormat Format>
     Image<Format> operator()(Image<Format> img) const {
-        if (!angle_) {
-            throw std::invalid_argument("Rotate: angle must be set");
-        }
+        if (!angle_)
+            throw ParameterError{"angle", "must be set before calling operator()", "Rotate"};
         cv::Point2f center(img.cols() / 2.0f, img.rows() / 2.0f);
         cv::Mat M = cv::getRotationMatrix2D(center, *angle_, scale_);
         cv::Mat dst;

--- a/include/improc/core/ops/threshold.hpp
+++ b/include/improc/core/ops/threshold.hpp
@@ -1,11 +1,11 @@
 // include/improc/core/ops/threshold.hpp
 #pragma once
 
-#include <stdexcept>
 #include <utility>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -36,7 +36,8 @@ struct Threshold {
         try {
             cv::threshold(img.mat(), dst, value_, max_value_, detail::to_cv_type(mode_));
         } catch (const cv::Exception& e) {
-            throw std::runtime_error("Threshold: " + std::string(e.what()));
+            throw ParameterError{"mode/value",
+                std::string(e.what()), "Threshold"};
         }
         return Image<Format>(std::move(dst));
     }

--- a/include/improc/error.hpp
+++ b/include/improc/error.hpp
@@ -1,0 +1,51 @@
+// include/improc/error.hpp
+#pragma once
+
+#include <string>
+
+namespace improc {
+
+// Value type used as the error channel in std::expected<T, improc::Error>.
+// Used for environmental / runtime errors where the caller should handle the
+// failure gracefully (no try/catch needed).
+struct Error {
+    enum class Code {
+        NoImages,           // ImageLoader found no valid images
+        EmptyDataset,       // Dataset directory has no class subdirectories
+        DirectoryNotFound,  // Requested directory does not exist
+        InvalidModelFile,   // Model path invalid or extension unsupported
+        CameraUnavailable,  // Camera device could not be opened
+        CameraFrameEmpty,   // Camera is open but returned an empty frame
+    };
+
+    Code        code;
+    std::string message;
+
+    // Factory helpers — rich, context-aware messages
+    static Error no_images(const std::string& dir) {
+        return {Code::NoImages,
+                "No valid images (.jpg, .jpeg, .png) found in: " + dir};
+    }
+    static Error empty_dataset(const std::string& dir) {
+        return {Code::EmptyDataset,
+                "Dataset directory contains no class subdirectories: " + dir};
+    }
+    static Error directory_not_found(const std::string& path) {
+        return {Code::DirectoryNotFound,
+                "Directory not found or is not a directory: " + path};
+    }
+    static Error invalid_model_file(const std::string& path, const std::string& reason) {
+        return {Code::InvalidModelFile,
+                "Invalid model file '" + path + "': " + reason};
+    }
+    static Error camera_unavailable(int device_id) {
+        return {Code::CameraUnavailable,
+                "Camera device " + std::to_string(device_id) + " could not be opened"};
+    }
+    static Error camera_frame_empty(int device_id) {
+        return {Code::CameraFrameEmpty,
+                "Camera device " + std::to_string(device_id) + " returned an empty frame"};
+    }
+};
+
+} // namespace improc

--- a/include/improc/exceptions.hpp
+++ b/include/improc/exceptions.hpp
@@ -1,0 +1,154 @@
+// include/improc/exceptions.hpp
+#pragma once
+
+#include <exception>
+#include <filesystem>
+#include <format>
+#include <string>
+#include <opencv2/core.hpp>
+
+namespace improc {
+
+// ---------------------------------------------------------------------------
+// Utility: human-readable cv_type name (mirrors FormatTraits::name)
+// ---------------------------------------------------------------------------
+inline std::string cv_type_to_name(int cv_type) {
+    switch (cv_type) {
+        case CV_8UC1:  return "Gray (CV_8UC1)";
+        case CV_8UC3:  return "BGR (CV_8UC3)";
+        case CV_8UC4:  return "BGRA (CV_8UC4)";
+        case CV_32FC1: return "Float32 (CV_32FC1)";
+        case CV_32FC3: return "Float32C3 (CV_32FC3)";
+        default:       return std::format("unknown (cv_type={})", cv_type);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Base
+// ---------------------------------------------------------------------------
+class Exception : public std::exception {
+public:
+    explicit Exception(std::string message) : message_(std::move(message)) {}
+    const char* what() const noexcept override { return message_.c_str(); }
+protected:
+    std::string message_;
+};
+
+// ---------------------------------------------------------------------------
+// FormatError — Image<Format> type mismatch
+// ---------------------------------------------------------------------------
+class FormatError : public Exception {
+public:
+    FormatError(std::string expected_format, std::string actual_format,
+                std::string context = "")
+        : Exception(std::format("FormatError: expected {}, got{}{}",
+                    expected_format, " " + actual_format,
+                    context.empty() ? "" : ". Context: " + context))
+        , expected_format_(std::move(expected_format))
+        , actual_format_(std::move(actual_format))
+        , context_(std::move(context)) {}
+
+    const std::string& expected_format() const { return expected_format_; }
+    const std::string& actual_format()   const { return actual_format_;   }
+    const std::string& context()         const { return context_;         }
+
+private:
+    std::string expected_format_;
+    std::string actual_format_;
+    std::string context_;
+};
+
+// ---------------------------------------------------------------------------
+// ParameterError — invalid argument / missing required parameter
+// ---------------------------------------------------------------------------
+class ParameterError : public Exception {
+public:
+    ParameterError(std::string param_name, std::string constraint,
+                   std::string context = "")
+        : Exception(std::format("ParameterError: '{}' {}{}",
+                    param_name, constraint,
+                    context.empty() ? "" : ". Context: " + context))
+        , param_name_(std::move(param_name))
+        , constraint_(std::move(constraint))
+        , context_(std::move(context)) {}
+
+    const std::string& param_name()  const { return param_name_; }
+    const std::string& constraint()  const { return constraint_;  }
+    const std::string& context()     const { return context_;     }
+
+private:
+    std::string param_name_;
+    std::string constraint_;
+    std::string context_;
+};
+
+// ---------------------------------------------------------------------------
+// IoError and subclasses — file / camera I/O failures
+// ---------------------------------------------------------------------------
+class IoError : public Exception {
+public:
+    explicit IoError(std::string message) : Exception(std::move(message)) {}
+};
+
+class FileNotFoundError : public IoError {
+public:
+    explicit FileNotFoundError(const std::filesystem::path& path)
+        : IoError(std::format("FileNotFoundError: '{}' not found or inaccessible",
+                  path.string()))
+        , path_(path) {}
+
+    const std::filesystem::path& path() const { return path_; }
+
+private:
+    std::filesystem::path path_;
+};
+
+class CameraError : public IoError {
+public:
+    CameraError(int device_id, std::string reason)
+        : IoError(std::format("CameraError: device {} — {}",
+                  device_id, reason))
+        , device_id_(device_id) {}
+
+    int device_id() const { return device_id_; }
+
+private:
+    int device_id_;
+};
+
+// ---------------------------------------------------------------------------
+// ModelError — model loading or inference failure
+// ---------------------------------------------------------------------------
+class ModelError : public Exception {
+public:
+    ModelError(const std::filesystem::path& path, std::string reason)
+        : Exception(std::format("ModelError: '{}' — {}",
+                    path.string(), reason))
+        , model_path_(path)
+        , reason_(std::move(reason)) {}
+
+    const std::filesystem::path& model_path() const { return model_path_; }
+    const std::string&           reason()      const { return reason_;     }
+
+private:
+    std::filesystem::path model_path_;
+    std::string           reason_;
+};
+
+// ---------------------------------------------------------------------------
+// DataError — ImageLoader / Dataset failures
+// ---------------------------------------------------------------------------
+class DataError : public Exception {
+public:
+    explicit DataError(std::string message) : Exception(std::move(message)) {}
+};
+
+// ---------------------------------------------------------------------------
+// AugmentError — augmentation pipeline failures
+// ---------------------------------------------------------------------------
+class AugmentError : public Exception {
+public:
+    explicit AugmentError(std::string message) : Exception(std::move(message)) {}
+};
+
+} // namespace improc

--- a/include/improc/io/camera_capture.hpp
+++ b/include/improc/io/camera_capture.hpp
@@ -7,8 +7,10 @@
 #include <opencv2/opencv.hpp>
 #include <thread>
 #include <atomic>
+#include <expected>
 #include <shared_mutex>
 #include <string>
+#include "improc/error.hpp"
 
 namespace improc::io {
 
@@ -23,21 +25,26 @@ public:
   CameraCapture& operator=(CameraCapture&&) = delete;
 
   void stop();
-  cv::Mat getFrame();
+
+  // Returns the latest captured frame, or an Error if the camera is
+  // unavailable or has not produced a frame yet.
+  std::expected<cv::Mat, improc::Error> getFrame();
+
   const std::string& getWindowName() const;
 
 private:
   void start();
   void captureLoop();
 
-  unsigned int camera_id_;
+  unsigned int      camera_id_;
   std::atomic<bool> keep_running_;
   std::atomic<bool> stopped_;
-  std::thread capture_thread_;
-  cv::VideoCapture cap_;
-  cv::Mat frame_;
+  std::atomic<bool> camera_available_{false};
+  std::thread       capture_thread_;
+  cv::VideoCapture  cap_;
+  cv::Mat           frame_;
   std::shared_mutex frame_mutex_;
-  std::string window_name_ = "Frame";
+  std::string       window_name_ = "Frame";
 };
 
 } // namespace improc::io

--- a/include/improc/ml/augment/color.hpp
+++ b/include/improc/ml/augment/color.hpp
@@ -3,12 +3,11 @@
 
 #include <random>
 #include <cmath>
-#include <stdexcept>
-#include <string>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
 #include "improc/ml/augment/detail.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -19,9 +18,9 @@ using improc::core::Image;
 struct RandomBrightness : detail::BindMixin<RandomBrightness> {
     RandomBrightness& range(float low, float high) {
         if (low <= 0.0f)
-            throw std::invalid_argument("RandomBrightness: low must be > 0");
+            throw ParameterError{"low", "must be > 0", "RandomBrightness"};
         if (low > high)
-            throw std::invalid_argument("RandomBrightness: low must be <= high");
+            throw ParameterError{"low", "must be <= high", "RandomBrightness"};
         low_ = low; high_ = high; return *this;
     }
 
@@ -46,9 +45,9 @@ private:
 struct RandomContrast : detail::BindMixin<RandomContrast> {
     RandomContrast& range(float low, float high) {
         if (low <= 0.0f)
-            throw std::invalid_argument("RandomContrast: low must be > 0");
+            throw ParameterError{"low", "must be > 0", "RandomContrast"};
         if (low > high)
-            throw std::invalid_argument("RandomContrast: low must be <= high");
+            throw ParameterError{"low", "must be <= high", "RandomContrast"};
         low_ = low; high_ = high; return *this;
     }
 
@@ -73,25 +72,25 @@ private:
 
 struct ColorJitter : detail::BindMixin<ColorJitter> {
     ColorJitter& brightness(float low, float high) {
-        if (low <= 0.0f) throw std::invalid_argument("ColorJitter: brightness low must be > 0");
-        if (low > high)  throw std::invalid_argument("ColorJitter: brightness low must be <= high");
+        if (low <= 0.0f) throw ParameterError{"brightness.low", "must be > 0", "ColorJitter"};
+        if (low > high)  throw ParameterError{"brightness.low", "must be <= high", "ColorJitter"};
         br_low_ = low; br_high_ = high; return *this;
     }
     ColorJitter& contrast(float low, float high) {
-        if (low <= 0.0f) throw std::invalid_argument("ColorJitter: contrast low must be > 0");
-        if (low > high)  throw std::invalid_argument("ColorJitter: contrast low must be <= high");
+        if (low <= 0.0f) throw ParameterError{"contrast.low", "must be > 0", "ColorJitter"};
+        if (low > high)  throw ParameterError{"contrast.low", "must be <= high", "ColorJitter"};
         ct_low_ = low; ct_high_ = high; return *this;
     }
     ColorJitter& saturation(float low, float high) {
-        if (low <= 0.0f) throw std::invalid_argument("ColorJitter: saturation low must be > 0");
-        if (low > high)  throw std::invalid_argument("ColorJitter: saturation low must be <= high");
+        if (low <= 0.0f) throw ParameterError{"saturation.low", "must be > 0", "ColorJitter"};
+        if (low > high)  throw ParameterError{"saturation.low", "must be <= high", "ColorJitter"};
         sa_low_ = low; sa_high_ = high; return *this;
     }
     ColorJitter& hue(float low, float high) {
         if (std::abs(low) > 180.0f || std::abs(high) > 180.0f)
-            throw std::invalid_argument("ColorJitter: hue values must be in [-180, 180]");
+            throw ParameterError{"hue", "values must be in [-180, 180]", "ColorJitter"};
         if (low > high)
-            throw std::invalid_argument("ColorJitter: hue low must be <= high");
+            throw ParameterError{"hue.low", "must be <= high", "ColorJitter"};
         hu_low_ = low; hu_high_ = high; return *this;
     }
 
@@ -141,7 +140,7 @@ struct ColorJitter : detail::BindMixin<ColorJitter> {
         try {
             return Image<Format>(std::move(dst));
         } catch (const cv::Exception& e) {
-            throw std::runtime_error("ColorJitter: " + std::string(e.what()));
+            throw AugmentError{"ColorJitter: " + std::string(e.what())};
         }
     }
 

--- a/include/improc/ml/augment/compose.hpp
+++ b/include/improc/ml/augment/compose.hpp
@@ -4,11 +4,11 @@
 #include <concepts>
 #include <functional>
 #include <random>
-#include <stdexcept>
 #include <vector>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
 #include "improc/ml/augment/detail.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -47,7 +47,7 @@ private:
 
     static float validate_p(float p) {
         if (p < 0.0f || p > 1.0f)
-            throw std::invalid_argument("RandomApply: p must be in [0, 1]");
+            throw ParameterError{"p", std::format("must be in [0, 1], got {}", p), "RandomApply"};
         return p;
     }
 
@@ -75,7 +75,7 @@ struct OneOf : detail::BindMixin<OneOf<Format>> {
 
     Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         if (options_.empty())
-            throw std::logic_error("OneOf: no augmentations added");
+            throw AugmentError{"OneOf: operator() called with no augmentations added"};
         std::uniform_int_distribution<std::size_t> d(0, options_.size() - 1);
         return options_[d(rng)](std::move(img), rng);
     }

--- a/include/improc/ml/augment/geometric.hpp
+++ b/include/improc/ml/augment/geometric.hpp
@@ -3,13 +3,13 @@
 
 #include <cmath>
 #include <random>
-#include <stdexcept>
 #include <utility>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
 #include "improc/core/ops/axis.hpp"
 #include "improc/ml/augment/detail.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -19,7 +19,7 @@ using improc::core::Image;
 struct RandomFlip : detail::BindMixin<RandomFlip> {
     RandomFlip& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
-            throw std::invalid_argument("RandomFlip: p must be in [0, 1]");
+            throw ParameterError{"p", std::format("must be in [0, 1], got {}", prob), "RandomFlip"};
         p_ = prob; return *this;
     }
     RandomFlip& axis(core::Axis a) { axis_ = a; return *this; }
@@ -48,12 +48,12 @@ private:
 struct RandomRotate : detail::BindMixin<RandomRotate> {
     RandomRotate& range(float min_deg, float max_deg) {
         if (min_deg > max_deg)
-            throw std::invalid_argument("RandomRotate: min_deg must be <= max_deg");
+            throw ParameterError{"min_deg", "must be <= max_deg", "RandomRotate"};
         min_deg_ = min_deg; max_deg_ = max_deg; return *this;
     }
     RandomRotate& scale(float s) {
         if (s <= 0.0f)
-            throw std::invalid_argument("RandomRotate: scale must be > 0");
+            throw ParameterError{"scale", "must be > 0", "RandomRotate"};
         scale_ = s; return *this;
     }
 
@@ -67,7 +67,7 @@ struct RandomRotate : detail::BindMixin<RandomRotate> {
         try {
             cv::warpAffine(img.mat(), dst, M, img.mat().size());
         } catch (const cv::Exception& e) {
-            throw std::runtime_error("RandomRotate: " + std::string(e.what()));
+            throw AugmentError{"RandomRotate: " + std::string(e.what())};
         }
         return Image<Format>(std::move(dst));
     }
@@ -80,20 +80,23 @@ private:
 
 struct RandomCrop : detail::BindMixin<RandomCrop> {
     RandomCrop& width(int w) {
-        if (w <= 0) throw std::invalid_argument("RandomCrop: width must be positive");
+        if (w <= 0) throw ParameterError{"width", "must be positive", "RandomCrop"};
         width_ = w; return *this;
     }
     RandomCrop& height(int h) {
-        if (h <= 0) throw std::invalid_argument("RandomCrop: height must be positive");
+        if (h <= 0) throw ParameterError{"height", "must be positive", "RandomCrop"};
         height_ = h; return *this;
     }
 
     template<AnyFormat Format>
     Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         if (width_ <= 0 || height_ <= 0)
-            throw std::invalid_argument("RandomCrop: width and height must both be set");
+            throw ParameterError{"width/height", "both must be set", "RandomCrop"};
         if (width_ > img.cols() || height_ > img.rows())
-            throw std::invalid_argument("RandomCrop: crop size exceeds image dimensions");
+            throw ParameterError{"width/height",
+                std::format("crop {}x{} exceeds image {}x{}",
+                    width_, height_, img.cols(), img.rows()),
+                "RandomCrop"};
         std::uniform_int_distribution<int> x_d(0, img.cols() - width_);
         std::uniform_int_distribution<int> y_d(0, img.rows() - height_);
         int x = x_d(rng);
@@ -110,9 +113,9 @@ private:
 struct RandomResize : detail::BindMixin<RandomResize> {
     RandomResize& range(int min_side, int max_side) {
         if (min_side <= 0)
-            throw std::invalid_argument("RandomResize: min_side must be > 0");
+            throw ParameterError{"min_side", "must be > 0", "RandomResize"};
         if (min_side > max_side)
-            throw std::invalid_argument("RandomResize: min_side must be <= max_side");
+            throw ParameterError{"min_side", "must be <= max_side", "RandomResize"};
         min_side_ = min_side; max_side_ = max_side; return *this;
     }
 

--- a/include/improc/ml/augment/noise.hpp
+++ b/include/improc/ml/augment/noise.hpp
@@ -2,12 +2,11 @@
 #pragma once
 
 #include <random>
-#include <stdexcept>
-#include <string>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
 #include "improc/ml/augment/detail.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -17,9 +16,9 @@ using improc::core::Image;
 struct RandomGaussianNoise : detail::BindMixin<RandomGaussianNoise> {
     RandomGaussianNoise& std_dev(float low, float high) {
         if (low < 0.0f)
-            throw std::invalid_argument("RandomGaussianNoise: std_dev low must be >= 0");
+            throw ParameterError{"std_dev.low", "must be >= 0", "RandomGaussianNoise"};
         if (low > high)
-            throw std::invalid_argument("RandomGaussianNoise: std_dev low must be <= high");
+            throw ParameterError{"std_dev.low", "must be <= high", "RandomGaussianNoise"};
         std_low_ = low; std_high_ = high; return *this;
     }
     RandomGaussianNoise& mean(float m) { mean_ = m; return *this; }
@@ -51,7 +50,7 @@ private:
 struct RandomSaltAndPepper : detail::BindMixin<RandomSaltAndPepper> {
     RandomSaltAndPepper& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
-            throw std::invalid_argument("RandomSaltAndPepper: p must be in [0, 1]");
+            throw ParameterError{"p", std::format("must be in [0, 1], got {}", prob), "RandomSaltAndPepper"};
         p_ = prob; return *this;
     }
 
@@ -76,8 +75,7 @@ struct RandomSaltAndPepper : detail::BindMixin<RandomSaltAndPepper> {
                     auto* ptr = dst.ptr<float>(r) + c * channels;
                     for (int ch = 0; ch < channels; ++ch) ptr[ch] = val;
                 } else {
-                    throw std::runtime_error(
-                        "RandomSaltAndPepper: unsupported image depth");
+                    throw AugmentError{"RandomSaltAndPepper: unsupported image depth"};
                 }
             }
         }

--- a/include/improc/ml/dataset.hpp
+++ b/include/improc/ml/dataset.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <expected>
 #include <optional>
+#include "improc/error.hpp"
 
 namespace improc::ml {
 
@@ -36,7 +37,7 @@ public:
      * @param max_per_class Optional: maximum number of images to load per class
      * @return std::expected with error if loading fails
      */
-    std::expected<void, std::string> load_from_directory(const std::filesystem::path& root,
+    std::expected<void, improc::Error> load_from_directory(const std::filesystem::path& root,
                                                          float test_ratio = 0.2f,
                                                          float val_ratio = 0.1f,
                                                          std::optional<size_t> max_per_class = std::nullopt);

--- a/include/improc/ml/dnn_classifier.hpp
+++ b/include/improc/ml/dnn_classifier.hpp
@@ -2,13 +2,13 @@
 #pragma once
 
 #include <filesystem>
-#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
 #include <opencv2/dnn.hpp>
 #include "improc/core/image.hpp"
 #include "improc/ml/result_types.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -16,27 +16,26 @@ using improc::core::Image;
 using improc::core::BGR;
 
 struct DnnClassifier {
-    // Loads model at construction. Throws std::runtime_error if file does not exist,
+    // Loads model at construction. Throws ModelError if file does not exist,
     // has an unsupported extension, or OpenCV fails to parse it.
     explicit DnnClassifier(std::string model_path);
 
     DnnClassifier& top_k(int k) {
-        if (k <= 0) throw std::invalid_argument("DnnClassifier: top_k must be positive");
+        if (k <= 0) throw ParameterError{"top_k", "must be positive", "DnnClassifier"};
         top_k_ = k; return *this;
     }
     DnnClassifier& input_size(int w, int h) {
-        if (w <= 0 || h <= 0) throw std::invalid_argument("DnnClassifier: input_size dimensions must be positive");
+        if (w <= 0 || h <= 0) throw ParameterError{"input_size", "dimensions must be positive", "DnnClassifier"};
         input_w_ = w; input_h_ = h; return *this;
     }
     DnnClassifier& mean(cv::Scalar m)   { mean_ = m; return *this; }
     DnnClassifier& scale(float s) {
-        if (s <= 0.0f) throw std::invalid_argument("DnnClassifier: scale must be positive");
+        if (s <= 0.0f) throw ParameterError{"scale", "must be positive", "DnnClassifier"};
         scale_ = s; return *this;
     }
     DnnClassifier& swap_rb(bool s)                      { swap_rb_ = s; return *this; }
     DnnClassifier& labels(std::vector<std::string> l)   { labels_ = std::move(l); return *this; }
 
-    // Throws std::runtime_error if inference fails.
     std::vector<ClassResult> operator()(const Image<BGR>& img) const;
 
 private:

--- a/include/improc/ml/dnn_detector.hpp
+++ b/include/improc/ml/dnn_detector.hpp
@@ -2,13 +2,13 @@
 #pragma once
 
 #include <filesystem>
-#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
 #include <opencv2/dnn.hpp>
 #include "improc/core/image.hpp"
 #include "improc/ml/result_types.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -21,7 +21,7 @@ struct DnnDetector {
         SSD    // two output blobs: boxes [1,N,4] + scores [1,N,C] (y1,x1,y2,x2 normalized)
     };
 
-    // Loads model at construction. Throws std::runtime_error on failure.
+    // Loads model at construction. Throws ModelError on failure.
     explicit DnnDetector(std::string model_path);
 
     DnnDetector& style(Style s)               { style_ = s; return *this; }
@@ -29,26 +29,26 @@ struct DnnDetector {
     DnnDetector& boxes_layer(std::string n)   { boxes_layer_  = std::move(n); return *this; }
     DnnDetector& scores_layer(std::string n)  { scores_layer_ = std::move(n); return *this; }
     DnnDetector& confidence_threshold(float t) {
-        if (t < 0.0f || t > 1.0f) throw std::invalid_argument("DnnDetector: confidence_threshold must be in [0, 1]");
+        if (t < 0.0f || t > 1.0f) throw ParameterError{"confidence_threshold", "must be in [0, 1]", "DnnDetector"};
         confidence_threshold_ = t; return *this;
     }
     DnnDetector& nms_threshold(float t) {
-        if (t < 0.0f || t > 1.0f) throw std::invalid_argument("DnnDetector: nms_threshold must be in [0, 1]");
+        if (t < 0.0f || t > 1.0f) throw ParameterError{"nms_threshold", "must be in [0, 1]", "DnnDetector"};
         nms_threshold_ = t; return *this;
     }
     DnnDetector& input_size(int w, int h) {
-        if (w <= 0 || h <= 0) throw std::invalid_argument("DnnDetector: input_size dimensions must be positive");
+        if (w <= 0 || h <= 0) throw ParameterError{"input_size", "dimensions must be positive", "DnnDetector"};
         input_w_ = w; input_h_ = h; return *this;
     }
     DnnDetector& mean(cv::Scalar m)                     { mean_ = m; return *this; }
     DnnDetector& scale(float s) {
-        if (s <= 0.0f) throw std::invalid_argument("DnnDetector: scale must be positive");
+        if (s <= 0.0f) throw ParameterError{"scale", "must be positive", "DnnDetector"};
         scale_ = s; return *this;
     }
     DnnDetector& swap_rb(bool s)                        { swap_rb_ = s; return *this; }
     DnnDetector& labels(std::vector<std::string> l)     { labels_ = std::move(l); return *this; }
 
-    // Throws std::runtime_error if inference fails.
+    // Throws Exception if inference fails.
     std::vector<Detection> operator()(const Image<BGR>& img) const;
 
 private:

--- a/include/improc/ml/dnn_forward.hpp
+++ b/include/improc/ml/dnn_forward.hpp
@@ -1,12 +1,12 @@
 // include/improc/ml/dnn_forward.hpp
 #pragma once
 
-#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
 #include <opencv2/dnn.hpp>
 #include "improc/core/image.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -14,22 +14,21 @@ using improc::core::Image;
 using improc::core::BGR;
 
 struct DnnForward {
-    // Loads model at construction. Throws std::runtime_error on failure.
+    // Loads model at construction. Throws ModelError on failure.
     explicit DnnForward(std::string model_path);
 
     DnnForward& input_size(int w, int h) {
-        if (w <= 0 || h <= 0) throw std::invalid_argument("DnnForward: input_size dimensions must be positive");
+        if (w <= 0 || h <= 0) throw ParameterError{"input_size", "dimensions must be positive", "DnnForward"};
         input_w_ = w; input_h_ = h; return *this;
     }
     DnnForward& mean(cv::Scalar m)  { mean_ = m; return *this; }
     DnnForward& scale(float s) {
-        if (s <= 0.0f) throw std::invalid_argument("DnnForward: scale must be positive");
+        if (s <= 0.0f) throw ParameterError{"scale", "must be positive", "DnnForward"};
         scale_ = s; return *this;
     }
     DnnForward& swap_rb(bool s)     { swap_rb_ = s; return *this; }
 
     // Runs forward pass. Returns flattened output tensor (all output values).
-    // Throws std::runtime_error if inference fails.
     std::vector<float> operator()(const Image<BGR>& img) const;
 
 private:

--- a/include/improc/ml/haar_cascade_loader.hpp
+++ b/include/improc/ml/haar_cascade_loader.hpp
@@ -13,7 +13,7 @@ namespace improc::ml {
 class HaarCascadeLoader : public ModelLoaderBase<HaarCascadeLoader, cv::CascadeClassifier> {
 public:
   void load_impl(const std::filesystem::path& path);
-  std::expected<cv::CascadeClassifier, std::string> get_impl() const;
+  std::expected<cv::CascadeClassifier, improc::Error> get_impl() const;
 
 private:
   cv::CascadeClassifier classifier_;

--- a/include/improc/ml/image_loader.hpp
+++ b/include/improc/ml/image_loader.hpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <unordered_set>
 #include <expected>
+#include "improc/error.hpp"
 
 namespace improc::ml {
 
@@ -25,7 +26,7 @@ public:
   /**
    * @brief Load all valid images from the given directory.
    * @param dir_path Path to directory containing image files.
-   * @throws std::runtime_error if the path is not a directory.
+   * @throws FileNotFoundError if the path is not a directory.
    */
   void load_images(const std::filesystem::path& dir_path);
 
@@ -34,10 +35,11 @@ public:
    * @return std::expected with vector of cv::Mat images.
    */
   [[nodiscard]]
-  std::expected<std::vector<cv::Mat>, std::string> get_images();
+  std::expected<std::vector<cv::Mat>, improc::Error> get_images();
 
 private:
   std::vector<cv::Mat> images_;
+  std::string          last_dir_;
   inline static std::unordered_set<std::string> valid_extensions_{ ".jpg", ".jpeg", ".png" };
 
   static std::string to_lower(const std::string& str);

--- a/include/improc/ml/model_loader_base.hpp
+++ b/include/improc/ml/model_loader_base.hpp
@@ -8,6 +8,8 @@
 #include <expected>
 #include <format>
 #include <ranges>
+#include "improc/exceptions.hpp"
+#include "improc/error.hpp"
 
 namespace improc::ml {
 
@@ -22,23 +24,27 @@ template<typename Derived, typename ModelType>
 class ModelLoaderBase {
 public:
   void load_model(const std::filesystem::path& path) {
-    auto expected = check_path(path);
-    if (!expected) {
-      throw std::runtime_error(expected.error());
-    }
-    static_cast<Derived*>(this)->load_impl(expected.value());
+    auto result = check_path(path);
+    if (!result)
+      throw improc::ModelError{path, result.error().message};
+    static_cast<Derived*>(this)->load_impl(result.value());
   }
 
-  [[nodiscard]] std::expected<ModelType, std::string> get_model() const {
+  [[nodiscard]] std::expected<ModelType, improc::Error> get_model() const {
     return static_cast<const Derived*>(this)->get_impl();
   }
 
-  static std::expected<std::filesystem::path, std::string> check_path(const std::filesystem::path& path) {
-    if (std::filesystem::is_regular_file(path) &&
-        valid_extensions().contains(std::ranges::to<std::string>(path.extension().string() | std::views::transform(::tolower)))) {
+  static std::expected<std::filesystem::path, improc::Error> check_path(const std::filesystem::path& path) {
+    auto ext = std::ranges::to<std::string>(
+        path.extension().string() | std::views::transform(::tolower));
+    if (std::filesystem::is_regular_file(path) && valid_extensions().contains(ext))
       return path;
-        }
-    return std::unexpected(std::format("Invalid model file: {}", path.string()));
+    if (!std::filesystem::exists(path))
+      return std::unexpected(improc::Error::invalid_model_file(
+          path.string(), "file not found"));
+    return std::unexpected(improc::Error::invalid_model_file(
+        path.string(),
+        std::format("unsupported extension '{}', expected .yml/.yaml/.xml", ext)));
   }
 
 protected:

--- a/include/improc/threading/frame_pipeline.hpp
+++ b/include/improc/threading/frame_pipeline.hpp
@@ -8,8 +8,8 @@
 #include <mutex>
 #include <optional>
 #include <queue>
-#include <stdexcept>
 #include <thread>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/io/camera_capture.hpp"
 #include "improc/threading/thread_pool.hpp"
@@ -34,9 +34,8 @@ public:
     void start(Processor fn) {
         bool expected = false;
         // Atomically transition running_ false→true; throws if already true.
-        if (!running_.compare_exchange_strong(expected, true)) {
-            throw std::logic_error("FramePipeline: already running");
-        }
+        if (!running_.compare_exchange_strong(expected, true))
+            throw Exception{"FramePipeline: start() called while already running"};
         processor_ = std::move(fn);
         poller_ = std::thread(&FramePipeline<Result>::pollLoop, this);
     }
@@ -63,11 +62,12 @@ private:
     void pollLoop() {
         Processor local_processor = processor_;  // safe: written before thread started
         while (running_) {
-            cv::Mat frame = camera_.getFrame();
-            if (frame.empty()) {
+            auto frame_result = camera_.getFrame();
+            if (!frame_result) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 continue;
             }
+            cv::Mat frame = std::move(*frame_result);
             try {
                 auto future = pool_.submit([local_processor, frame]{ return local_processor(frame); });
                 std::lock_guard<std::mutex> lock(pending_mutex_);

--- a/include/improc/threading/thread_pool.hpp
+++ b/include/improc/threading/thread_pool.hpp
@@ -6,10 +6,10 @@
 #include <future>
 #include <mutex>
 #include <queue>
-#include <stdexcept>
 #include <thread>
 #include <type_traits>
 #include <vector>
+#include "improc/exceptions.hpp"
 
 namespace improc::threading {
 
@@ -53,7 +53,7 @@ auto ThreadPool::submit(Fn&& fn, Args&&... args)
     std::future<R> future = task->get_future();
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
-        if (stop_) throw std::runtime_error("ThreadPool: cannot submit after shutdown");
+        if (stop_) throw Exception{"ThreadPool: cannot submit tasks after shutdown"};
         tasks_.emplace([task]{ (*task)(); });
     }
     cv_.notify_one();

--- a/include/improc/visualization/histogram.hpp
+++ b/include/improc/visualization/histogram.hpp
@@ -1,11 +1,11 @@
 // include/improc/visualization/histogram.hpp
 #pragma once
 
-#include <stdexcept>
 #include <vector>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/pipeline.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::visualization {
 
@@ -16,17 +16,17 @@ using improc::core::Float32;
 
 struct Histogram {
     Histogram& bins(int n) {
-        if (n <= 0) throw std::invalid_argument("Histogram: bins must be positive");
+        if (n <= 0) throw ParameterError{"bins", "must be positive", "Histogram"};
         bins_ = n;
         return *this;
     }
     Histogram& width(int w) {
-        if (w <= 0) throw std::invalid_argument("Histogram: width must be positive");
+        if (w <= 0) throw ParameterError{"width", "must be positive", "Histogram"};
         width_ = w;
         return *this;
     }
     Histogram& height(int h) {
-        if (h <= 0) throw std::invalid_argument("Histogram: height must be positive");
+        if (h <= 0) throw ParameterError{"height", "must be positive", "Histogram"};
         height_ = h;
         return *this;
     }

--- a/include/improc/visualization/line_plot.hpp
+++ b/include/improc/visualization/line_plot.hpp
@@ -1,11 +1,11 @@
 // include/improc/visualization/line_plot.hpp
 #pragma once
 
-#include <stdexcept>
 #include <string>
 #include <vector>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::visualization {
 
@@ -16,17 +16,17 @@ struct LinePlot {
     LinePlot& title(std::string t) { title_ = std::move(t); return *this; }
     LinePlot& color(cv::Scalar c) { color_ = c; return *this; }
     LinePlot& width(int w) {
-        if (w <= 0) throw std::invalid_argument("LinePlot: width must be positive");
+        if (w <= 0) throw ParameterError{"width", "must be positive", "LinePlot"};
         width_ = w;
         return *this;
     }
     LinePlot& height(int h) {
-        if (h <= 0) throw std::invalid_argument("LinePlot: height must be positive");
+        if (h <= 0) throw ParameterError{"height", "must be positive", "LinePlot"};
         height_ = h;
         return *this;
     }
 
-    // Throws std::invalid_argument if values is empty.
+    // Throws ParameterError if values is empty.
     Image<BGR> operator()(const std::vector<float>& values) const;
 
 private:

--- a/include/improc/visualization/scatter.hpp
+++ b/include/improc/visualization/scatter.hpp
@@ -1,11 +1,11 @@
 // include/improc/visualization/scatter.hpp
 #pragma once
 
-#include <stdexcept>
 #include <string>
 #include <vector>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::visualization {
 
@@ -16,22 +16,22 @@ struct Scatter {
     Scatter& title(std::string t) { title_ = std::move(t); return *this; }
     Scatter& color(cv::Scalar c) { color_ = c; return *this; }
     Scatter& point_radius(int r) {
-        if (r <= 0) throw std::invalid_argument("Scatter: point_radius must be positive");
+        if (r <= 0) throw ParameterError{"point_radius", "must be positive", "Scatter"};
         point_radius_ = r;
         return *this;
     }
     Scatter& width(int w) {
-        if (w <= 0) throw std::invalid_argument("Scatter: width must be positive");
+        if (w <= 0) throw ParameterError{"width", "must be positive", "Scatter"};
         width_ = w;
         return *this;
     }
     Scatter& height(int h) {
-        if (h <= 0) throw std::invalid_argument("Scatter: height must be positive");
+        if (h <= 0) throw ParameterError{"height", "must be positive", "Scatter"};
         height_ = h;
         return *this;
     }
 
-    // Throws std::invalid_argument if xs or ys is empty, or xs.size() != ys.size().
+    // Throws ParameterError if xs or ys is empty, or xs.size() != ys.size().
     Image<BGR> operator()(const std::vector<float>& xs,
                           const std::vector<float>& ys) const;
 

--- a/include/improc/visualization/show.hpp
+++ b/include/improc/visualization/show.hpp
@@ -1,10 +1,10 @@
 // include/improc/visualization/show.hpp
 #pragma once
 
-#include <stdexcept>
 #include <string>
 #include <opencv2/highgui.hpp>
 #include "improc/core/image.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::visualization {
 
@@ -16,7 +16,7 @@ struct Show {
         : window_name_(std::move(window_name)) {}
 
     Show& wait_ms(int ms) {
-        if (ms < 0) throw std::invalid_argument("Show: wait_ms must be >= 0");
+        if (ms < 0) throw ParameterError{"wait_ms", "must be >= 0", "Show"};
         wait_ms_ = ms;
         return *this;
     }

--- a/src/core/ops/normalize.cpp
+++ b/src/core/ops/normalize.cpp
@@ -2,6 +2,9 @@
 #include "improc/core/ops/normalize.hpp"
 #include <cmath>
 #include <opencv2/core.hpp>
+#include "improc/exceptions.hpp"
+
+using improc::ParameterError;
 
 namespace improc::core {
 
@@ -41,9 +44,8 @@ Image<Float32C3> Normalize::operator()(Image<Float32C3> img) const {
 }
 
 NormalizeTo::NormalizeTo(float min, float max) : min_(min), max_(max) {
-    if (min >= max) {
-        throw std::invalid_argument("NormalizeTo: min must be less than max");
-    }
+    if (min >= max)
+        throw ParameterError{"min", "must be less than max", "NormalizeTo"};
 }
 
 Image<Float32> NormalizeTo::operator()(Image<Float32> img) const {
@@ -77,9 +79,8 @@ Image<Float32C3> NormalizeTo::operator()(Image<Float32C3> img) const {
 }
 
 Standardize::Standardize(float mean, float std_dev) : mean_(mean), std_dev_(std_dev) {
-    if (std_dev <= 0.0f) {
-        throw std::invalid_argument("Standardize: std_dev must be positive");
-    }
+    if (std_dev <= 0.0f)
+        throw ParameterError{"std_dev", "must be positive", "Standardize"};
 }
 
 Image<Float32> Standardize::operator()(Image<Float32> img) const {

--- a/src/io/camera_capture.cpp
+++ b/src/io/camera_capture.cpp
@@ -31,8 +31,12 @@ void CameraCapture::stop() {
   }
 }
 
-cv::Mat CameraCapture::getFrame() {
+std::expected<cv::Mat, improc::Error> CameraCapture::getFrame() {
+  if (!camera_available_)
+    return std::unexpected(improc::Error::camera_unavailable(camera_id_));
   std::shared_lock<std::shared_mutex> lock(frame_mutex_);
+  if (frame_.empty())
+    return std::unexpected(improc::Error::camera_frame_empty(camera_id_));
   return frame_.clone();
 }
 
@@ -46,10 +50,10 @@ void CameraCapture::start() {
 
 void CameraCapture::captureLoop() {
   cap_.open(camera_id_);
-  if (!cap_.isOpened()) {
-    std::cerr << "Cannot open camera " << camera_id_ << std::endl;
-    return;
-  }
+  if (!cap_.isOpened())
+    return;  // camera_available_ stays false; getFrame() will report the error
+
+  camera_available_ = true;
 
   while (keep_running_) {
     cv::Mat temp_frame;

--- a/src/ml/dataset.cpp
+++ b/src/ml/dataset.cpp
@@ -12,13 +12,12 @@
 
 namespace improc::ml {
 
-std::expected<void, std::string> Dataset::load_from_directory(const std::filesystem::path& root,
-                                                              float test_ratio,
-                                                              float val_ratio,
-                                                              std::optional<size_t> max_per_class) {
-    if (!std::filesystem::exists(root) || !std::filesystem::is_directory(root)) {
-        return std::unexpected(std::format("Invalid dataset directory: {}", root.string()));
-    }
+std::expected<void, improc::Error> Dataset::load_from_directory(const std::filesystem::path& root,
+                                                               float test_ratio,
+                                                               float val_ratio,
+                                                               std::optional<size_t> max_per_class) {
+    if (!std::filesystem::exists(root) || !std::filesystem::is_directory(root))
+        return std::unexpected(improc::Error::directory_not_found(root.string()));
 
     class_to_label_.clear();
     label_to_class_.clear();
@@ -36,9 +35,9 @@ std::expected<void, std::string> Dataset::load_from_directory(const std::filesys
         loader.load_images(class_dir);
         auto result = loader.get_images();
 
-        if (!result) {
-            return std::unexpected(std::format("Failed to load images from class '{}': {}", class_name, result.error()));
-        }
+        if (!result)
+            return std::unexpected(improc::Error::no_images(
+                class_dir.string() + " (class '" + class_name + "'): " + result.error().message));
 
         auto images = std::move(result.value());
         if (max_per_class && images.size() > *max_per_class) {

--- a/src/ml/dnn_classifier.cpp
+++ b/src/ml/dnn_classifier.cpp
@@ -11,22 +11,22 @@ const std::unordered_set<std::string>& DnnClassifier::valid_extensions() {
 }
 
 DnnClassifier::DnnClassifier(std::string model_path) {
-    if (!std::filesystem::exists(model_path))
-        throw std::runtime_error("DnnClassifier: model file not found: " + model_path);
+    std::filesystem::path p{model_path};
+    if (!std::filesystem::exists(p))
+        throw ModelError{p, "file not found"};
 
-    std::string ext = std::filesystem::path(model_path).extension().string();
+    std::string ext = p.extension().string();
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-    const auto& valid = valid_extensions();
-    if (!valid.contains(ext))
-        throw std::runtime_error("DnnClassifier: unsupported model extension '" + ext + "': " + model_path);
+    if (!valid_extensions().contains(ext))
+        throw ModelError{p, "unsupported extension '" + ext + "'"};
 
     try {
         net_ = cv::dnn::readNet(model_path);
     } catch (const cv::Exception& e) {
-        throw std::runtime_error("DnnClassifier: failed to load model: " + std::string(e.what()));
+        throw ModelError{p, "failed to parse model: " + std::string(e.what())};
     }
     if (net_.empty())
-        throw std::runtime_error("DnnClassifier: loaded model is empty: " + model_path);
+        throw ModelError{p, "loaded model is empty"};
 }
 
 std::vector<ClassResult> DnnClassifier::operator()(const Image<BGR>& img) const {

--- a/src/ml/dnn_detector.cpp
+++ b/src/ml/dnn_detector.cpp
@@ -2,6 +2,11 @@
 #include "improc/ml/dnn_detector.hpp"
 #include <algorithm>
 #include <filesystem>
+#include <format>
+#include "improc/exceptions.hpp"
+
+using improc::ModelError;
+using improc::Exception;
 
 namespace improc::ml {
 
@@ -14,20 +19,20 @@ const std::unordered_set<std::string>& DnnDetector::valid_extensions() {
 
 DnnDetector::DnnDetector(std::string model_path) {
     if (!std::filesystem::exists(model_path))
-        throw std::runtime_error("DnnDetector: model file not found: " + model_path);
+        throw ModelError{model_path, "file not found"};
 
     std::string ext = std::filesystem::path(model_path).extension().string();
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
     if (!valid_extensions().contains(ext))
-        throw std::runtime_error("DnnDetector: unsupported model extension '" + ext + "': " + model_path);
+        throw ModelError{model_path, "unsupported extension '" + ext + "'"};
 
     try {
         net_ = cv::dnn::readNet(model_path);
     } catch (const cv::Exception& e) {
-        throw std::runtime_error("DnnDetector: failed to load model: " + std::string(e.what()));
+        throw ModelError{model_path, "failed to load: " + std::string(e.what())};
     }
     if (net_.empty())
-        throw std::runtime_error("DnnDetector: loaded model is empty: " + model_path);
+        throw ModelError{model_path, "loaded model is empty"};
 }
 
 std::vector<Detection> DnnDetector::operator()(const Image<BGR>& img) const {
@@ -45,7 +50,7 @@ std::vector<Detection> DnnDetector::operator()(const Image<BGR>& img) const {
         else
             outs = {net_.forward(output_layer_)};
         if (outs.empty())
-            throw std::runtime_error("DnnDetector: YOLO forward pass produced no output blobs");
+            throw Exception{"DnnDetector: YOLO forward pass produced no output blobs"};
         cv::Mat out = outs[0];
         return parse_yolo(out, orig_w, orig_h);
     } else {
@@ -65,13 +70,11 @@ std::vector<Detection> DnnDetector::parse_yolo(const cv::Mat& output,
         det_mat = output;
 
     if (det_mat.dims != 2)
-        throw std::runtime_error("DnnDetector: YOLO output has unexpected shape (dims=" +
-                                 std::to_string(det_mat.dims) + ")");
+        throw Exception{std::format("DnnDetector: YOLO output has unexpected shape (dims={})", det_mat.dims)};
 
     const int num_classes = det_mat.cols - 5;
     if (num_classes <= 0)
-        throw std::runtime_error("DnnDetector: YOLO output has unexpected column count: " +
-                                 std::to_string(det_mat.cols));
+        throw Exception{std::format("DnnDetector: YOLO output has unexpected column count: {}", det_mat.cols)};
 
     const float x_scale = static_cast<float>(orig_w) / input_w_;
     const float y_scale = static_cast<float>(orig_h) / input_h_;
@@ -132,7 +135,7 @@ std::vector<Detection> DnnDetector::parse_ssd(const cv::Mat& boxes_blob, const c
     cv::Mat scores_mat = scores_blob.reshape(1, scores_blob.size[1]);  // [N, C]
 
     if (boxes_mat.rows != scores_mat.rows)
-        throw std::runtime_error("DnnDetector: SSD boxes/scores row count mismatch");
+        throw Exception{"DnnDetector: SSD boxes/scores row count mismatch"};
 
     std::vector<cv::Rect> boxes;
     std::vector<float>    confs;

--- a/src/ml/dnn_forward.cpp
+++ b/src/ml/dnn_forward.cpp
@@ -2,6 +2,9 @@
 #include "improc/ml/dnn_forward.hpp"
 #include <algorithm>
 #include <filesystem>
+#include "improc/exceptions.hpp"
+
+using improc::ModelError;
 
 namespace improc::ml {
 
@@ -14,20 +17,20 @@ const std::unordered_set<std::string>& DnnForward::valid_extensions() {
 
 DnnForward::DnnForward(std::string model_path) {
     if (!std::filesystem::exists(model_path))
-        throw std::runtime_error("DnnForward: model file not found: " + model_path);
+        throw ModelError{model_path, "file not found"};
 
     std::string ext = std::filesystem::path(model_path).extension().string();
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
     if (!valid_extensions().contains(ext))
-        throw std::runtime_error("DnnForward: unsupported model extension '" + ext + "': " + model_path);
+        throw ModelError{model_path, "unsupported extension '" + ext + "'"};
 
     try {
         net_ = cv::dnn::readNet(model_path);
     } catch (const cv::Exception& e) {
-        throw std::runtime_error("DnnForward: failed to load model: " + std::string(e.what()));
+        throw ModelError{model_path, "failed to load: " + std::string(e.what())};
     }
     if (net_.empty())
-        throw std::runtime_error("DnnForward: loaded model is empty: " + model_path);
+        throw ModelError{model_path, "loaded model is empty"};
 }
 
 std::vector<float> DnnForward::operator()(const Image<BGR>& img) const {

--- a/src/ml/haar_cascade_loader.cpp
+++ b/src/ml/haar_cascade_loader.cpp
@@ -1,20 +1,19 @@
 // Created by Michał Maj on 14/04/2025.
 
 #include "improc/ml/haar_cascade_loader.hpp"
-#include <stdexcept>
+#include "improc/exceptions.hpp"
+#include "improc/error.hpp"
 
 namespace improc::ml {
 
 void HaarCascadeLoader::load_impl(const std::filesystem::path& path) {
-  if (!classifier_.load(path.string())) {
-    throw std::runtime_error("Failed to load Haar Cascade from: " + path.string());
-  }
+  if (!classifier_.load(path.string()))
+    throw improc::ModelError{path, "CascadeClassifier::load() failed"};
 }
 
-std::expected<cv::CascadeClassifier, std::string> HaarCascadeLoader::get_impl() const {
-  if (classifier_.empty()) {
-    return std::unexpected("Haar cascade model is empty");
-  }
+std::expected<cv::CascadeClassifier, improc::Error> HaarCascadeLoader::get_impl() const {
+  if (classifier_.empty())
+    return std::unexpected(improc::Error::invalid_model_file("", "Haar cascade model is empty"));
   return classifier_;
 }
 

--- a/src/ml/image_loader.cpp
+++ b/src/ml/image_loader.cpp
@@ -8,16 +8,16 @@
 #include <format>
 #include <ranges>
 #include <algorithm>
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
 void ImageLoader::load_images(const std::filesystem::path& dir_path) {
-  if (!std::filesystem::is_directory(dir_path)) {
-    std::cerr << std::format("Wrong dir_path: {}\n", dir_path.string());
-    throw std::runtime_error("Can't load data!\n");
-  }
+  if (!std::filesystem::is_directory(dir_path))
+    throw improc::FileNotFoundError{dir_path};
 
   images_.clear();
+  last_dir_ = dir_path.string();
 
   for (const auto& file : std::filesystem::directory_iterator(dir_path)) {
     if (!std::filesystem::is_regular_file(file)) continue;
@@ -35,11 +35,9 @@ void ImageLoader::load_images(const std::filesystem::path& dir_path) {
   }
 }
 
-std::expected<std::vector<cv::Mat>, std::string> ImageLoader::get_images() {
-  if (images_.empty()) {
-    return std::unexpected("There is no images to process!\n");
-  }
-
+std::expected<std::vector<cv::Mat>, improc::Error> ImageLoader::get_images() {
+  if (images_.empty())
+    return std::unexpected(improc::Error::no_images(last_dir_));
   return std::move(images_);
 }
 

--- a/src/threading/thread_pool.cpp
+++ b/src/threading/thread_pool.cpp
@@ -1,11 +1,12 @@
 // src/threading/thread_pool.cpp
 #include "improc/threading/thread_pool.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::threading {
 
 ThreadPool::ThreadPool(std::size_t threads) {
     if (threads == 0)
-        throw std::invalid_argument("ThreadPool: thread count must be > 0");
+        throw ParameterError{"threads", "must be > 0", "ThreadPool"};
     workers_.reserve(threads);
     try {
         for (std::size_t i = 0; i < threads; ++i)

--- a/src/visualization/line_plot.cpp
+++ b/src/visualization/line_plot.cpp
@@ -3,11 +3,13 @@
 #include <algorithm>
 #include <opencv2/imgproc.hpp>
 
+using improc::ParameterError;
+
 namespace improc::visualization {
 
 Image<BGR> LinePlot::operator()(const std::vector<float>& values) const {
     if (values.empty())
-        throw std::invalid_argument("LinePlot: values must not be empty");
+        throw ParameterError{"values", "must not be empty", "LinePlot"};
 
     cv::Mat canvas(height_, width_, CV_8UC3, cv::Scalar(0, 0, 0));
 

--- a/src/visualization/scatter.cpp
+++ b/src/visualization/scatter.cpp
@@ -3,14 +3,16 @@
 #include <algorithm>
 #include <opencv2/imgproc.hpp>
 
+using improc::ParameterError;
+
 namespace improc::visualization {
 
 Image<BGR> Scatter::operator()(const std::vector<float>& xs,
                                 const std::vector<float>& ys) const {
     if (xs.empty() || ys.empty())
-        throw std::invalid_argument("Scatter: xs and ys must not be empty");
+        throw ParameterError{"xs/ys", "must not be empty", "Scatter"};
     if (xs.size() != ys.size())
-        throw std::invalid_argument("Scatter: xs and ys must have the same size");
+        throw ParameterError{"xs/ys", "must have the same size", "Scatter"};
 
     cv::Mat canvas(height_, width_, CV_8UC3, cv::Scalar(0, 0, 0));
 

--- a/tests/core/ops/test_blur.cpp
+++ b/tests/core/ops/test_blur.cpp
@@ -1,5 +1,6 @@
 // tests/core/ops/test_blur.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/core/ops/blur.hpp"
 #include "improc/core/pipeline.hpp"
@@ -31,15 +32,15 @@ TEST(BlurTest, GaussianBlurOnGrayPreservesType) {
 }
 
 TEST(BlurTest, GaussianBlurEvenKernelThrows) {
-    EXPECT_THROW(GaussianBlur{}.kernel_size(4), std::invalid_argument);
+    EXPECT_THROW(GaussianBlur{}.kernel_size(4), improc::ParameterError);
 }
 
 TEST(BlurTest, GaussianBlurZeroKernelThrows) {
-    EXPECT_THROW(GaussianBlur{}.kernel_size(0), std::invalid_argument);
+    EXPECT_THROW(GaussianBlur{}.kernel_size(0), improc::ParameterError);
 }
 
 TEST(BlurTest, GaussianBlurNegativeSigmaThrows) {
-    EXPECT_THROW(GaussianBlur{}.sigma(-1.0), std::invalid_argument);
+    EXPECT_THROW(GaussianBlur{}.sigma(-1.0), improc::ParameterError);
 }
 
 TEST(BlurTest, GaussianBlurPipelineOp) {
@@ -60,11 +61,11 @@ TEST(BlurTest, MedianBlurDefaultPreservesSizeAndType) {
 }
 
 TEST(BlurTest, MedianBlurEvenKernelThrows) {
-    EXPECT_THROW(MedianBlur{}.kernel_size(4), std::invalid_argument);
+    EXPECT_THROW(MedianBlur{}.kernel_size(4), improc::ParameterError);
 }
 
 TEST(BlurTest, MedianBlurZeroKernelThrows) {
-    EXPECT_THROW(MedianBlur{}.kernel_size(0), std::invalid_argument);
+    EXPECT_THROW(MedianBlur{}.kernel_size(0), improc::ParameterError);
 }
 
 TEST(BlurTest, MedianBlurPipelineOp) {
@@ -84,9 +85,9 @@ TEST(BlurTest, GaussianBlurActuallySmooths) {
 }
 
 TEST(BlurTest, GaussianBlurNegativeKernelThrows) {
-    EXPECT_THROW(GaussianBlur{}.kernel_size(-1), std::invalid_argument);
+    EXPECT_THROW(GaussianBlur{}.kernel_size(-1), improc::ParameterError);
 }
 
 TEST(BlurTest, MedianBlurNegativeKernelThrows) {
-    EXPECT_THROW(MedianBlur{}.kernel_size(-3), std::invalid_argument);
+    EXPECT_THROW(MedianBlur{}.kernel_size(-3), improc::ParameterError);
 }

--- a/tests/core/ops/test_crop.cpp
+++ b/tests/core/ops/test_crop.cpp
@@ -1,5 +1,6 @@
 // tests/core/ops/test_crop.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/core/pipeline.hpp"
 #include "improc/core/ops/crop.hpp"
 
@@ -31,28 +32,28 @@ TEST(CropTest, ResultOwnsItsMemory) {
 TEST(CropTest, ThrowsOnMissingWidth) {
     cv::Mat mat(100, 200, CV_8UC3);
     Image<BGR> img(mat);
-    EXPECT_THROW((img | Crop{}.x(0).y(0).height(50)), std::invalid_argument);
+    EXPECT_THROW((img | Crop{}.x(0).y(0).height(50)), improc::ParameterError);
 }
 
 TEST(CropTest, ThrowsOnMissingX) {
     cv::Mat mat(100, 200, CV_8UC3);
     Image<BGR> img(mat);
-    EXPECT_THROW((img | Crop{}.y(0).width(50).height(50)), std::invalid_argument);
+    EXPECT_THROW((img | Crop{}.y(0).width(50).height(50)), improc::ParameterError);
 }
 
 TEST(CropTest, ThrowsOnROIOutOfBounds) {
     cv::Mat mat(100, 200, CV_8UC3);
     Image<BGR> img(mat);
-    EXPECT_THROW((img | Crop{}.x(0).y(0).width(300).height(50)), std::invalid_argument);
+    EXPECT_THROW((img | Crop{}.x(0).y(0).width(300).height(50)), improc::ParameterError);
 }
 
 TEST(CropTest, ThrowsOnROIExceedingHeight) {
     cv::Mat mat(100, 200, CV_8UC3);
     Image<BGR> img(mat);
-    EXPECT_THROW((img | Crop{}.x(0).y(50).width(50).height(100)), std::invalid_argument);
+    EXPECT_THROW((img | Crop{}.x(0).y(50).width(50).height(100)), improc::ParameterError);
 }
 
 TEST(CropTest, ThrowsOnNonPositiveDimension) {
-    EXPECT_THROW(Crop{}.width(0),  std::invalid_argument);
-    EXPECT_THROW(Crop{}.height(-1), std::invalid_argument);
+    EXPECT_THROW(Crop{}.width(0),  improc::ParameterError);
+    EXPECT_THROW(Crop{}.height(-1), improc::ParameterError);
 }

--- a/tests/core/ops/test_morphology.cpp
+++ b/tests/core/ops/test_morphology.cpp
@@ -1,5 +1,6 @@
 // tests/core/ops/test_morphology.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/core/ops/morphology.hpp"
 #include "improc/core/pipeline.hpp"
@@ -39,15 +40,15 @@ TEST(MorphologyTest, DilateWithIterations2PreservesSize) {
 }
 
 TEST(MorphologyTest, DilateZeroKernelThrows) {
-    EXPECT_THROW(Dilate{}.kernel_size(0), std::invalid_argument);
+    EXPECT_THROW(Dilate{}.kernel_size(0), improc::ParameterError);
 }
 
 TEST(MorphologyTest, DilateNegativeKernelThrows) {
-    EXPECT_THROW(Dilate{}.kernel_size(-1), std::invalid_argument);
+    EXPECT_THROW(Dilate{}.kernel_size(-1), improc::ParameterError);
 }
 
 TEST(MorphologyTest, DilateZeroIterationsThrows) {
-    EXPECT_THROW(Dilate{}.iterations(0), std::invalid_argument);
+    EXPECT_THROW(Dilate{}.iterations(0), improc::ParameterError);
 }
 
 TEST(MorphologyTest, DilatePipelineOp) {
@@ -77,15 +78,15 @@ TEST(MorphologyTest, ErodeDefaultPreservesSizeAndType) {
 }
 
 TEST(MorphologyTest, ErodeZeroKernelThrows) {
-    EXPECT_THROW(Erode{}.kernel_size(0), std::invalid_argument);
+    EXPECT_THROW(Erode{}.kernel_size(0), improc::ParameterError);
 }
 
 TEST(MorphologyTest, ErodeNegativeKernelThrows) {
-    EXPECT_THROW(Erode{}.kernel_size(-2), std::invalid_argument);
+    EXPECT_THROW(Erode{}.kernel_size(-2), improc::ParameterError);
 }
 
 TEST(MorphologyTest, ErodeZeroIterationsThrows) {
-    EXPECT_THROW(Erode{}.iterations(0), std::invalid_argument);
+    EXPECT_THROW(Erode{}.iterations(0), improc::ParameterError);
 }
 
 TEST(MorphologyTest, ErodePipelineOp) {
@@ -106,11 +107,11 @@ TEST(MorphologyTest, ErodeActuallyErodes) {
 }
 
 TEST(MorphologyTest, DilateEvenKernelThrows) {
-    EXPECT_THROW(Dilate{}.kernel_size(4), std::invalid_argument);
+    EXPECT_THROW(Dilate{}.kernel_size(4), improc::ParameterError);
 }
 
 TEST(MorphologyTest, ErodeEvenKernelThrows) {
-    EXPECT_THROW(Erode{}.kernel_size(2), std::invalid_argument);
+    EXPECT_THROW(Erode{}.kernel_size(2), improc::ParameterError);
 }
 
 TEST(MorphologyTest, ErodeWithIterations2PreservesSize) {

--- a/tests/core/ops/test_normalize.cpp
+++ b/tests/core/ops/test_normalize.cpp
@@ -1,5 +1,6 @@
 // tests/core/ops/test_normalize.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/core/ops/normalize.hpp"
 #include "improc/core/pipeline.hpp"
 
@@ -46,8 +47,8 @@ TEST(NormalizeToTest, ScalesToExplicitRange) {
 }
 
 TEST(NormalizeToTest, ThrowsOnInvalidRange) {
-    EXPECT_THROW(NormalizeTo(1.0f, 0.0f), std::invalid_argument);
-    EXPECT_THROW(NormalizeTo(1.0f, 1.0f), std::invalid_argument);
+    EXPECT_THROW(NormalizeTo(1.0f, 0.0f), improc::ParameterError);
+    EXPECT_THROW(NormalizeTo(1.0f, 1.0f), improc::ParameterError);
 }
 
 TEST(NormalizeToTest, UniformImageReturnsZeros) {
@@ -71,8 +72,8 @@ TEST(StandardizeTest, AppliesZScore) {
 }
 
 TEST(StandardizeTest, ThrowsOnZeroStdDev) {
-    EXPECT_THROW(Standardize(0.5f, 0.0f),  std::invalid_argument);
-    EXPECT_THROW(Standardize(0.5f, -1.0f), std::invalid_argument);
+    EXPECT_THROW(Standardize(0.5f, 0.0f),  improc::ParameterError);
+    EXPECT_THROW(Standardize(0.5f, -1.0f), improc::ParameterError);
 }
 
 // --- Float32C3 overloads (global normalization across all channels) ---

--- a/tests/core/ops/test_pad.cpp
+++ b/tests/core/ops/test_pad.cpp
@@ -1,5 +1,6 @@
 // tests/core/ops/test_pad.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/core/ops/pad.hpp"
 #include "improc/core/pipeline.hpp"
@@ -43,23 +44,23 @@ TEST(PadTest, ReplicateModeCorrectSize) {
 TEST(PadTest, AllZeroSidesThrows) {
     cv::Mat mat(10, 10, CV_8UC3, cv::Scalar(100, 100, 100));
     Image<BGR> img(mat);
-    EXPECT_THROW(Pad{}(img), std::invalid_argument);
+    EXPECT_THROW(Pad{}(img), improc::ParameterError);
 }
 
 TEST(PadTest, NegativeTopThrows) {
-    EXPECT_THROW(Pad{}.top(-1), std::invalid_argument);
+    EXPECT_THROW(Pad{}.top(-1), improc::ParameterError);
 }
 
 TEST(PadTest, NegativeLeftThrows) {
-    EXPECT_THROW(Pad{}.left(-3), std::invalid_argument);
+    EXPECT_THROW(Pad{}.left(-3), improc::ParameterError);
 }
 
 TEST(PadTest, NegativeBottomThrows) {
-    EXPECT_THROW(Pad{}.bottom(-2), std::invalid_argument);
+    EXPECT_THROW(Pad{}.bottom(-2), improc::ParameterError);
 }
 
 TEST(PadTest, NegativeRightThrows) {
-    EXPECT_THROW(Pad{}.right(-1), std::invalid_argument);
+    EXPECT_THROW(Pad{}.right(-1), improc::ParameterError);
 }
 
 TEST(PadTest, ConstantPadCustomValueFillsBorder) {

--- a/tests/core/ops/test_resize.cpp
+++ b/tests/core/ops/test_resize.cpp
@@ -1,5 +1,6 @@
 // tests/core/ops/test_resize.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/core/pipeline.hpp"
 #include "improc/core/ops/resize.hpp"
 
@@ -49,13 +50,13 @@ TEST(ResizeTest, WorksOnFloat32Format) {
 TEST(ResizeTest, ThrowsWithNoDimensions) {
     cv::Mat mat(100, 200, CV_8UC3);
     Image<BGR> img(mat);
-    EXPECT_THROW((img | Resize{}), std::invalid_argument);
+    EXPECT_THROW((img | Resize{}), improc::ParameterError);
 }
 
 TEST(ResizeTest, ThrowsOnZeroWidth) {
-    EXPECT_THROW(Resize{}.width(0), std::invalid_argument);
+    EXPECT_THROW(Resize{}.width(0), improc::ParameterError);
 }
 
 TEST(ResizeTest, ThrowsOnNegativeHeight) {
-    EXPECT_THROW(Resize{}.height(-10), std::invalid_argument);
+    EXPECT_THROW(Resize{}.height(-10), improc::ParameterError);
 }

--- a/tests/core/ops/test_rotate.cpp
+++ b/tests/core/ops/test_rotate.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/core/ops/rotate.hpp"
 #include "improc/core/pipeline.hpp"
 
@@ -29,8 +30,8 @@ TEST(RotateTest, WorksWithScaleOption) {
 }
 
 TEST(RotateTest, ThrowsOnNonPositiveScale) {
-    EXPECT_THROW(Rotate{}.scale(0.0),  std::invalid_argument);
-    EXPECT_THROW(Rotate{}.scale(-1.0), std::invalid_argument);
+    EXPECT_THROW(Rotate{}.scale(0.0),  improc::ParameterError);
+    EXPECT_THROW(Rotate{}.scale(-1.0), improc::ParameterError);
 }
 
 TEST(RotateTest, WorksOnFloat32) {
@@ -43,5 +44,5 @@ TEST(RotateTest, WorksOnFloat32) {
 TEST(RotateTest, ThrowsWithoutAngle) {
     cv::Mat mat(50, 50, CV_8UC3);
     Image<BGR> img(mat);
-    EXPECT_THROW((img | Rotate{}), std::invalid_argument);
+    EXPECT_THROW((img | Rotate{}), improc::ParameterError);
 }

--- a/tests/core/ops/test_threshold.cpp
+++ b/tests/core/ops/test_threshold.cpp
@@ -1,5 +1,6 @@
 // tests/core/ops/test_threshold.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/core/ops/threshold.hpp"
 #include "improc/core/pipeline.hpp"
@@ -56,7 +57,7 @@ TEST(ThresholdTest, OtsuOnGrayPreservesSizeAndType) {
 TEST(ThresholdTest, OtsuOnBGRThrowsRuntimeError) {
     cv::Mat mat(10, 10, CV_8UC3, cv::Scalar(100, 100, 100));
     Image<BGR> img(mat);
-    EXPECT_THROW(Threshold{}.mode(ThresholdMode::Otsu)(img), std::runtime_error);
+    EXPECT_THROW(Threshold{}.mode(ThresholdMode::Otsu)(img), improc::ParameterError);
 }
 
 TEST(ThresholdTest, BinaryProducesCorrectValues) {

--- a/tests/core/test_image.cpp
+++ b/tests/core/test_image.cpp
@@ -1,5 +1,6 @@
 // tests/core/test_image.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/core/image.hpp"
 
 using namespace improc::core;
@@ -11,7 +12,7 @@ TEST(ImageTest, ConstructFromValidBGRMat) {
 
 TEST(ImageTest, ThrowsOnWrongType) {
     cv::Mat mat(100, 100, CV_8UC1);  // Gray mat, not BGR
-    EXPECT_THROW((Image<BGR>{mat}), std::invalid_argument);
+    EXPECT_THROW((Image<BGR>{mat}), improc::ParameterError);
 }
 
 TEST(ImageTest, RowsColsReflectMat) {
@@ -22,7 +23,7 @@ TEST(ImageTest, RowsColsReflectMat) {
 }
 
 TEST(ImageTest, EmptyMatThrows) {
-    EXPECT_THROW(Image<BGR>(cv::Mat(0, 0, CV_8UC3)), std::invalid_argument);
+    EXPECT_THROW(Image<BGR>(cv::Mat(0, 0, CV_8UC3)), improc::ParameterError);
 }
 
 TEST(ImageTest, NonEmptyDetected) {

--- a/tests/ml/augment/test_color.cpp
+++ b/tests/ml/augment/test_color.cpp
@@ -1,5 +1,6 @@
 // tests/ml/augment/test_color.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/ml/augment/color.hpp"
 #include "improc/core/pipeline.hpp"
@@ -38,8 +39,8 @@ TEST(ColorAugTest, RandomBrightnessClampAt255) {
 }
 
 TEST(ColorAugTest, RandomBrightnessInvalidRangeThrows) {
-    EXPECT_THROW(RandomBrightness{}.range(0.0f, 1.0f), std::invalid_argument);  // low <= 0
-    EXPECT_THROW(RandomBrightness{}.range(1.5f, 1.0f), std::invalid_argument);  // low > high
+    EXPECT_THROW(RandomBrightness{}.range(0.0f, 1.0f), improc::ParameterError);  // low <= 0
+    EXPECT_THROW(RandomBrightness{}.range(1.5f, 1.0f), improc::ParameterError);  // low > high
 }
 
 TEST(ColorAugTest, RandomBrightnessBindRngPipelineOp) {
@@ -73,8 +74,8 @@ TEST(ColorAugTest, RandomContrastUniformImageUnchanged) {
 }
 
 TEST(ColorAugTest, RandomContrastInvalidRangeThrows) {
-    EXPECT_THROW(RandomContrast{}.range(0.0f, 1.0f), std::invalid_argument);  // low <= 0
-    EXPECT_THROW(RandomContrast{}.range(1.5f, 1.0f), std::invalid_argument);  // low > high
+    EXPECT_THROW(RandomContrast{}.range(0.0f, 1.0f), improc::ParameterError);  // low <= 0
+    EXPECT_THROW(RandomContrast{}.range(1.5f, 1.0f), improc::ParameterError);  // low > high
 }
 
 TEST(ColorAugTest, RandomContrastBindRngPipelineOp) {
@@ -109,13 +110,13 @@ TEST(ColorAugTest, ColorJitterChangesPixels) {
 }
 
 TEST(ColorAugTest, ColorJitterInvalidBrightnessThrows) {
-    EXPECT_THROW(ColorJitter{}.brightness(0.0f, 1.0f), std::invalid_argument);
-    EXPECT_THROW(ColorJitter{}.brightness(1.5f, 1.0f), std::invalid_argument);
+    EXPECT_THROW(ColorJitter{}.brightness(0.0f, 1.0f), improc::ParameterError);
+    EXPECT_THROW(ColorJitter{}.brightness(1.5f, 1.0f), improc::ParameterError);
 }
 
 TEST(ColorAugTest, ColorJitterInvalidHueThrows) {
-    EXPECT_THROW(ColorJitter{}.hue(-200.0f, 0.0f), std::invalid_argument);
-    EXPECT_THROW(ColorJitter{}.hue(10.0f, 5.0f),   std::invalid_argument);
+    EXPECT_THROW(ColorJitter{}.hue(-200.0f, 0.0f), improc::ParameterError);
+    EXPECT_THROW(ColorJitter{}.hue(10.0f, 5.0f),   improc::ParameterError);
 }
 
 TEST(ColorAugTest, ColorJitterBindRngPipelineOp) {

--- a/tests/ml/augment/test_compose.cpp
+++ b/tests/ml/augment/test_compose.cpp
@@ -1,5 +1,6 @@
 // tests/ml/augment/test_compose.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/ml/augment/compose.hpp"
 #include "improc/ml/augment/geometric.hpp"
@@ -80,8 +81,8 @@ TEST(ComposeAugTest, RandomApplyAtP0NeverApplies) {
 }
 
 TEST(ComposeAugTest, RandomApplyInvalidPThrows) {
-    EXPECT_THROW((RandomApply<BGR>{RandomFlip{}, 1.5f}), std::invalid_argument);
-    EXPECT_THROW((RandomApply<BGR>{RandomFlip{}, -0.1f}), std::invalid_argument);
+    EXPECT_THROW((RandomApply<BGR>{RandomFlip{}, 1.5f}), improc::ParameterError);
+    EXPECT_THROW((RandomApply<BGR>{RandomFlip{}, -0.1f}), improc::ParameterError);
 }
 
 TEST(ComposeAugTest, RandomApplyBindRngPipelineOp) {
@@ -109,7 +110,7 @@ TEST(ComposeAugTest, OneOfEmptyThrows) {
     cv::Mat mat(10, 10, CV_8UC3, cv::Scalar(100, 100, 100));
     Image<BGR> img(mat);
     std::mt19937 rng(42);
-    EXPECT_THROW(OneOf<BGR>{}(img, rng), std::logic_error);
+    EXPECT_THROW(OneOf<BGR>{}(img, rng), improc::AugmentError);
 }
 
 TEST(ComposeAugTest, OneOfDistributesAcrossOptions) {

--- a/tests/ml/augment/test_geometric.cpp
+++ b/tests/ml/augment/test_geometric.cpp
@@ -1,5 +1,6 @@
 // tests/ml/augment/test_geometric.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/ml/augment/geometric.hpp"
 #include "improc/core/pipeline.hpp"
@@ -40,8 +41,8 @@ TEST(GeometricAugTest, RandomFlipNeverFlipsAtP0) {
 }
 
 TEST(GeometricAugTest, RandomFlipInvalidPThrows) {
-    EXPECT_THROW(RandomFlip{}.p(1.5f),  std::invalid_argument);
-    EXPECT_THROW(RandomFlip{}.p(-0.1f), std::invalid_argument);
+    EXPECT_THROW(RandomFlip{}.p(1.5f),  improc::ParameterError);
+    EXPECT_THROW(RandomFlip{}.p(-0.1f), improc::ParameterError);
 }
 
 TEST(GeometricAugTest, RandomFlipBindRngPipelineOp) {
@@ -66,12 +67,12 @@ TEST(GeometricAugTest, RandomRotatePreservesSizeAndType) {
 }
 
 TEST(GeometricAugTest, RandomRotateInvalidRangeThrows) {
-    EXPECT_THROW(RandomRotate{}.range(10.0f, 5.0f), std::invalid_argument);
+    EXPECT_THROW(RandomRotate{}.range(10.0f, 5.0f), improc::ParameterError);
 }
 
 TEST(GeometricAugTest, RandomRotateInvalidScaleThrows) {
-    EXPECT_THROW(RandomRotate{}.scale(0.0f),  std::invalid_argument);
-    EXPECT_THROW(RandomRotate{}.scale(-1.0f), std::invalid_argument);
+    EXPECT_THROW(RandomRotate{}.scale(0.0f),  improc::ParameterError);
+    EXPECT_THROW(RandomRotate{}.scale(-1.0f), improc::ParameterError);
 }
 
 TEST(GeometricAugTest, RandomRotateBindRngPipelineOp) {
@@ -98,21 +99,21 @@ TEST(GeometricAugTest, RandomCropLargerThanImageThrows) {
     cv::Mat mat(10, 10, CV_8UC3, cv::Scalar(100, 100, 100));
     Image<BGR> img(mat);
     std::mt19937 rng(42);
-    EXPECT_THROW(RandomCrop{}.width(20).height(5)(img, rng),  std::invalid_argument);
-    EXPECT_THROW(RandomCrop{}.width(5).height(20)(img, rng),  std::invalid_argument);
+    EXPECT_THROW(RandomCrop{}.width(20).height(5)(img, rng),  improc::ParameterError);
+    EXPECT_THROW(RandomCrop{}.width(5).height(20)(img, rng),  improc::ParameterError);
 }
 
 TEST(GeometricAugTest, RandomCropMissingDimensionsThrows) {
     cv::Mat mat(10, 10, CV_8UC3, cv::Scalar(100, 100, 100));
     Image<BGR> img(mat);
     std::mt19937 rng(42);
-    EXPECT_THROW(RandomCrop{}.width(5)(img, rng),  std::invalid_argument);
-    EXPECT_THROW(RandomCrop{}(img, rng),            std::invalid_argument);
+    EXPECT_THROW(RandomCrop{}.width(5)(img, rng),  improc::ParameterError);
+    EXPECT_THROW(RandomCrop{}(img, rng),            improc::ParameterError);
 }
 
 TEST(GeometricAugTest, RandomCropInvalidDimensionThrows) {
-    EXPECT_THROW(RandomCrop{}.width(0),   std::invalid_argument);
-    EXPECT_THROW(RandomCrop{}.height(-1), std::invalid_argument);
+    EXPECT_THROW(RandomCrop{}.width(0),   improc::ParameterError);
+    EXPECT_THROW(RandomCrop{}.height(-1), improc::ParameterError);
 }
 
 TEST(GeometricAugTest, RandomCropBindRngPipelineOp) {
@@ -147,8 +148,8 @@ TEST(GeometricAugTest, RandomResizeShorterSideInRangePortrait) {
 }
 
 TEST(GeometricAugTest, RandomResizeInvalidRangeThrows) {
-    EXPECT_THROW(RandomResize{}.range(100, 50),  std::invalid_argument);
-    EXPECT_THROW(RandomResize{}.range(0, 100),   std::invalid_argument);
+    EXPECT_THROW(RandomResize{}.range(100, 50),  improc::ParameterError);
+    EXPECT_THROW(RandomResize{}.range(0, 100),   improc::ParameterError);
 }
 
 TEST(GeometricAugTest, RandomResizeBindRngPipelineOp) {

--- a/tests/ml/augment/test_noise.cpp
+++ b/tests/ml/augment/test_noise.cpp
@@ -1,5 +1,6 @@
 // tests/ml/augment/test_noise.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <opencv2/core.hpp>
 #include "improc/ml/augment/noise.hpp"
 #include "improc/core/pipeline.hpp"
@@ -41,8 +42,8 @@ TEST(NoiseAugTest, GaussianNoiseOnGrayPreservesType) {
 }
 
 TEST(NoiseAugTest, GaussianNoiseInvalidStdDevThrows) {
-    EXPECT_THROW(RandomGaussianNoise{}.std_dev(-1.0f, 10.0f), std::invalid_argument);
-    EXPECT_THROW(RandomGaussianNoise{}.std_dev(20.0f, 10.0f), std::invalid_argument);
+    EXPECT_THROW(RandomGaussianNoise{}.std_dev(-1.0f, 10.0f), improc::ParameterError);
+    EXPECT_THROW(RandomGaussianNoise{}.std_dev(20.0f, 10.0f), improc::ParameterError);
 }
 
 TEST(NoiseAugTest, GaussianNoiseBindRngPipelineOp) {
@@ -88,8 +89,8 @@ TEST(NoiseAugTest, SaltAndPepperAtP0LeavesImageUnchanged) {
 }
 
 TEST(NoiseAugTest, SaltAndPepperInvalidPThrows) {
-    EXPECT_THROW(RandomSaltAndPepper{}.p(-0.1f), std::invalid_argument);
-    EXPECT_THROW(RandomSaltAndPepper{}.p(1.1f),  std::invalid_argument);
+    EXPECT_THROW(RandomSaltAndPepper{}.p(-0.1f), improc::ParameterError);
+    EXPECT_THROW(RandomSaltAndPepper{}.p(1.1f),  improc::ParameterError);
 }
 
 TEST(NoiseAugTest, SaltAndPepperBindRngPipelineOp) {

--- a/tests/ml/test_dnn_classifier.cpp
+++ b/tests/ml/test_dnn_classifier.cpp
@@ -1,5 +1,6 @@
 // tests/ml/test_dnn_classifier.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <filesystem>
 #include <fstream>
 #include "improc/ml/dnn_classifier.hpp"
@@ -8,20 +9,20 @@ using namespace improc::ml;
 namespace fs = std::filesystem;
 
 TEST(DnnClassifierTest, NonExistentPathThrows) {
-    EXPECT_THROW(DnnClassifier{"nonexistent/model.onnx"}, std::runtime_error);
+    EXPECT_THROW(DnnClassifier{"nonexistent/model.onnx"}, improc::ModelError);
 }
 
 TEST(DnnClassifierTest, InvalidExtensionThrows) {
     fs::path p = fs::temp_directory_path() / "improc_test_dummy.txt";
     { std::ofstream f(p); f << "not a model"; }
-    EXPECT_THROW(DnnClassifier{p.string()}, std::runtime_error);
+    EXPECT_THROW(DnnClassifier{p.string()}, improc::ModelError);
     fs::remove(p);
 }
 
 TEST(DnnClassifierTest, CorruptModelThrows) {
     fs::path p = fs::temp_directory_path() / "improc_test_dummy.onnx";
     { std::ofstream f(p); f << "not a real onnx file"; }
-    EXPECT_THROW(DnnClassifier{p.string()}, std::runtime_error);
+    EXPECT_THROW(DnnClassifier{p.string()}, improc::ModelError);
     fs::remove(p);
 }
 

--- a/tests/ml/test_dnn_detector.cpp
+++ b/tests/ml/test_dnn_detector.cpp
@@ -1,5 +1,6 @@
 // tests/ml/test_dnn_detector.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <filesystem>
 #include <fstream>
 #include "improc/ml/dnn_detector.hpp"
@@ -8,20 +9,20 @@ using namespace improc::ml;
 namespace fs = std::filesystem;
 
 TEST(DnnDetectorTest, NonExistentPathThrows) {
-    EXPECT_THROW(DnnDetector{"nonexistent/model.onnx"}, std::runtime_error);
+    EXPECT_THROW(DnnDetector{"nonexistent/model.onnx"}, improc::ModelError);
 }
 
 TEST(DnnDetectorTest, InvalidExtensionThrows) {
     fs::path p = fs::temp_directory_path() / "improc_det_dummy.txt";
     { std::ofstream f(p); f << "not a model"; }
-    EXPECT_THROW(DnnDetector{p.string()}, std::runtime_error);
+    EXPECT_THROW(DnnDetector{p.string()}, improc::ModelError);
     fs::remove(p);
 }
 
 TEST(DnnDetectorTest, CorruptModelThrows) {
     fs::path p = fs::temp_directory_path() / "improc_det_dummy.onnx";
     { std::ofstream f(p); f << "not a real onnx file"; }
-    EXPECT_THROW(DnnDetector{p.string()}, std::runtime_error);
+    EXPECT_THROW(DnnDetector{p.string()}, improc::ModelError);
     fs::remove(p);
 }
 

--- a/tests/ml/test_dnn_forward.cpp
+++ b/tests/ml/test_dnn_forward.cpp
@@ -1,5 +1,6 @@
 // tests/ml/test_dnn_forward.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <filesystem>
 #include <fstream>
 #include "improc/ml/dnn_forward.hpp"
@@ -8,20 +9,20 @@ using namespace improc::ml;
 namespace fs = std::filesystem;
 
 TEST(DnnForwardTest, NonExistentPathThrows) {
-    EXPECT_THROW(DnnForward{"nonexistent/model.onnx"}, std::runtime_error);
+    EXPECT_THROW(DnnForward{"nonexistent/model.onnx"}, improc::ModelError);
 }
 
 TEST(DnnForwardTest, InvalidExtensionThrows) {
     fs::path p = fs::temp_directory_path() / "improc_fwd_dummy.txt";
     { std::ofstream f(p); f << "not a model"; }
-    EXPECT_THROW(DnnForward{p.string()}, std::runtime_error);
+    EXPECT_THROW(DnnForward{p.string()}, improc::ModelError);
     fs::remove(p);
 }
 
 TEST(DnnForwardTest, CorruptModelThrows) {
     fs::path p = fs::temp_directory_path() / "improc_fwd_dummy.onnx";
     { std::ofstream f(p); f << "not a real onnx file"; }
-    EXPECT_THROW(DnnForward{p.string()}, std::runtime_error);
+    EXPECT_THROW(DnnForward{p.string()}, improc::ModelError);
     fs::remove(p);
 }
 

--- a/tests/ml/test_haar_cascade_loader.cpp
+++ b/tests/ml/test_haar_cascade_loader.cpp
@@ -1,6 +1,7 @@
 // Created by Michał Maj on 14/04/2025.
 
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <filesystem>
 #include <fstream>
 #include "improc/ml/haar_cascade_loader.hpp"
@@ -29,6 +30,6 @@ TEST(HaarCascadeLoaderTest, ThrowsOnInvalidLoad) {
   auto path = std::filesystem::path(__FILE__).parent_path() / "invalid_file.txt";
   std::ofstream(path) << "not a valid model";
 
-  EXPECT_THROW(loader.load_model(path), std::runtime_error);
+  EXPECT_THROW(loader.load_model(path), improc::ModelError);
   std::filesystem::remove(path);
 }

--- a/tests/ml/test_image_loader.cpp
+++ b/tests/ml/test_image_loader.cpp
@@ -3,13 +3,14 @@
 //
 
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/ml/image_loader.hpp"
 
 using improc::ml::ImageLoader;
 
 TEST(ImageLoaderTest, InvalidPathThrows) {
   ImageLoader loader;
-  EXPECT_THROW(loader.load_images("not_a_dir"), std::runtime_error);
+  EXPECT_THROW(loader.load_images("not_a_dir"), improc::FileNotFoundError);
 }
 
 TEST(ImageLoaderTest, EmptyDirReturnsNoImages) {

--- a/tests/threading/test_frame_pipeline.cpp
+++ b/tests/threading/test_frame_pipeline.cpp
@@ -1,5 +1,6 @@
 // tests/threading/test_frame_pipeline.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <chrono>
 #include <thread>
 #include <opencv2/videoio.hpp>
@@ -32,7 +33,7 @@ TEST(FramePipelineTest, StartTwiceThrows) {
     pipeline.start([](cv::Mat frame){ return frame; });
     EXPECT_THROW(
         pipeline.start([](cv::Mat frame){ return frame; }),
-        std::logic_error
+        improc::Exception
     );
 }
 

--- a/tests/threading/test_thread_pool.cpp
+++ b/tests/threading/test_thread_pool.cpp
@@ -1,5 +1,6 @@
 // tests/threading/test_thread_pool.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include <atomic>
 #include <chrono>
 #include <thread>
@@ -54,7 +55,7 @@ TEST(ThreadPoolTest, DestructorDrainsQueue) {
 }
 
 TEST(ThreadPoolTest, ZeroThreadsThrows) {
-    EXPECT_THROW(ThreadPool(0), std::invalid_argument);
+    EXPECT_THROW(ThreadPool(0), improc::ParameterError);
 }
 
 TEST(ThreadPoolTest, ExceptionPropagatesThroughFuture) {

--- a/tests/visualization/test_histogram.cpp
+++ b/tests/visualization/test_histogram.cpp
@@ -1,5 +1,6 @@
 // tests/visualization/test_histogram.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/core/pipeline.hpp"
 #include "improc/visualization/histogram.hpp"
 
@@ -47,25 +48,25 @@ TEST(HistogramTest, CustomBinsAndSize) {
 }
 
 TEST(HistogramTest, ZeroBinsThrows) {
-    EXPECT_THROW(Histogram{}.bins(0), std::invalid_argument);
+    EXPECT_THROW(Histogram{}.bins(0), improc::ParameterError);
 }
 
 TEST(HistogramTest, NegativeBinsThrows) {
-    EXPECT_THROW(Histogram{}.bins(-1), std::invalid_argument);
+    EXPECT_THROW(Histogram{}.bins(-1), improc::ParameterError);
 }
 
 TEST(HistogramTest, ZeroWidthThrows) {
-    EXPECT_THROW(Histogram{}.width(0), std::invalid_argument);
+    EXPECT_THROW(Histogram{}.width(0), improc::ParameterError);
 }
 
 TEST(HistogramTest, NegativeWidthThrows) {
-    EXPECT_THROW(Histogram{}.width(-1), std::invalid_argument);
+    EXPECT_THROW(Histogram{}.width(-1), improc::ParameterError);
 }
 
 TEST(HistogramTest, ZeroHeightThrows) {
-    EXPECT_THROW(Histogram{}.height(0), std::invalid_argument);
+    EXPECT_THROW(Histogram{}.height(0), improc::ParameterError);
 }
 
 TEST(HistogramTest, NegativeHeightThrows) {
-    EXPECT_THROW(Histogram{}.height(-1), std::invalid_argument);
+    EXPECT_THROW(Histogram{}.height(-1), improc::ParameterError);
 }

--- a/tests/visualization/test_line_plot.cpp
+++ b/tests/visualization/test_line_plot.cpp
@@ -1,12 +1,13 @@
 // tests/visualization/test_line_plot.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/visualization/line_plot.hpp"
 
 using namespace improc::core;
 using namespace improc::visualization;
 
 TEST(LinePlotTest, EmptyVectorThrows) {
-    EXPECT_THROW(LinePlot{}({}), std::invalid_argument);
+    EXPECT_THROW(LinePlot{}({}), improc::ParameterError);
 }
 
 TEST(LinePlotTest, SingleValueDoesNotThrow) {
@@ -31,17 +32,17 @@ TEST(LinePlotTest, CustomSize) {
 }
 
 TEST(LinePlotTest, ZeroWidthThrows) {
-    EXPECT_THROW(LinePlot{}.width(0), std::invalid_argument);
+    EXPECT_THROW(LinePlot{}.width(0), improc::ParameterError);
 }
 
 TEST(LinePlotTest, NegativeWidthThrows) {
-    EXPECT_THROW(LinePlot{}.width(-1), std::invalid_argument);
+    EXPECT_THROW(LinePlot{}.width(-1), improc::ParameterError);
 }
 
 TEST(LinePlotTest, ZeroHeightThrows) {
-    EXPECT_THROW(LinePlot{}.height(0), std::invalid_argument);
+    EXPECT_THROW(LinePlot{}.height(0), improc::ParameterError);
 }
 
 TEST(LinePlotTest, NegativeHeightThrows) {
-    EXPECT_THROW(LinePlot{}.height(-1), std::invalid_argument);
+    EXPECT_THROW(LinePlot{}.height(-1), improc::ParameterError);
 }

--- a/tests/visualization/test_scatter.cpp
+++ b/tests/visualization/test_scatter.cpp
@@ -1,20 +1,21 @@
 // tests/visualization/test_scatter.cpp
 #include <gtest/gtest.h>
+#include "improc/exceptions.hpp"
 #include "improc/visualization/scatter.hpp"
 
 using namespace improc::core;
 using namespace improc::visualization;
 
 TEST(ScatterTest, EmptyXsThrows) {
-    EXPECT_THROW(Scatter{}({}, {1.0f}), std::invalid_argument);
+    EXPECT_THROW(Scatter{}({}, {1.0f}), improc::ParameterError);
 }
 
 TEST(ScatterTest, EmptyYsThrows) {
-    EXPECT_THROW(Scatter{}({1.0f}, {}), std::invalid_argument);
+    EXPECT_THROW(Scatter{}({1.0f}, {}), improc::ParameterError);
 }
 
 TEST(ScatterTest, MismatchedSizesThrow) {
-    EXPECT_THROW(Scatter{}({1.0f, 2.0f}, {1.0f}), std::invalid_argument);
+    EXPECT_THROW(Scatter{}({1.0f, 2.0f}, {1.0f}), improc::ParameterError);
 }
 
 TEST(ScatterTest, SinglePointDoesNotThrow) {
@@ -42,25 +43,25 @@ TEST(ScatterTest, CustomSize) {
 }
 
 TEST(ScatterTest, ZeroPointRadiusThrows) {
-    EXPECT_THROW(Scatter{}.point_radius(0), std::invalid_argument);
+    EXPECT_THROW(Scatter{}.point_radius(0), improc::ParameterError);
 }
 
 TEST(ScatterTest, NegativeWidthThrows) {
-    EXPECT_THROW(Scatter{}.width(-1), std::invalid_argument);
+    EXPECT_THROW(Scatter{}.width(-1), improc::ParameterError);
 }
 
 TEST(ScatterTest, NegativeHeightThrows) {
-    EXPECT_THROW(Scatter{}.height(-1), std::invalid_argument);
+    EXPECT_THROW(Scatter{}.height(-1), improc::ParameterError);
 }
 
 TEST(ScatterTest, ZeroWidthThrows) {
-    EXPECT_THROW(Scatter{}.width(0), std::invalid_argument);
+    EXPECT_THROW(Scatter{}.width(0), improc::ParameterError);
 }
 
 TEST(ScatterTest, ZeroHeightThrows) {
-    EXPECT_THROW(Scatter{}.height(0), std::invalid_argument);
+    EXPECT_THROW(Scatter{}.height(0), improc::ParameterError);
 }
 
 TEST(ScatterTest, NegativePointRadiusThrows) {
-    EXPECT_THROW(Scatter{}.point_radius(-1), std::invalid_argument);
+    EXPECT_THROW(Scatter{}.point_radius(-1), improc::ParameterError);
 }


### PR DESCRIPTION
- Add improc/exceptions.hpp: Exception base → FormatError, ParameterError, IoError (FileNotFoundError, CameraError), ModelError, DataError, AugmentError
- Add improc/error.hpp: Error value type with Code enum for std::expected returns
- Replace all std::invalid_argument / std::runtime_error / std::logic_error throughout headers, sources, and tests with typed improc exceptions
- Update CameraCapture::getFrame() to return std::expected<cv::Mat, Error>
- Update HaarCascadeLoader::get_impl() return type to use improc::Error
- Update all tests to expect new exception types