### PR TITLE
feat(examples/views): add demo executables for M1, M2, M3 views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,16 @@ target_link_libraries(demo_video_reader PRIVATE improc)
 add_executable(demo_montage examples/visualization/demo_montage.cpp)
 target_link_libraries(demo_montage PRIVATE improc)
 
+# Views demos (M1: single-image lazy pipeline, M2: collection pipeline, M3: external sources)
+add_executable(demo_views_m1 examples/views/demo_views_m1.cpp)
+target_link_libraries(demo_views_m1 PRIVATE improc)
+
+add_executable(demo_views_m2 examples/views/demo_views_m2.cpp)
+target_link_libraries(demo_views_m2 PRIVATE improc)
+
+add_executable(demo_views_m3 examples/views/demo_views_m3.cpp)
+target_link_libraries(demo_views_m3 PRIVATE improc)
+
 # ONNX inference demo
 if(IMPROC_WITH_ONNX)
     add_executable(demo_onnx_inference examples/ml/demo_onnx_inference.cpp)

--- a/examples/views/demo_views_m1.cpp
+++ b/examples/views/demo_views_m1.cpp
@@ -1,0 +1,60 @@
+// examples/views/demo_views_m1.cpp
+// M1 demo: lazy single-image pipeline with views::transform / views::to<Image<F>>()
+//
+// Compares the eager operator| approach (executes immediately, one copy per op)
+// with the lazy views:: approach (builds a deferred chain, single eval at the end).
+
+#include <cassert>
+#include <format>
+#include <iostream>
+#include "improc/core/pipeline.hpp"
+#include "improc/views/views.hpp"
+
+using namespace improc::core;
+namespace views = improc::views;
+
+int main() {
+    // ── Setup: synthetic 640×480 BGR image ──────────────────────────────────
+    cv::Mat mat(480, 640, CV_8UC3, cv::Scalar(100, 150, 200));
+    Image<BGR> img{mat};
+
+    std::cout << std::format("Source: {}×{}\n", img.cols(), img.rows());
+
+    // ── Eager pipeline (existing improc::core operator|) ────────────────────
+    // Each | executes immediately, producing an intermediate Image<BGR>.
+    Image<BGR> eager = img
+        | Resize{}.width(224).height(224)
+        | GaussianBlur{}.kernel_size(5)
+        | Brightness{}.delta(20.0);
+
+    std::cout << std::format("Eager result:  {}×{}\n", eager.cols(), eager.rows());
+
+    // ── Lazy pipeline (views::) ──────────────────────────────────────────────
+    // Building the view does zero work — no pixels are touched yet.
+    auto view = img
+        | views::transform(Resize{}.width(224).height(224))
+        | views::transform(GaussianBlur{}.kernel_size(5))
+        | views::transform(Brightness{}.delta(20.0));
+
+    // Evaluation only happens here, applying all three ops in one pass.
+    Image<BGR> lazy = view | views::to<Image<BGR>>();
+
+    std::cout << std::format("Lazy result:   {}×{}\n", lazy.cols(), lazy.rows());
+
+    // ── Verify: source unchanged, results identical in size ──────────────────
+    assert(img.cols() == 640 && img.rows() == 480);
+    assert(eager.cols() == lazy.cols() && eager.rows() == lazy.rows());
+
+    std::cout << "Source dimensions unchanged: OK\n";
+    std::cout << "Eager == Lazy dimensions: OK\n";
+
+    // ── Chaining multiple ops on the same source ─────────────────────────────
+    auto thumbnail = img
+        | views::transform(Resize{}.width(64).height(64))
+        | views::transform(GaussianBlur{}.kernel_size(3))
+        | views::to<Image<BGR>>();
+
+    std::cout << std::format("Thumbnail: {}×{}\n", thumbnail.cols(), thumbnail.rows());
+
+    return 0;
+}

