### PR TITLE
Add demo executables for enhance, edge, and draw ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,14 @@ target_link_libraries(demo_image_ops PRIVATE improc)
 add_executable(demo_filters examples/core/demo_filters.cpp)
 target_link_libraries(demo_filters PRIVATE improc)
 
+# CLAHE, GammaCorrection, BilateralFilter
+add_executable(demo_enhance examples/core/demo_enhance.cpp)
+target_link_libraries(demo_enhance PRIVATE improc)
+
+# SobelEdge, CannyEdge
+add_executable(demo_edge examples/core/demo_edge.cpp)
+target_link_libraries(demo_edge PRIVATE improc)
+
 # Threading demos
 add_executable(demo_thread_pool examples/threading/demo_thread_pool.cpp)
 target_link_libraries(demo_thread_pool PRIVATE improc)
@@ -96,6 +104,10 @@ target_link_libraries(demo_frame_pipeline PRIVATE improc)
 # Visualization demo
 add_executable(demo_visualization examples/visualization/demo_visualization.cpp)
 target_link_libraries(demo_visualization PRIVATE improc)
+
+# DrawBoundingBoxes demo
+add_executable(demo_draw examples/visualization/demo_draw.cpp)
+target_link_libraries(demo_draw PRIVATE improc)
 
 # DNN Inference demo
 add_executable(demo_dnn_inference examples/ml/demo_dnn_inference.cpp)

