### PR TITLE
Fix compilation errors after getFrame() and exception refactoring

### DIFF
--- a/examples/io/demo_camera_capture.cpp
+++ b/examples/io/demo_camera_capture.cpp
@@ -17,8 +17,8 @@ int main() {
   while (true) {
     auto frame = camera.getFrame();
 
-    if (!frame.empty()) {
-      cv::imshow(camera.getWindowName(), frame);
+    if (frame.has_value()) {
+      cv::imshow(camera.getWindowName(), *frame);
     }
 
     int key = cv::waitKey(30);

--- a/examples/ml/demo_dataset.cpp
+++ b/examples/ml/demo_dataset.cpp
@@ -14,7 +14,7 @@ int main() {
 
   auto result = dataset.load_from_directory(dataset_path, 0.2f, 0.1f, 5);
   if (!result) {
-    std::cerr << "Error loading dataset: " << result.error() << std::endl;
+    std::cerr << "Error loading dataset: " << result.error().message << std::endl;
     return 1;
   }
 

--- a/examples/ml/demo_haar_cascade_loader.cpp
+++ b/examples/ml/demo_haar_cascade_loader.cpp
@@ -14,7 +14,7 @@ int main() {
     loader.load_model(model_path);
     auto model = loader.get_model();
     if (!model) {
-      std::cerr << "Model load failed: " << model.error() << std::endl;
+      std::cerr << "Model load failed: " << model.error().message << std::endl;
       return 1;
     }
 

--- a/examples/ml/demo_image_loader.cpp
+++ b/examples/ml/demo_image_loader.cpp
@@ -21,7 +21,7 @@ int main() {
       cv::imshow("First Image", result->front());
       cv::waitKey(0);
     } else {
-      std::cerr << result.error() << std::endl;
+      std::cerr << result.error().message << std::endl;
     }
 
   } catch (const std::exception& e) {

--- a/tests/core/test_image.cpp
+++ b/tests/core/test_image.cpp
@@ -12,7 +12,7 @@ TEST(ImageTest, ConstructFromValidBGRMat) {
 
 TEST(ImageTest, ThrowsOnWrongType) {
     cv::Mat mat(100, 100, CV_8UC1);  // Gray mat, not BGR
-    EXPECT_THROW((Image<BGR>{mat}), improc::ParameterError);
+    EXPECT_THROW((Image<BGR>{mat}), improc::FormatError);
 }
 
 TEST(ImageTest, RowsColsReflectMat) {

--- a/tests/io/test_camera.cpp
+++ b/tests/io/test_camera.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <opencv2/videoio.hpp>
 #include "improc/io/camera_capture.hpp"
+#include "improc/exceptions.hpp"
 
 using improc::io::CameraCapture;
 
@@ -25,7 +26,8 @@ TEST(CameraCaptureTest, CanStartAndGrabFrame) {
     std::this_thread::sleep_for(std::chrono::milliseconds(2500));
 
     auto frame = camera.getFrame();
-    EXPECT_FALSE(frame.empty()) << "Frame from camera is empty";
+    ASSERT_TRUE(frame.has_value()) << "getFrame() returned error";
+    EXPECT_FALSE(frame->empty()) << "Frame from camera is empty";
 }
 
 TEST(CameraCaptureTest, CanStopCapture) {
@@ -53,9 +55,9 @@ TEST(CameraCaptureTest, StopIsIdempotent) {
     SUCCEED() << "Multiple calls to stop() work correctly.";
 }
 
-TEST(CameraCaptureTest, InvalidCameraIDReturnsEmptyFrame) {
+TEST(CameraCaptureTest, InvalidCameraIDReturnsError) {
     CameraCapture camera(9999);
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
     auto frame = camera.getFrame();
-    EXPECT_TRUE(frame.empty()) << "Frame should be empty for an invalid camera ID.";
+    EXPECT_FALSE(frame.has_value()) << "Expected error for invalid camera ID";
 }


### PR DESCRIPTION
- test_camera.cpp: update to std::expected API (has_value(), ->)
- test_image.cpp: ThrowsOnWrongType expects FormatError, not ParameterError
- demo_camera_capture.cpp: update frame access to std::expected API
- demo_image_loader, demo_dataset, demo_haar_cascade: use error.message