### PR TITLE
docs: add tutorials, Doxyfile, and fix doxygen warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ cmake-build-*
 **/.DS_Store
 ._*
 
+# Doxygen generated output
+docs/doxygen/
+
 # Claude Code working files
 memory/
 docs/superpowers/

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,73 @@
+# Doxyfile for improc++
+# Run: doxygen Doxyfile
+# Output: docs/doxygen/html/index.html
+
+#---------------------------------------------------------------------------
+# Project
+#---------------------------------------------------------------------------
+PROJECT_NAME           = "improc++"
+PROJECT_NUMBER         = "0.1.0"
+PROJECT_BRIEF          = "Modern C++ image processing toolkit with compile-time type safety"
+OUTPUT_DIRECTORY       = docs/doxygen
+
+#---------------------------------------------------------------------------
+# Input
+#---------------------------------------------------------------------------
+INPUT                  = include
+FILE_PATTERNS          = *.hpp
+RECURSIVE              = YES
+EXCLUDE_PATTERNS       = */detail/*
+
+#---------------------------------------------------------------------------
+# Source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = NO
+
+#---------------------------------------------------------------------------
+# Output formats
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_LATEX         = NO
+
+#---------------------------------------------------------------------------
+# Extraction
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+HIDE_UNDOC_MEMBERS     = YES
+HIDE_UNDOC_CLASSES     = YES
+
+#---------------------------------------------------------------------------
+# Warnings
+#---------------------------------------------------------------------------
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_LOGFILE           =
+
+#---------------------------------------------------------------------------
+# Preprocessing
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+PREDEFINED             = IMPROC_WITH_ONNX \
+                         DOXYGEN_RUNNING
+
+#---------------------------------------------------------------------------
+# Diagrams
+#---------------------------------------------------------------------------
+HAVE_DOT               = NO
+
+#---------------------------------------------------------------------------
+# HTML appearance
+#---------------------------------------------------------------------------
+GENERATE_TREEVIEW      = YES
+DISABLE_INDEX          = NO
+FULL_SIDEBAR           = NO
+HTML_COLORSTYLE        = LIGHT
+TIMESTAMP              = NO

--- a/docs/tutorials/building-a-pipeline.md
+++ b/docs/tutorials/building-a-pipeline.md
@@ -1,0 +1,224 @@
+# Building a Pipeline
+
+This tutorial covers the core pipeline mechanics: composing ops, converting formats, using lazy views for collections, and plugging in augmentation.
+
+## Eager vs Lazy
+
+improc++ has two pipeline styles.
+
+**Eager** (`operator|` on `Image<F>`) — each step executes immediately:
+
+```cpp
+#include "improc/core/pipeline.hpp"
+using namespace improc::core;
+
+Image<BGR> result = img
+    | Resize{}.width(224).height(224)   // executes now → new Image<BGR>
+    | GaussianBlur{}.kernel_size(3)     // executes now → new Image<BGR>
+    | Brightness{}.delta(10.0);         // executes now → new Image<BGR>
+```
+
+**Lazy** (`improc::views`) — builds a deferred chain; nothing runs until you materialise:
+
+```cpp
+#include "improc/views/views.hpp"
+namespace views = improc::views;
+
+auto view = img
+    | views::transform(Resize{}.width(224).height(224))
+    | views::transform(GaussianBlur{}.kernel_size(3));
+
+Image<BGR> result = view | views::to<Image<BGR>>();  // executes here, once
+```
+
+Use eager pipelines when you have a single image and want readable, step-by-step processing. Use lazy views when you have a collection and want to avoid allocating intermediate vectors.
+
+## Format Conversions
+
+Format mismatches are compiler errors. Use `convert<To>()` or the explicit functor ops to cross format boundaries:
+
+```cpp
+// Free function — explicit conversion
+Image<Gray>    gray    = convert<Gray>(bgr_img);
+Image<Float32C3> f32c3 = convert<Float32C3>(bgr_img);
+
+// In a pipeline — same thing, composable
+Image<Float32C3> tensor = img
+    | Resize{}.width(224).height(224)
+    | ToFloat32C3{}
+    | NormalizeTo{0.0f, 1.0f};
+```
+
+Available conversions:
+
+| From | To | Function |
+|---|---|---|
+| `BGR` | `Gray` | `convert<Gray>(img)` |
+| `BGR` | `Float32C3` | `convert<Float32C3>(img)` |
+| `BGR` | `HSV` | `convert<HSV>(img)` |
+| `Gray` | `BGR` | `convert<BGR>(img)` |
+| `Float32C3` | `BGR` | `convert<BGR>(img)` |
+| `HSV` | `BGR` | `convert<BGR>(img)` |
+
+## All Core Ops
+
+### Geometric
+
+```cpp
+img | Resize{}.width(224).height(224)          // exact size
+img | Resize{}.width(224)                      // aspect-ratio preserved
+img | Crop{}.x(10).y(10).width(100).height(100)
+img | Flip{}.axis(Axis::Horizontal)
+img | Rotate{}.angle(45.0f).scale(1.0f)
+img | Pad{}.top(10).bottom(10).left(10).right(10).mode(PadMode::Constant)
+img | PadToSquare{}
+img | WarpAffine{}.matrix(M).width(w).height(h)
+img | WarpPerspective{}.homography(H).width(w).height(h)
+```
+
+### Filter & Enhancement
+
+```cpp
+img | GaussianBlur{}.kernel_size(3)
+img | MedianBlur{}.kernel_size(5)
+img | BilateralFilter{}.diameter(9).sigma_color(75).sigma_space(75)
+img | UnsharpMask{}.sigma(1.0f).strength(1.5f)
+img | CLAHE{}.clip_limit(2.0).tile_size(8)
+img | GammaCorrection{}.gamma(0.5f)            // < 1 brightens, > 1 darkens
+```
+
+### Morphology & Threshold
+
+```cpp
+img | Dilate{}.kernel_size(3).iterations(1)
+img | Erode{}.kernel_size(3)
+img | Threshold{}.value(128.0).mode(ThresholdMode::Binary)
+img | Threshold{}.mode(ThresholdMode::Otsu)    // automatic threshold
+```
+
+### Edge Detection
+
+```cpp
+// Both accept Image<Gray> or Image<BGR> (auto-converted internally)
+img | SobelEdge{}.ksize(3)                     // returns Image<Gray>
+img | CannyEdge{}.threshold1(50).threshold2(150)
+```
+
+### Normalization
+
+```cpp
+img | Normalize{}                              // [0, 255] → [0, 1]
+img | NormalizeTo{0.0f, 1.0f}                  // explicit range
+img | Standardize{}.mean(0.485f).std(0.229f)   // per-channel mean/std
+```
+
+### Color
+
+```cpp
+img | Brightness{}.delta(20.0)
+img | Contrast{}.factor(1.2f)
+img | WeightedBlend{other}.alpha(0.7f)
+img | AlphaBlend{overlay}                      // overlay is Image<BGRA>
+img | ApplyMask{mask}                          // mask is Image<Gray>
+```
+
+## Lazy Views over Collections
+
+```cpp
+#include "improc/views/views.hpp"
+namespace views = improc::views;
+
+std::vector<Image<BGR>> images = ...;
+
+// transform every image lazily
+auto resized = images
+    | views::transform(Resize{}.width(64).height(64))
+    | views::to<std::vector<Image<BGR>>>();
+
+// filter, then transform, then take first 10
+auto result = images
+    | views::filter([](const Image<BGR>& img) { return img.cols() >= 128; })
+    | views::transform(Resize{}.width(64).height(64))
+    | views::take(10)
+    | views::to<std::vector<Image<BGR>>>();
+
+// iterate lazily over a directory — images loaded on demand
+for (const auto& img : views::from_dir("dataset/", {".png", ".jpg"})) {
+    // process img — only this image is in RAM at a time
+}
+
+// batch(N) — process in fixed-size chunks
+for (const auto& chunk : views::from_dir("frames/", {".png"}) | views::batch(8)) {
+    // chunk is std::vector<Image<BGR>>, up to 8 images
+}
+
+// enumerate — zero-based index alongside each element
+for (const auto& [idx, img] : images | views::enumerate) {
+    std::cout << idx << ": " << img.cols() << "x" << img.rows() << "\n";
+}
+
+// zip — pair two sources element-wise
+for (const auto& [img, mask] : views::zip(images, masks)) {
+    Image<BGR> masked = img | ApplyMask{mask};
+}
+```
+
+## Augmentation
+
+Stochastic augmentations for training pipelines. Each op takes `(Image<F>, std::mt19937&)` directly or via `.bind(rng)` for `operator|` use.
+
+```cpp
+#include "improc/ml/augmentation.hpp"
+using namespace improc::ml;
+
+std::mt19937 rng(42);
+
+// Single op — direct call
+Image<BGR> flipped = RandomFlip{}.p(0.5f)(img, rng);
+
+// Pipeline form via .bind()
+Image<BGR> augmented = img
+    | RandomFlip{}.p(0.5f).bind(rng)
+    | RandomBrightness{}.range(0.8f, 1.2f).bind(rng)
+    | RandomRotate{}.range(-15.0f, 15.0f).bind(rng);
+
+// Full training augmentor with composition ops
+auto augmentor = Compose<BGR>{}
+    .add(RandomFlip{}.p(0.5f))
+    .add(RandomApply<BGR>{ColorJitter{}, 0.5f})
+    .add(OneOf<BGR>{}
+        .add(RandomGaussianNoise{}.std_dev(5.0f, 15.0f))
+        .add(RandomSaltAndPepper{}.p(0.02f)));
+
+// Apply once
+Image<BGR> out = augmentor(img, rng);
+
+// Or in a pipeline
+Image<BGR> out2 = img | augmentor.bind(rng);
+```
+
+All augmentation ops are constrained by C++20 concepts — passing the wrong format is a compiler error.
+
+## ML Preprocessing Pipeline
+
+A complete image-to-tensor pipeline for a classification model:
+
+```cpp
+using namespace improc::core;
+using namespace improc::io;
+
+auto src = imread<BGR>("photo.jpg");
+if (!src) return 1;
+
+// Standard ImageNet preprocessing
+Image<Float32C3> tensor = *src
+    | Resize{}.width(224).height(224)
+    | CLAHE{}.clip_limit(2.0)
+    | ToFloat32C3{}
+    | NormalizeTo{0.0f, 1.0f};
+```
+
+## Next Steps
+
+- [Real-Time Camera](real-time-camera.md) — `CameraCapture` + `ThreadPool` + `FramePipeline`
+- [NAMESPACES.md](../../NAMESPACES.md) — complete API reference for every op, error code, and return type

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,114 @@
+# Getting Started with improc++
+
+This tutorial gets you from zero to a working image processing pipeline in about 10 minutes.
+
+## Prerequisites
+
+- C++23 compiler: GCC 14+ or Clang 18+
+- CMake 3.30+
+- Conan 2: `pip install "conan>=2,<3"`
+- macOS: Xcode Command Line Tools (`xcode-select --install`)
+- Linux: `sudo apt-get install build-essential cmake libgtk-3-dev`
+
+## Install
+
+```bash
+git clone https://github.com/michalmaj/improc.git
+cd improc
+```
+
+## Configure and Build
+
+Conan is invoked automatically by CMake via `conan_provider.cmake`. Point CMake at your Conan binary:
+
+```bash
+# Detect your compiler profile (run once per machine)
+conan profile detect --force
+
+# Configure — OpenCV, GTest, and Eigen are downloaded and built by Conan
+cmake \
+  -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="conan_provider.cmake" \
+  -DCONAN_COMMAND=$(which conan) \
+  -DCMAKE_BUILD_TYPE=Release \
+  -B build .
+
+# Build everything
+cmake --build build --parallel
+```
+
+## Run the Tests
+
+```bash
+./build/improc_tests
+```
+
+All tests should pass. The six `VideoWriterTest` cases that show codec warnings are a known environment issue on some systems and do not affect the library.
+
+## Your First Pipeline
+
+Create `hello.cpp`:
+
+```cpp
+#include <iostream>
+#include "improc/core/pipeline.hpp"
+#include "improc/io/image_io.hpp"
+
+using namespace improc::core;
+using namespace improc::io;
+
+int main() {
+    // Load an image — imread returns std::expected<Image<BGR>, Error>
+    auto src = imread<BGR>("photo.jpg");
+    if (!src) {
+        std::cerr << "Could not load photo.jpg\n";
+        return 1;
+    }
+
+    // Build a pipeline: resize → blur → brighten
+    Image<BGR> result = *src
+        | Resize{}.width(224).height(224)
+        | GaussianBlur{}.kernel_size(3)
+        | Brightness{}.delta(20.0);
+
+    imwrite("output.jpg", result);
+    std::cout << "Saved " << result.cols() << "x" << result.rows() << " image\n";
+}
+```
+
+Add it to your `CMakeLists.txt`:
+
+```cmake
+add_executable(hello hello.cpp)
+target_link_libraries(hello PRIVATE improc)
+```
+
+Rebuild and run:
+
+```bash
+cmake --build build --parallel
+./build/hello
+```
+
+## What Just Happened
+
+- `imread<BGR>` loads the file and wraps the pixels in an `Image<BGR>`. The format tag is a compile-time guarantee — passing an `Image<Gray>` where `Image<BGR>` is expected is a **compiler error**, not a silent runtime bug.
+- Each `|` applies one operation eagerly and returns a new `Image<BGR>`. The source image is never modified.
+- `imwrite` encodes and saves the result; the extension determines the format.
+
+## Key Headers
+
+| Header | What it gives you |
+|---|---|
+| `improc/core/pipeline.hpp` | All core ops (`Resize`, `GaussianBlur`, …) + `operator\|` |
+| `improc/io/image_io.hpp` | `imread<F>`, `imwrite` |
+| `improc/io/camera_capture.hpp` | Threaded camera capture |
+| `improc/io/video_writer.hpp` | RAII video recording |
+| `improc/views/views.hpp` | Lazy pipeline adapters |
+| `improc/ml/augmentation.hpp` | Stochastic augmentation ops |
+| `improc/onnx/onnx.hpp` | ONNX Runtime inference |
+| `improc/visualization/visualization.hpp` | Charts, `Show`, `DrawBoundingBoxes` |
+
+## Next Steps
+
+- [Building a Pipeline](building-a-pipeline.md) — composing ops, format conversions, lazy views, augmentation
+- [Real-Time Camera](real-time-camera.md) — `CameraCapture` + `ThreadPool` + `FramePipeline`

--- a/docs/tutorials/real-time-camera.md
+++ b/docs/tutorials/real-time-camera.md
@@ -1,0 +1,190 @@
+# Real-Time Camera Processing
+
+This tutorial shows how to capture frames from a camera, process them in a thread pool, and display or record the results.
+
+## Components
+
+| Class | Responsibility |
+|---|---|
+| `CameraCapture` | Asynchronous frame capture in a background thread |
+| `ThreadPool` | Fixed-size worker pool; `submit()` returns `std::future<T>` |
+| `FramePipeline<Result>` | Ties capture + pool together; `tryPop()` returns `std::optional<Result>` |
+| `VideoWriter` | RAII video recording; pipeline-composable via `operator\|` |
+| `Show` | Passthrough display op; returns the image unchanged after showing it |
+
+## Minimal Live Preview
+
+The simplest case — capture and display on the main thread:
+
+```cpp
+#include "improc/core/pipeline.hpp"
+#include "improc/io/camera_capture.hpp"
+#include "improc/visualization/visualization.hpp"
+
+using namespace improc::core;
+using namespace improc::io;
+using namespace improc::visualization;
+
+int main() {
+    CameraCapture cam(0);   // device index 0
+
+    while (true) {
+        auto frame = cam.getFrame();  // std::expected<cv::Mat, Error>
+        if (!frame) continue;
+
+        Image<BGR> img(*frame);
+        img | Show{"Live"}.wait_ms(1);  // display, wait 1 ms
+
+        if (cv::waitKey(1) == 27) break;  // ESC to quit
+    }
+}
+```
+
+## Capture + Process + Record
+
+Process frames in the main thread and record them to a file simultaneously. `VideoWriter` is pipeline-composable — `img | Show{...} | writer` displays and records in one expression:
+
+```cpp
+#include "improc/core/pipeline.hpp"
+#include "improc/io/camera_capture.hpp"
+#include "improc/io/video_writer.hpp"
+#include "improc/visualization/visualization.hpp"
+
+using namespace improc::core;
+using namespace improc::io;
+using namespace improc::visualization;
+
+int main() {
+    CameraCapture cam(0);
+    VideoWriter writer{"output.mp4"};
+    writer.fps(30);
+
+    while (true) {
+        auto frame = cam.getFrame();
+        if (!frame) continue;
+
+        Image<BGR> img(*frame);
+
+        // Apply processing, display, and record in one pipeline
+        img
+            | GaussianBlur{}.kernel_size(3)
+            | Brightness{}.delta(10.0)
+            | Show{"Preview"}.wait_ms(1)
+            | writer;
+
+        if (cv::waitKey(1) == 27) break;
+    }
+    // VideoWriter destructor finalises the file
+}
+```
+
+## Threaded Processing with FramePipeline
+
+For computationally heavy per-frame work (inference, augmentation, multi-step pipelines), offload processing to a `ThreadPool` so the capture loop never blocks:
+
+```cpp
+#include <iostream>
+#include <optional>
+#include "improc/core/pipeline.hpp"
+#include "improc/io/camera_capture.hpp"
+#include "improc/threading/thread_pool.hpp"
+#include "improc/threading/frame_pipeline.hpp"
+#include "improc/visualization/visualization.hpp"
+
+using namespace improc::core;
+using namespace improc::io;
+using namespace improc::threading;
+using namespace improc::visualization;
+
+// The result type your pipeline produces per frame
+struct FrameResult {
+    Image<BGR> processed;
+};
+
+int main() {
+    CameraCapture cam(0);
+    ThreadPool pool(4);  // 4 worker threads
+
+    // FramePipeline holds *references* — cam and pool must outlive it
+    FramePipeline<FrameResult> pipeline(cam, pool);
+
+    pipeline.start([](const cv::Mat& raw) -> FrameResult {
+        // This lambda runs on a worker thread
+        Image<BGR> img(raw);
+        return {
+            img
+                | Resize{}.width(640).height(360)
+                | GaussianBlur{}.kernel_size(5)
+                | CLAHE{}.clip_limit(2.0)
+        };
+    });
+
+    while (true) {
+        // tryPop() is non-blocking — returns std::nullopt if no result ready
+        if (auto result = pipeline.tryPop()) {
+            result->processed | Show{"Processed"}.wait_ms(1);
+        }
+
+        if (cv::waitKey(1) == 27) break;
+    }
+
+    pipeline.stop();
+}
+```
+
+`FramePipeline` submits one task per frame to the pool. The pool processes frames concurrently; results are queued in arrival order and retrieved with `tryPop()`.
+
+## ThreadPool Directly
+
+For custom parallelism patterns, use `ThreadPool` directly:
+
+```cpp
+#include "improc/threading/thread_pool.hpp"
+using namespace improc::threading;
+
+ThreadPool pool(std::thread::hardware_concurrency());
+
+// submit() returns std::future<T>
+auto future = pool.submit([]() -> int {
+    // ... some work ...
+    return 42;
+});
+
+int result = future.get();  // blocks until done
+
+// submit_detached() — fire and forget
+pool.submit_detached([]() {
+    // ... background work, no result needed ...
+});
+
+// ThreadPool destructor drains the queue and joins all workers
+```
+
+## VideoWriter Standalone
+
+```cpp
+#include "improc/io/video_writer.hpp"
+using improc::io::VideoWriter;
+
+// Auto-detects codec from extension: .mp4 → mp4v, .avi → MJPG, .mkv → XVID
+VideoWriter writer{"output.mp4"};
+writer.fps(30);
+
+for (const auto& frame : frames) {
+    writer(frame);  // write a frame directly
+}
+
+writer.close();  // or let the destructor handle it
+```
+
+## Tips
+
+- `CameraCapture` is non-copyable — pass by reference or store in a unique location.
+- `FramePipeline` holds references to `CameraCapture` and `ThreadPool`, not ownership. Both must stay alive for the lifetime of the pipeline.
+- `tryPop()` never blocks — poll it in your display loop and skip frames if the pool is behind.
+- If processing is faster than capture, the pool workers will idle; if slower, the result queue grows. Tune the pool size and pipeline complexity for your target frame rate.
+
+## Next Steps
+
+- [NAMESPACES.md](../../NAMESPACES.md) — complete API reference for every class, method, and error code
+- [Building a Pipeline](building-a-pipeline.md) — core ops, format conversions, lazy views, augmentation

--- a/include/improc/core/convert.hpp
+++ b/include/improc/core/convert.hpp
@@ -14,7 +14,6 @@ namespace improc::core {
  *
  * @tparam To    Target format tag.
  * @tparam From  Source format tag.
- * @param  src   Source image.
  * @return       New `Image<To>` containing the converted data.
  *
  * @code

--- a/include/improc/ml/dnn_detector.hpp
+++ b/include/improc/ml/dnn_detector.hpp
@@ -18,7 +18,7 @@ using improc::core::BGR;
 /**
  * @brief OpenCV DNN-backed object detector with NMS post-processing.
  *
- * Supports two output formats selectable via @ref Style: YOLO-style single-blob
+ * Supports two output formats selectable via `Style`: YOLO-style single-blob
  * output and SSD-style dual-blob (boxes + scores) output. Bounding boxes are
  * rescaled to the original image dimensions and filtered through NMS before
  * being returned as `Detection` values.

--- a/include/improc/onnx/onnx_detector.hpp
+++ b/include/improc/onnx/onnx_detector.hpp
@@ -23,7 +23,7 @@ using improc::ml::Detection;
  * resize → float conversion → mean subtraction → optional channel swap →
  * HWC→CHW → inference → format-specific parsing → NMS → coordinate rescaling.
  *
- * Two output formats are supported via @ref Style:
+ * Two output formats are supported via `Style`:
  * - **YOLO**: single blob `[1, 4+C, N]` — `cx,cy,w,h` + per-class scores.
  * - **SSD**: two blobs — boxes `[1, N, 4]` (y1,x1,y2,x2 normalised) and
  *   scores `[1, N, C]`.


### PR DESCRIPTION
- docs/tutorials/getting-started.md: install, build, first pipeline
- docs/tutorials/building-a-pipeline.md: all ops, format conversions, lazy views, augmentation, ML preprocessing
- docs/tutorials/real-time-camera.md: CameraCapture, ThreadPool, FramePipeline, VideoWriter
- Doxyfile: configured for include/ input, HTML output, zero warnings
- Fix 3 doxygen warnings: stray @param in convert.hpp primary template, unresolvable @ref Style: in dnn_detector.hpp and onnx_detector.hpp
- .gitignore: exclude docs/doxygen/ generated output