--- a/examples/views/demo_views_m2.cpp
+++ b/examples/views/demo_views_m2.cpp
@@ -1,0 +1,81 @@
+// examples/views/demo_views_m2.cpp
+// M2 demo: lazy collection pipeline over std::vector<Image<BGR>>
+// Shows transform, filter, take, drop and their compositions.
+
+#include <format>
+#include <iostream>
+#include <vector>
+#include "improc/core/pipeline.hpp"
+#include "improc/views/views.hpp"
+
+using namespace improc::core;
+namespace views = improc::views;
+
+static Image<BGR> make_image(int w, int h, int blue) {
+    cv::Mat mat(h, w, CV_8UC3, cv::Scalar(blue, 100, 200));
+    return Image<BGR>{mat};
+}
+
+int main() {
+    // ── Build a batch of 10 images of varying sizes ──────────────────────────
+    std::vector<Image<BGR>> batch;
+    for (int i = 0; i < 10; ++i) {
+        int side = (i % 2 == 0) ? 128 : 64;  // alternating 128px and 64px
+        batch.push_back(make_image(side, side, i * 20));
+    }
+    std::cout << std::format("Source batch: {} images\n", batch.size());
+
+    // ── transform: resize every image lazily ────────────────────────────────
+    auto resized = batch
+        | views::transform(Resize{}.width(32).height(32))
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After transform(Resize→32×32): {} images, each {}×{}\n",
+        resized.size(), resized[0].cols(), resized[0].rows());
+
+    // ── filter: keep only the large (128px) images ──────────────────────────
+    auto large_only = batch
+        | views::filter([](const Image<BGR>& img) { return img.cols() == 128; })
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After filter(cols==128): {} images\n", large_only.size());
+
+    // ── take: first 3 images from batch ─────────────────────────────────────
+    auto first_three = batch
+        | views::take(3)
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After take(3): {} images\n", first_three.size());
+
+    // ── drop: skip the first 4, keep the rest ───────────────────────────────
+    auto after_drop = batch
+        | views::drop(4)
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After drop(4): {} images\n", after_drop.size());
+
+    // ── composition: filter → transform → take ───────────────────────────────
+    // Keep large images, resize them, take the first 3.
+    auto pipeline_result = batch
+        | views::filter([](const Image<BGR>& img) { return img.cols() == 128; })
+        | views::transform(Resize{}.width(64).height(64))
+        | views::take(3)
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("filter(large) | transform(64×64) | take(3): {} images, each {}×{}\n",
+        pipeline_result.size(), pipeline_result[0].cols(), pipeline_result[0].rows());
+
+    // ── lazy range-for: no materialization ──────────────────────────────────
+    // Process one image at a time — only the current image is in RAM.
+    int processed = 0;
+    for (const auto& img : batch | views::transform(Resize{}.width(16).height(16))) {
+        (void)img;
+        ++processed;
+    }
+    std::cout << std::format("Lazy range-for processed: {} images\n", processed);
+
+    // ── source unchanged ─────────────────────────────────────────────────────
+    std::cout << std::format("Source batch still has {} images\n", batch.size());
+
+    return 0;
+}

