### PR TITLE
docs: update README and CHANGELOG for improc::views (M1–M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,4 +87,20 @@ that subsequent releases will extend without breaking.
 
 ## [Unreleased]
 
-- `improc::cuda` — GPU-accelerated ops via OpenCV CUDA (planned)
+### Added
+
+#### `improc::views`
+- `views::transform(op)` — lazy single-image and collection transform; defers op execution until materialisation
+- `views::filter(pred)` — lazy predicate filter over image collections
+- `views::take(n)` / `views::drop(n)` — lazy size-limiting and offset adapters
+- `views::to<T>()` — materialisation sink: `to<Image<F>>()` for single images, `to<std::vector<Image<F>>>()` for collections
+- `views::from_dir(path, exts)` — lazy directory scanner; images are loaded only as they are iterated
+- `views::VideoView{reader}` — lazy frame-by-frame adapter over `VideoReader`
+- `views::batch(n)` — groups elements into `std::vector<Image<F>>` chunks of size ≤ n (last chunk may be smaller)
+- `views::enumerate` — pairs each element with a zero-based `std::size_t` index; yields `std::pair<std::size_t, Image<F>>`
+- `views::zip(v1, v2)` — pairs elements from two sources element-wise; stops at the shorter source
+- All adapters compose via `operator|`; `from_dir` and `VideoView` support the full adapter set
+- `views.hpp` umbrella include
+
+### Planned
+- `improc::cuda` — GPU-accelerated ops via OpenCV CUDA

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | `improc::ml` | ✅ Stable | New ops added regularly |
 | `improc::threading` | ✅ Stable | |
 | `improc::visualization` | ✅ Stable | New ops added regularly |
+| `improc::views` | ✅ Stable | Lazy image pipeline adapters |
 | `improc::onnx` | ✅ Stable | ONNX Runtime 1.20.1; CPU + CoreML on Apple Silicon |
 | `improc::cuda` | 🔜 Planned | GPU-accelerated ops via OpenCV CUDA |
 
@@ -112,6 +113,7 @@ OpenCV is powerful but its raw API is stringly-typed, mutation-heavy, and easy t
 - **Haar Cascade loader** — CRTP-based model loader for OpenCV cascade classifiers
 - **Threading** — `ThreadPool` and `FramePipeline<Result>` for real-time frame processing
 - **Visualization** — `Histogram`, `LinePlot`, `Scatter` chart functors, a `Show` passthrough display op, and `DrawBoundingBoxes` for annotating `Detection` results — all composable with `operator|`
+- **Lazy image views** — `improc::views` lazy pipeline adapters: `transform`, `filter`, `take`, `drop`, `batch(N)`, `enumerate`, `zip`; compose with `from_dir()`, `VideoView`, and `std::vector<Image<F>>` sources via `operator|`; zero work until materialised with `views::to<T>()`
 
 ## Quick Start
 
@@ -174,6 +176,9 @@ All ops are functors that compose via `operator|`. The `pipeline.hpp` umbrella h
 
 // Visualization
 #include "improc/visualization/visualization.hpp"
+
+// Lazy views
+#include "improc/views/views.hpp"
 ```
 
 ## Augmentation
@@ -305,6 +310,53 @@ Image<BGR> annotated = frame | DrawBoundingBoxes{detections}.thickness(2);
 Image<BGR> boxes_only = frame | DrawBoundingBoxes{detections}
     .show_label(false).show_confidence(false);
 ```
+
+## Lazy Views
+
+Lazy pipeline adapters over image collections. Nothing executes until you materialise with `views::to<T>()` or a range-for loop.
+
+```cpp
+#include "improc/views/views.hpp"
+namespace views = improc::views;
+using namespace improc::core;
+
+std::vector<Image<BGR>> images = ...;
+
+// transform + filter + take — materialise into a new vector
+auto result = images
+    | views::filter([](const Image<BGR>& img) { return img.cols() >= 128; })
+    | views::transform(Resize{}.width(64).height(64))
+    | views::take(10)
+    | views::to<std::vector<Image<BGR>>>();
+
+// lazy iteration over a directory — only loads images on demand
+for (const auto& img : views::from_dir("dataset/train", {".png", ".jpg"})) {
+    // process img ...
+}
+
+// batch(N) — iterate over fixed-size chunks
+for (const auto& chunk : views::from_dir("frames/", {".png"}) | views::batch(8)) {
+    // chunk is std::vector<Image<BGR>> of up to 8 images
+}
+
+// enumerate — zero-based index alongside each element
+for (const auto& [idx, img] : images | views::take(5) | views::enumerate) {
+    std::cout << idx << ": " << img.cols() << "x" << img.rows() << "\n";
+}
+
+// zip — pair two sources element-wise (stops at the shorter)
+for (const auto& [img, mask] : views::zip(images, masks)) {
+    // img and mask aligned by position
+}
+
+// compose freely — lazy VideoView source, then batch + enumerate
+VideoReader reader{"video.mp4"};
+for (const auto& [idx, chunk] : views::VideoView{reader} | views::batch(4) | views::enumerate) {
+    std::cout << "Batch " << idx << ": " << chunk.size() << " frames\n";
+}
+```
+
+See `examples/views/` for the full demo suite (M1–M4) and `NAMESPACES.md` for the complete symbol reference.
 
 ## Requirements
 


### PR DESCRIPTION
Add views namespace to status table, features list, includes, and a dedicated "Lazy Views" section with batch/enumerate/zip examples. CHANGELOG [Unreleased] documents all new views adapters.