--- a/examples/core/demo_edge.cpp
+++ b/examples/core/demo_edge.cpp
@@ -1,0 +1,86 @@
+// examples/core/demo_edge.cpp
+//
+// Demo: SobelEdge and CannyEdge
+//
+// Usage: run from the build directory; press any key to advance.
+
+#include "improc/core/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::core;
+
+static void show(const std::string& title, const cv::Mat& mat) {
+    cv::imshow(title, mat);
+    cv::waitKey(0);
+}
+
+int main() {
+    // ── Source images ──────────────────────────────────────────────────────────
+    // Synthetic: shapes on a dark background
+    cv::Mat raw(300, 400, CV_8UC3, cv::Scalar(30, 30, 30));
+    cv::rectangle(raw, {50, 50},   {150, 150}, {200, 200, 200}, -1);
+    cv::circle(raw,   {280, 150},  60,          {180, 180, 180}, -1);
+    cv::line(raw,     {0,  250},   {400, 250},  {220, 220, 220},  3);
+    cv::ellipse(raw,  {200, 240},  {80, 40}, 30, 0, 360, {160, 160, 160}, -1);
+
+    Image<BGR>  bgr(raw);
+    Image<Gray> gray = bgr | ToGray{};
+
+    show("0a — Source (BGR)", bgr.mat());
+    show("0b — Source (Gray)", gray.mat());
+
+    // ── 1. SobelEdge ──────────────────────────────────────────────────────────
+    std::cout << "\n--- SobelEdge ---\n";
+
+    Image<Gray> sobel3 = gray | SobelEdge{}.ksize(3);
+    Image<Gray> sobel5 = gray | SobelEdge{}.ksize(5);
+    Image<Gray> sobel7 = gray | SobelEdge{}.ksize(7);
+    show("1a — Sobel ksize=3 (fine detail)", sobel3.mat());
+    show("1b — Sobel ksize=5 (smoother)", sobel5.mat());
+    show("1c — Sobel ksize=7 (broadest edges)", sobel7.mat());
+
+    // BGR input — auto-converted to Gray internally
+    Image<Gray> sobel_bgr = bgr | SobelEdge{};
+    show("1d — Sobel from BGR input (auto-converted)", sobel_bgr.mat());
+
+    // ── 2. CannyEdge ──────────────────────────────────────────────────────────
+    std::cout << "\n--- CannyEdge ---\n";
+
+    Image<Gray> canny_default = gray | CannyEdge{};
+    Image<Gray> canny_low     = gray | CannyEdge{}.threshold1(20).threshold2(60);
+    Image<Gray> canny_high    = gray | CannyEdge{}.threshold1(150).threshold2(250);
+    Image<Gray> canny_ap5     = gray | CannyEdge{}.threshold1(50).threshold2(150).aperture_size(5);
+    show("2a — Canny (t1=100, t2=200) default", canny_default.mat());
+    show("2b — Canny (t1=20, t2=60) low thresholds — more edges", canny_low.mat());
+    show("2c — Canny (t1=150, t2=250) high thresholds — fewer edges", canny_high.mat());
+    show("2d — Canny (aperture=5) — slightly smoother edges", canny_ap5.mat());
+
+    // BGR input
+    Image<Gray> canny_bgr = bgr | CannyEdge{}.threshold1(50).threshold2(150);
+    show("2e — Canny from BGR input (auto-converted)", canny_bgr.mat());
+
+    // ── 3. Sobel vs Canny comparison ──────────────────────────────────────────
+    std::cout << "\n--- Sobel vs Canny comparison ---\n";
+
+    // Blur first to reduce noise sensitivity
+    Image<Gray> prepped = gray | GaussianBlur{}.kernel_size(3).sigma(1.0);
+    Image<Gray> sobel_clean = prepped | SobelEdge{}.ksize(3);
+    Image<Gray> canny_clean = prepped | CannyEdge{}.threshold1(40).threshold2(120);
+    show("3a — Blurred input", prepped.mat());
+    show("3b — Sobel after blur (gradient magnitude)", sobel_clean.mat());
+    show("3c — Canny after blur (thin binary edges)", canny_clean.mat());
+
+    // ── 4. Pipeline integration ───────────────────────────────────────────────
+    std::cout << "\n--- Pipeline: BGR → CLAHE → Sobel → Threshold ---\n";
+
+    Image<Gray> pipeline_result = bgr
+        | CLAHE{}.clip_limit(2.0)
+        | SobelEdge{}.ksize(3)
+        | Threshold{}.value(30).mode(ThresholdMode::Binary);
+
+    show("4  — BGR → CLAHE → Sobel → Binary threshold", pipeline_result.mat());
+
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/examples/core/demo_enhance.cpp
+++ b/examples/core/demo_enhance.cpp
@@ -1,0 +1,107 @@
+// examples/core/demo_enhance.cpp
+//
+// Demo: CLAHE, GammaCorrection, BilateralFilter
+//
+// Usage: run from the build directory; press any key to advance.
+
+#include "improc/core/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::core;
+
+static void show(const std::string& title, const cv::Mat& mat) {
+    cv::imshow(title, mat);
+    cv::waitKey(0);
+}
+
+int main() {
+    // ── Source images ──────────────────────────────────────────────────────────
+    // Low-contrast grayscale ramp (simulate a dark, flat image)
+    cv::Mat gray_raw(300, 400, CV_8UC1);
+    for (int r = 0; r < gray_raw.rows; ++r)
+        for (int c = 0; c < gray_raw.cols; ++c)
+            gray_raw.at<uchar>(r, c) = static_cast<uchar>(60 + (c * 80) / gray_raw.cols);
+
+    // BGR gradient with a circle overlay (for bilateral + gamma)
+    cv::Mat bgr_raw(300, 400, CV_8UC3);
+    for (int r = 0; r < bgr_raw.rows; ++r)
+        for (int c = 0; c < bgr_raw.cols; ++c)
+            bgr_raw.at<cv::Vec3b>(r, c) = {
+                static_cast<uchar>(c * 255 / bgr_raw.cols),
+                static_cast<uchar>(r * 255 / bgr_raw.rows),
+                static_cast<uchar>(128)
+            };
+    cv::circle(bgr_raw, {200, 150}, 80, {0, 0, 255}, -1);
+
+    Image<Gray> gray(gray_raw);
+    Image<BGR>  bgr(bgr_raw);
+
+    std::cout << "Source: " << bgr.cols() << "x" << bgr.rows() << " BGR\n";
+    show("0a — Source (Gray, low contrast)", gray.mat());
+    show("0b — Source (BGR)", bgr.mat());
+
+    // ── 1. CLAHE ──────────────────────────────────────────────────────────────
+    std::cout << "\n--- CLAHE ---\n";
+
+    Image<Gray> clahe_gray = gray | CLAHE{};
+    Image<Gray> clahe_strong = gray | CLAHE{}.clip_limit(2.0).tile_grid_size(4, 4);
+    show("1a — CLAHE Gray (clip=40, tile=8x8)", clahe_gray.mat());
+    show("1b — CLAHE Gray (clip=2.0, tile=4x4) — finer local contrast", clahe_strong.mat());
+
+    Image<BGR> clahe_bgr = bgr | CLAHE{}.clip_limit(3.0);
+    show("1c — CLAHE BGR (colour-safe via LAB L-channel)", clahe_bgr.mat());
+
+    // ── 2. GammaCorrection ────────────────────────────────────────────────────
+    std::cout << "\n--- GammaCorrection ---\n";
+
+    Image<BGR> gamma_bright = bgr | GammaCorrection{}.gamma(0.4f);
+    Image<BGR> gamma_dark   = bgr | GammaCorrection{}.gamma(2.5f);
+    Image<BGR> gamma_linear = bgr | GammaCorrection{}.gamma(1.0f);
+    show("2a — Gamma 0.4 (brightened)", gamma_bright.mat());
+    show("2b — Gamma 2.5 (darkened)", gamma_dark.mat());
+    show("2c — Gamma 1.0 (identity)", gamma_linear.mat());
+
+    Image<Gray> gamma_gray_bright = gray | GammaCorrection{}.gamma(0.5f);
+    show("2d — GammaCorrection Gray (gamma=0.5)", gamma_gray_bright.mat());
+
+    std::cout << "  gamma < 1 brightens; gamma > 1 darkens; gamma = 1 is identity\n";
+
+    // ── 3. BilateralFilter ────────────────────────────────────────────────────
+    std::cout << "\n--- BilateralFilter ---\n";
+
+    // Add noise to compare filtering results
+    cv::Mat noisy = bgr_raw.clone();
+    cv::RNG rng(42);
+    for (int i = 0; i < 2000; ++i) {
+        int r = rng.uniform(0, noisy.rows);
+        int c = rng.uniform(0, noisy.cols);
+        noisy.at<cv::Vec3b>(r, c) = (i % 2 == 0)
+            ? cv::Vec3b{255, 255, 255} : cv::Vec3b{0, 0, 0};
+    }
+    Image<BGR> noisy_src(noisy);
+    show("3a — Noisy source", noisy_src.mat());
+
+    Image<BGR> bilateral  = noisy_src | BilateralFilter{};
+    Image<BGR> bilateral2 = noisy_src | BilateralFilter{}.diameter(15).sigma_color(80).sigma_space(80);
+    Image<BGR> gaussian_ref = noisy_src | GaussianBlur{}.kernel_size(9).sigma(2.0);
+    show("3b — BilateralFilter (d=9, σ=75) — edges preserved", bilateral.mat());
+    show("3c — BilateralFilter (d=15, σ=80) — stronger, still sharp at edges", bilateral2.mat());
+    show("3d — GaussianBlur (k=9) for comparison — edges blurred", gaussian_ref.mat());
+
+    Image<Gray> bilat_gray = (gray | GammaCorrection{}.gamma(0.5f))
+                           | BilateralFilter{}.diameter(9);
+    show("3e — BilateralFilter Gray", bilat_gray.mat());
+
+    // ── Combined pipeline ─────────────────────────────────────────────────────
+    std::cout << "\n--- Combined pipeline ---\n";
+
+    Image<BGR> result = bgr
+        | GammaCorrection{}.gamma(0.6f)
+        | BilateralFilter{}.diameter(9).sigma_color(60).sigma_space(60)
+        | CLAHE{}.clip_limit(2.0);
+
+    show("4  — Gamma(0.6) → Bilateral → CLAHE", result.mat());
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/examples/visualization/demo_draw.cpp
+++ b/examples/visualization/demo_draw.cpp
@@ -1,0 +1,132 @@
+// examples/visualization/demo_draw.cpp
+//
+// Demo: DrawBoundingBoxes — annotating detection results on images.
+//
+// Uses synthetic detections so no model or camera is required.
+// Press any key to advance between windows.
+
+#include "improc/core/pipeline.hpp"
+#include "improc/visualization/draw.hpp"
+#include "improc/ml/result_types.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::core;
+using namespace improc::visualization;
+using improc::ml::Detection;
+
+static void show(const std::string& title, const cv::Mat& mat) {
+    cv::imshow(title, mat);
+    cv::waitKey(0);
+}
+
+static Detection make_det(float x, float y, float w, float h,
+                           int class_id, std::string label, float conf) {
+    Detection d;
+    d.box        = {x, y, w, h};
+    d.class_id   = class_id;
+    d.label      = std::move(label);
+    d.confidence = conf;
+    return d;
+}
+
+int main() {
+    // ── Background: simple scene with coloured regions ─────────────────────
+    cv::Mat raw(480, 640, CV_8UC3, cv::Scalar(40, 40, 40));
+    // "objects" — filled rectangles in different colours
+    cv::rectangle(raw, {30,  40},  {180, 180}, {60,  130, 200}, -1);   // blue-ish
+    cv::rectangle(raw, {220, 80},  {400, 260}, {50,  180,  70}, -1);   // green-ish
+    cv::circle(raw,    {530, 150},  80,         {180,  60,  60}, -1);   // red-ish
+    cv::rectangle(raw, {60,  280}, {260, 420},  {170, 130,  30}, -1);  // yellow-ish
+    cv::ellipse(raw,   {450, 360},  {100, 60}, 0, 0, 360, {120, 60, 170}, -1); // purple-ish
+
+    Image<BGR> scene(raw);
+    show("0 — Scene (no annotations)", scene.mat());
+
+    // ── 1. Basic annotations ──────────────────────────────────────────────────
+    std::cout << "\n--- Basic annotations ---\n";
+
+    std::vector<Detection> dets = {
+        make_det( 30,  40, 150, 140, 0, "person",  0.92f),
+        make_det(220,  80, 180, 180, 1, "car",     0.87f),
+        make_det(450,  70, 160, 160, 2, "bicycle", 0.75f),
+        make_det( 60, 280, 200, 140, 3, "dog",     0.83f),
+        make_det(350, 300, 200, 120, 4, "cat",     0.61f),
+    };
+
+    Image<BGR> annotated = scene | DrawBoundingBoxes{dets};
+    show("1  — Default (green, thickness=2, label+confidence)", annotated.mat());
+
+    // ── 2. Display variants ───────────────────────────────────────────────────
+    std::cout << "\n--- Display variants ---\n";
+
+    Image<BGR> label_only = scene | DrawBoundingBoxes{dets}.show_confidence(false);
+    show("2a — Label only (no confidence)", label_only.mat());
+
+    Image<BGR> conf_only = scene | DrawBoundingBoxes{dets}.show_label(false);
+    show("2b — Confidence only (no label)", conf_only.mat());
+
+    Image<BGR> boxes_only = scene | DrawBoundingBoxes{dets}
+        .show_label(false).show_confidence(false);
+    show("2c — Boxes only", boxes_only.mat());
+
+    // ── 3. Custom appearance ──────────────────────────────────────────────────
+    std::cout << "\n--- Custom appearance ---\n";
+
+    Image<BGR> red_thick = scene | DrawBoundingBoxes{dets}
+        .color({0, 0, 255})
+        .thickness(3)
+        .font_scale(0.6);
+    show("3a — Red boxes, thickness=3, font_scale=0.6", red_thick.mat());
+
+    Image<BGR> cyan_thin = scene | DrawBoundingBoxes{dets}
+        .color({255, 255, 0})
+        .thickness(1)
+        .font_scale(0.35)
+        .show_confidence(false);
+    show("3b — Cyan, thin, labels only", cyan_thin.mat());
+
+    // ── 4. Source image unchanged ─────────────────────────────────────────────
+    std::cout << "\n--- Source unchanged ---\n";
+
+    Image<BGR> before = scene;
+    DrawBoundingBoxes{dets}(scene);  // result discarded — scene must be untouched
+    cv::Mat diff;
+    cv::absdiff(before.mat(), scene.mat(), diff);
+    std::cout << "  Diff sum after DrawBoundingBoxes: "
+              << cv::sum(diff)[0] << " (should be 0)\n";
+
+    // ── 5. Low-confidence filter ──────────────────────────────────────────────
+    std::cout << "\n--- Filter by confidence threshold ---\n";
+
+    std::vector<Detection> high_conf;
+    for (const auto& d : dets)
+        if (d.confidence >= 0.80f)
+            high_conf.push_back(d);
+
+    Image<BGR> filtered = scene | DrawBoundingBoxes{high_conf};
+    std::cout << "  Showing " << high_conf.size() << "/" << dets.size()
+              << " detections (conf >= 0.80)\n";
+    show("5  — Only high-confidence detections (≥ 0.80)", filtered.mat());
+
+    // ── 6. Pipeline: inference prep → annotate → display ──────────────────────
+    std::cout << "\n--- Full pipeline ---\n";
+
+    // Simulate: resize for inference, annotate, resize back for display
+    std::vector<Detection> scaled_dets = {
+        make_det( 7,  9,  30,  27, 0, "person",  0.91f),
+        make_det(44,  16, 36,  36, 1, "car",     0.88f),
+        make_det(12,  56, 40,  28, 3, "dog",     0.82f),
+    };
+
+    Image<BGR> pipeline_result =
+        scene
+        | Resize{}.width(128).height(96)
+        | DrawBoundingBoxes{scaled_dets}.thickness(1).font_scale(0.3)
+        | Resize{}.width(640).height(480);
+
+    show("6  — Resize → Annotate → Resize back", pipeline_result.mat());
+
+    std::cout << "Done.\n";
+    return 0;
+}


### PR DESCRIPTION
demo_enhance: CLAHE, GammaCorrection, BilateralFilter with comparisons demo_edge: SobelEdge, CannyEdge with threshold/aperture variants demo_draw: DrawBoundingBoxes with synthetic detections, display variants,
           confidence filtering, and pipeline integration