--- a/examples/views/demo_views_m3.cpp
+++ b/examples/views/demo_views_m3.cpp
@@ -1,0 +1,188 @@
+// examples/views/demo_views_m3.cpp
+// M3 demo: lazy views over external sources — directory and video.
+//
+// DirView:   from_dir() scans a directory and lazily loads images on iteration.
+// VideoView: wraps a VideoReader and lazily reads frames one at a time.
+
+#include <filesystem>
+#include <format>
+#include <iostream>
+#include <vector>
+#include "improc/core/pipeline.hpp"
+#include "improc/io/image_io.hpp"
+#include "improc/io/video_reader.hpp"
+#include "improc/views/views.hpp"
+
+namespace fs    = std::filesystem;
+namespace views = improc::views;
+using namespace improc::core;
+using improc::io::VideoReader;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static fs::path make_temp_dir() {
+    auto tmp = fs::temp_directory_path() / "demo_views_m3";
+    fs::create_directories(tmp);
+    return tmp;
+}
+
+// Write N synthetic PNG images into dir.
+static void write_synthetic_images(const fs::path& dir, int n) {
+    for (int i = 0; i < n; ++i) {
+        int side = (i % 2 == 0) ? 128 : 64;
+        cv::Mat mat(side, side, CV_8UC3, cv::Scalar(i * 20, 100, 200));
+        auto path = dir / std::format("img_{:03d}.png", i);
+        cv::imwrite(path.string(), mat);
+    }
+}
+
+// ── DirView demo ──────────────────────────────────────────────────────────────
+
+static void demo_dir_view(const fs::path& dir) {
+    std::cout << "\n── DirView demo ───────────────────────────────────────────\n";
+
+    // -- count all images lazily
+    int total = 0;
+    for (const auto& img : views::from_dir(dir, {".png"})) {
+        (void)img;
+        ++total;
+    }
+    std::cout << std::format("from_dir: {} images found\n", total);
+
+    // -- transform: resize every image to 32×32
+    auto resized = views::from_dir(dir, {".png"})
+        | views::transform(Resize{}.width(32).height(32))
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After transform(32×32): {} images, each {}×{}\n",
+        resized.size(), resized[0].cols(), resized[0].rows());
+
+    // -- filter: keep only large (128px) images
+    auto large_only = views::from_dir(dir, {".png"})
+        | views::filter([](const Image<BGR>& img) { return img.cols() == 128; })
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After filter(cols==128): {} images\n", large_only.size());
+
+    // -- take: first 3 images
+    auto first_three = views::from_dir(dir, {".png"})
+        | views::take(3)
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After take(3): {} images\n", first_three.size());
+
+    // -- drop: skip first 4
+    auto after_drop = views::from_dir(dir, {".png"})
+        | views::drop(4)
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("After drop(4): {} images\n", after_drop.size());
+
+    // -- composition: filter → transform → take
+    auto pipeline_result = views::from_dir(dir, {".png"})
+        | views::filter([](const Image<BGR>& img) { return img.cols() == 128; })
+        | views::transform(Resize{}.width(64).height(64))
+        | views::take(3)
+        | views::to<std::vector<Image<BGR>>>();
+
+    std::cout << std::format("filter(large)|transform(64×64)|take(3): {} images, each {}×{}\n",
+        pipeline_result.size(), pipeline_result[0].cols(), pipeline_result[0].rows());
+}
+
+// ── VideoView demo ────────────────────────────────────────────────────────────
+
+static bool ffmpeg_available() {
+    return std::system("ffmpeg -version > /dev/null 2>&1") == 0;
+}
+
+static fs::path make_test_video(const fs::path& dir, int frame_count) {
+    auto path = dir / "test.mp4";
+    // Write synthetic frames as individual PNGs, then encode via ffmpeg.
+    auto frames_dir = dir / "frames";
+    fs::create_directories(frames_dir);
+    for (int i = 0; i < frame_count; ++i) {
+        cv::Mat mat(64, 64, CV_8UC3, cv::Scalar(i * 10, 100, 200));
+        cv::imwrite((frames_dir / std::format("{:04d}.png", i)).string(), mat);
+    }
+    auto cmd = std::format(
+        "ffmpeg -y -framerate 10 -i {}/%04d.png -c:v libx264 -pix_fmt yuv420p {} > /dev/null 2>&1",
+        frames_dir.string(), path.string());
+    std::system(cmd.c_str());
+    fs::remove_all(frames_dir);
+    return path;
+}
+
+static void demo_video_view(const fs::path& dir) {
+    std::cout << "\n── VideoView demo ─────────────────────────────────────────\n";
+
+    if (!ffmpeg_available()) {
+        std::cout << "ffmpeg not found — skipping VideoView demo\n";
+        return;
+    }
+
+    const int frame_count = 10;
+    auto video_path = make_test_video(dir, frame_count);
+
+    if (!fs::exists(video_path)) {
+        std::cout << "Video encoding failed — skipping VideoView demo\n";
+        return;
+    }
+
+    // -- count all frames lazily
+    {
+        VideoReader reader{video_path.string()};
+        int total = 0;
+        for (const auto& frame : views::VideoView{reader}) {
+            (void)frame;
+            ++total;
+        }
+        std::cout << std::format("VideoView: {} frames read\n", total);
+    }
+
+    // -- transform: resize every frame to 32×32, take first 5
+    {
+        VideoReader reader{video_path.string()};
+        auto result = views::VideoView{reader}
+            | views::transform(Resize{}.width(32).height(32))
+            | views::take(5)
+            | views::to<std::vector<Image<BGR>>>();
+
+        std::cout << std::format("transform(32×32)|take(5): {} frames, each {}×{}\n",
+            result.size(), result[0].cols(), result[0].rows());
+    }
+
+    // -- filter: keep frames where cols == 64 (all frames should qualify)
+    {
+        VideoReader reader{video_path.string()};
+        auto result = views::VideoView{reader}
+            | views::filter([](const Image<BGR>& frame) { return frame.cols() == 64; })
+            | views::to<std::vector<Image<BGR>>>();
+
+        std::cout << std::format("filter(cols==64): {} frames\n", result.size());
+    }
+
+    // -- drop first 3, take next 4
+    {
+        VideoReader reader{video_path.string()};
+        auto result = views::VideoView{reader}
+            | views::drop(3)
+            | views::take(4)
+            | views::to<std::vector<Image<BGR>>>();
+
+        std::cout << std::format("drop(3)|take(4): {} frames\n", result.size());
+    }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+int main() {
+    auto tmp = make_temp_dir();
+
+    write_synthetic_images(tmp, 8);
+    demo_dir_view(tmp);
+    demo_video_view(tmp);
+
+    fs::remove_all(tmp);
+    std::cout << "\nDone.\n";
+    return 0;
+}


### PR DESCRIPTION
demo_views_m1: eager vs lazy single-image pipeline comparison
demo_views_m2: collection pipeline — transform, filter, take, drop, composition, lazy range-for
demo_views_m3: external sources — DirView over temp PNGs, VideoView over ffmpeg-encoded MP4