### PR TITLE
ci: fix Linux system packages mode and pin macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
 
     runs-on: ${{ matrix.os }}
 
@@ -36,6 +36,12 @@ jobs:
           path: ~/.conan2/p
           key: conan-${{ matrix.os }}-${{ hashFiles('conanfile.py') }}
           restore-keys: conan-${{ matrix.os }}-
+
+      - name: Allow Conan to install system packages (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          echo "tools.system.package_manager:mode=install" >> ~/.conan2/global.conf
+          echo "tools.system.package_manager:sudo=True"    >> ~/.conan2/global.conf
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
Linux: dodaj tools.system.package_manager:mode=install żeby Conan mógł instalować systemowe zależności (libva-dev itp.) przez apt.

macOS: zamień macos-latest (teraz ARM64/M1) na macos-13 (Intel x86_64) gdzie istnieją gotowe binarne paczki opencv/4.8.1 w Conan Center — budowanie ze źródeł na ARM64 pękało na brakującym libwebp::libwebp.