### PR TITLE
fix(ml/tracking): fix Hungarian OOB crash when rows > cols (n > m)

### DIFF
--- a/src/ml/byte_tracker.cpp
+++ b/src/ml/byte_tracker.cpp
@@ -45,7 +45,12 @@ std::vector<int> hungarian(const std::vector<std::vector<float>>& cost) {
     if (m == 0) return std::vector<int>(n, -1);
     int sz = std::max(n, m);
     const float kInf = 1e9f;
-    std::vector<std::vector<float>> C(sz, std::vector<float>(sz, kInf));
+    float kPad = 0.0f;
+    for (int i = 0; i < n; ++i)
+        for (int j = 0; j < m; ++j)
+            kPad = std::max(kPad, cost[i][j]);
+    kPad += 1.0f;
+    std::vector<std::vector<float>> C(sz, std::vector<float>(sz, kPad));
     for (int i = 0; i < n; ++i)
         for (int j = 0; j < m; ++j)
             C[i][j] = cost[i][j];

--- a/src/ml/sort_tracker.cpp
+++ b/src/ml/sort_tracker.cpp
@@ -51,7 +51,12 @@ std::vector<int> hungarian(const std::vector<std::vector<float>>& cost) {
 
     int sz = std::max(n, m);
     const float kInf = 1e9f;
-    std::vector<std::vector<float>> C(sz, std::vector<float>(sz, kInf));
+    float kPad = 0.0f;
+    for (int i = 0; i < n; ++i)
+        for (int j = 0; j < m; ++j)
+            kPad = std::max(kPad, cost[i][j]);
+    kPad += 1.0f;
+    std::vector<std::vector<float>> C(sz, std::vector<float>(sz, kPad));
     for (int i = 0; i < n; ++i)
         for (int j = 0; j < m; ++j)
             C[i][j] = cost[i][j];

--- a/src/ml/tracking_eval.cpp
+++ b/src/ml/tracking_eval.cpp
@@ -27,7 +27,15 @@ std::vector<int> hungarian(const std::vector<std::vector<float>>& cost) {
     if (m == 0) return std::vector<int>(n, -1);
     int sz = std::max(n, m);
     const float kInf = 1e9f;
-    std::vector<std::vector<float>> C(sz, std::vector<float>(sz, kInf));
+    // Padding cells must be finite (> all real costs, < kInf).
+    // kInf padding breaks augmentation when n > m: cur=kInf=minv[j], both
+    // strict-less checks fail, j1 stays -1, then p[-1] → OOB crash on Linux.
+    float kPad = 0.0f;
+    for (int i = 0; i < n; ++i)
+        for (int j = 0; j < m; ++j)
+            kPad = std::max(kPad, cost[i][j]);
+    kPad += 1.0f;
+    std::vector<std::vector<float>> C(sz, std::vector<float>(sz, kPad));
     for (int i = 0; i < n; ++i)
         for (int j = 0; j < m; ++j)
             C[i][j] = cost[i][j];


### PR DESCRIPTION
When the cost matrix has more rows than columns (e.g. 2 tracks, 1 GT), the padded dummy cells had cost kInf.  During augmentation the inner loop computes cur = kInf for a dummy column and compares against minv[j] = kInf; since kInf < kInf is false, j1 stays -1, then j0 = -1, and p[-1] is an OOB access → SIGABRT on Linux.

Fix: compute kPad = max(real costs) + 1 and use that for padding. kPad is finite and strictly greater than all real costs, so augmenting paths can traverse dummy columns, while the minimiser still assigns real rows to real columns first.  Applied to all three copies of the algorithm (tracking_eval, sort_tracker, byte_tracker).