### PR TITLE
fix(threading): replace fixed 100ms sleep with condition-based wait i…

### DIFF
--- a/tests/threading/test_thread_pool.cpp
+++ b/tests/threading/test_thread_pool.cpp
@@ -28,7 +28,11 @@ TEST(ThreadPoolTest, SubmitDetachedDoesNotBlock) {
         ran = true;
     });
     EXPECT_FALSE(ran.load());
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Poll instead of a fixed sleep: completes in ~30ms on fast machines,
+    // but gives 5 s of budget on loaded CI schedulers.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!ran.load() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     EXPECT_TRUE(ran.load());
 }
 


### PR DESCRIPTION
…n SubmitDetachedDoesNotBlock

macOS CI runners can have >80ms thread scheduling latency, exhausting the 100ms budget before the 20ms task completes. Poll every 10ms with a 5s deadline so the test is robust on loaded VMs without slowing fast machines.