### PR TITLE
fix(ml/tracking): add parameter validation and edge-case tests

### DIFF
--- a/include/improc/ml/tracking/byte_tracker.hpp
+++ b/include/improc/ml/tracking/byte_tracker.hpp
@@ -1,15 +1,32 @@
 // include/improc/ml/tracking/byte_tracker.hpp
 #pragma once
 #include "improc/ml/tracking/track.hpp"
+#include "improc/exceptions.hpp"
 #include <memory>
 
 namespace improc::ml {
 
 struct ByteTracker {
-    ByteTracker& max_age(int frames)          { max_age_  = frames; return *this; }
-    ByteTracker& min_hits(int hits)           { min_hits_ = hits;   return *this; }
-    ByteTracker& high_conf_threshold(float t) { high_thr_ = t;      return *this; }
-    ByteTracker& low_conf_threshold(float t)  { low_thr_  = t;      return *this; }
+    ByteTracker& max_age(int frames) {
+        if (frames < 0)
+            throw improc::ParameterError("max_age", "must be >= 0", "ByteTracker");
+        max_age_ = frames; return *this;
+    }
+    ByteTracker& min_hits(int hits) {
+        if (hits < 1)
+            throw improc::ParameterError("min_hits", "must be >= 1", "ByteTracker");
+        min_hits_ = hits; return *this;
+    }
+    ByteTracker& high_conf_threshold(float t) {
+        if (t < 0.f || t > 1.f)
+            throw improc::ParameterError("high_conf_threshold", "must be in [0, 1]", "ByteTracker");
+        high_thr_ = t; return *this;
+    }
+    ByteTracker& low_conf_threshold(float t) {
+        if (t < 0.f || t > 1.f)
+            throw improc::ParameterError("low_conf_threshold", "must be in [0, 1]", "ByteTracker");
+        low_thr_ = t; return *this;
+    }
 
     [[nodiscard]] std::vector<Track> update(const std::vector<Detection>& dets);
     void reset();

--- a/include/improc/ml/tracking/iou_tracker.hpp
+++ b/include/improc/ml/tracking/iou_tracker.hpp
@@ -1,12 +1,21 @@
 // include/improc/ml/tracking/iou_tracker.hpp
 #pragma once
 #include "improc/ml/tracking/track.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
 struct IouTracker {
-    IouTracker& min_iou(float t)    { min_iou_ = t; return *this; }
-    IouTracker& max_age(int frames) { max_age_ = frames; return *this; }
+    IouTracker& min_iou(float t) {
+        if (t < 0.f || t > 1.f)
+            throw improc::ParameterError("min_iou", "must be in [0, 1]", "IouTracker");
+        min_iou_ = t; return *this;
+    }
+    IouTracker& max_age(int frames) {
+        if (frames < 0)
+            throw improc::ParameterError("max_age", "must be >= 0", "IouTracker");
+        max_age_ = frames; return *this;
+    }
 
     [[nodiscard]] std::vector<Track> update(const std::vector<Detection>& dets);
     void reset();

--- a/include/improc/ml/tracking/sort_tracker.hpp
+++ b/include/improc/ml/tracking/sort_tracker.hpp
@@ -1,14 +1,27 @@
 // include/improc/ml/tracking/sort_tracker.hpp
 #pragma once
 #include "improc/ml/tracking/track.hpp"
+#include "improc/exceptions.hpp"
 #include <memory>
 
 namespace improc::ml {
 
 struct SortTracker {
-    SortTracker& max_age(int frames)    { max_age_  = frames; return *this; }
-    SortTracker& min_hits(int hits)     { min_hits_ = hits;   return *this; }
-    SortTracker& iou_threshold(float t) { iou_thr_  = t;      return *this; }
+    SortTracker& max_age(int frames) {
+        if (frames < 0)
+            throw improc::ParameterError("max_age", "must be >= 0", "SortTracker");
+        max_age_ = frames; return *this;
+    }
+    SortTracker& min_hits(int hits) {
+        if (hits < 1)
+            throw improc::ParameterError("min_hits", "must be >= 1", "SortTracker");
+        min_hits_ = hits; return *this;
+    }
+    SortTracker& iou_threshold(float t) {
+        if (t < 0.f || t > 1.f)
+            throw improc::ParameterError("iou_threshold", "must be in [0, 1]", "SortTracker");
+        iou_thr_ = t; return *this;
+    }
 
     SortTracker();
     ~SortTracker();

--- a/include/improc/ml/tracking/tracking_eval.hpp
+++ b/include/improc/ml/tracking/tracking_eval.hpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 #include "improc/ml/tracking/track.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::ml {
 
@@ -17,7 +18,11 @@ struct TrackingMetrics {
 };
 
 struct TrackingEval {
-    TrackingEval& iou_threshold(float t) { iou_thr_ = t; return *this; }
+    TrackingEval& iou_threshold(float t) {
+        if (t < 0.f || t > 1.f)
+            throw improc::ParameterError("iou_threshold", "must be in [0, 1]", "TrackingEval");
+        iou_thr_ = t; return *this;
+    }
 
     void update(const std::vector<Track>&   tracks,
                 const std::vector<TrackGT>& gts);

--- a/src/ml/byte_tracker.cpp
+++ b/src/ml/byte_tracker.cpp
@@ -163,6 +163,10 @@ ByteTracker::~ByteTracker() = default;
 // ── ByteTracker::update ────────────────────────────────────────────────────────
 
 std::vector<Track> ByteTracker::update(const std::vector<Detection>& dets) {
+    if (low_thr_ >= high_thr_)
+        throw improc::ParameterError("low_conf_threshold",
+            "must be strictly less than high_conf_threshold", "ByteTracker");
+
     // 1. Predict all existing tracklets
     for (auto& t : tracklets_) t->predict();
 

--- a/tests/ml/test_byte_tracker.cpp
+++ b/tests/ml/test_byte_tracker.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include "improc/ml/tracking/byte_tracker.hpp"
 #include "improc/ml/tracking/sort_tracker.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::ml;
 
@@ -78,4 +79,31 @@ TEST(ByteTrackerTest, ResetClearsState) {
     auto r = tracker.update({make_det(0, 0, 10, 10, 0.9f)});
     ASSERT_FALSE(r.empty());
     for (const auto& t : r) EXPECT_EQ(t.id, 0);
+}
+
+TEST(ByteTrackerTest, ThrowsOnInvalidSetterRange) {
+    ByteTracker t;
+    EXPECT_THROW(t.max_age(-1),                improc::ParameterError);
+    EXPECT_THROW(t.min_hits(0),                improc::ParameterError);
+    EXPECT_THROW(t.high_conf_threshold(-0.1f), improc::ParameterError);
+    EXPECT_THROW(t.high_conf_threshold(1.1f),  improc::ParameterError);
+    EXPECT_THROW(t.low_conf_threshold(-0.1f),  improc::ParameterError);
+    EXPECT_THROW(t.low_conf_threshold(1.1f),   improc::ParameterError);
+    EXPECT_NO_THROW(t.max_age(0));
+    EXPECT_NO_THROW(t.min_hits(1));
+    EXPECT_NO_THROW(t.high_conf_threshold(1.0f));
+    EXPECT_NO_THROW(t.low_conf_threshold(0.0f));
+}
+
+TEST(ByteTrackerTest, ThrowsWhenLowThreshNotLessThanHigh) {
+    // Cross-invariant checked at update() time to avoid order-dependency in setters
+    ByteTracker t;
+    t.high_conf_threshold(0.4f);
+    t.low_conf_threshold(0.4f);  // equal — not strictly less
+    EXPECT_THROW(t.update({}), improc::ParameterError);
+}
+
+TEST(ByteTrackerTest, EmptyDetectionsOnFreshTrackerReturnsEmpty) {
+    ByteTracker tracker;
+    EXPECT_TRUE(tracker.update({}).empty());
 }

--- a/tests/ml/test_iou_tracker.cpp
+++ b/tests/ml/test_iou_tracker.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include "improc/ml/tracking/track.hpp"
 #include "improc/ml/tracking/iou_tracker.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::ml;
 
@@ -70,4 +71,23 @@ TEST(IouTrackerTest, ResetClearsState) {
     auto r = tracker.update({make_det(0, 0, 10, 10)});
     ASSERT_EQ(r.size(), 1u);
     EXPECT_EQ(r[0].id, 0);  // ID counter reset to 0
+}
+
+TEST(IouTrackerTest, ThrowsOnInvalidMinIou) {
+    IouTracker t;
+    EXPECT_THROW(t.min_iou(-0.1f), improc::ParameterError);
+    EXPECT_THROW(t.min_iou(1.1f),  improc::ParameterError);
+    EXPECT_NO_THROW(t.min_iou(0.0f));
+    EXPECT_NO_THROW(t.min_iou(1.0f));
+}
+
+TEST(IouTrackerTest, ThrowsOnNegativeMaxAge) {
+    IouTracker t;
+    EXPECT_THROW(t.max_age(-1), improc::ParameterError);
+    EXPECT_NO_THROW(t.max_age(0));
+}
+
+TEST(IouTrackerTest, EmptyDetectionsOnFreshTrackerReturnsEmpty) {
+    IouTracker tracker;
+    EXPECT_TRUE(tracker.update({}).empty());
 }

--- a/tests/ml/test_sort_tracker.cpp
+++ b/tests/ml/test_sort_tracker.cpp
@@ -1,6 +1,7 @@
 // tests/ml/test_sort_tracker.cpp
 #include <gtest/gtest.h>
 #include "improc/ml/tracking/sort_tracker.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::ml;
 
@@ -99,4 +100,21 @@ TEST(SortTrackerTest, ResetClearsState) {
     tracker.reset();
     auto r = tracker.update({make_det(0, 0, 10, 10)});
     for (const auto& t : r) EXPECT_EQ(t.id, 0);
+}
+
+TEST(SortTrackerTest, ThrowsOnInvalidParameters) {
+    SortTracker t;
+    EXPECT_THROW(t.max_age(-1),           improc::ParameterError);
+    EXPECT_THROW(t.min_hits(0),           improc::ParameterError);
+    EXPECT_THROW(t.iou_threshold(-0.1f),  improc::ParameterError);
+    EXPECT_THROW(t.iou_threshold(1.1f),   improc::ParameterError);
+    EXPECT_NO_THROW(t.max_age(0));
+    EXPECT_NO_THROW(t.min_hits(1));
+    EXPECT_NO_THROW(t.iou_threshold(0.0f));
+    EXPECT_NO_THROW(t.iou_threshold(1.0f));
+}
+
+TEST(SortTrackerTest, EmptyDetectionsOnFreshTrackerReturnsEmpty) {
+    SortTracker tracker;
+    EXPECT_TRUE(tracker.update({}).empty());
 }

--- a/tests/ml/test_tracking_eval.cpp
+++ b/tests/ml/test_tracking_eval.cpp
@@ -1,6 +1,7 @@
 // tests/ml/test_tracking_eval.cpp
 #include <gtest/gtest.h>
 #include "improc/ml/tracking/tracking_eval.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::ml;
 
@@ -81,5 +82,33 @@ TEST(TrackingEvalTest, ResetClearsState) {
     EXPECT_FLOAT_EQ(m.IDF1, 0.0f);
     EXPECT_EQ(m.FP,   0);
     EXPECT_EQ(m.FN,   0);
+    EXPECT_EQ(m.IDSW, 0);
+}
+
+TEST(TrackingEvalTest, ThrowsOnInvalidIouThreshold) {
+    TrackingEval eval;
+    EXPECT_THROW(eval.iou_threshold(-0.1f), improc::ParameterError);
+    EXPECT_THROW(eval.iou_threshold(1.1f),  improc::ParameterError);
+    EXPECT_NO_THROW(eval.iou_threshold(0.0f));
+    EXPECT_NO_THROW(eval.iou_threshold(1.0f));
+}
+
+TEST(TrackingEvalTest, HungarianHandlesMoreTracksThanGTs) {
+    // nt=3, ng=1: exercises the n>m augmenting-path fix (kPad instead of kInf)
+    TrackingEval eval;
+    eval.update({make_track(0, 0,0,10,10)}, {make_gt(0, 0,0,10,10)});
+    eval.update({make_track(1, 0,0,10,10)}, {make_gt(0, 0,0,10,10)});
+    eval.update({make_track(2, 0,0,10,10)}, {make_gt(0, 0,0,10,10)});
+    auto m = eval.compute();  // must not crash
+    EXPECT_EQ(m.IDSW, 2);
+    EXPECT_LT(m.IDF1, 1.0f);
+}
+
+TEST(TrackingEvalTest, EmptyTracksCountsFalseNegative) {
+    TrackingEval eval;
+    eval.update({}, {make_gt(0, 0,0,10,10)});
+    auto m = eval.compute();
+    EXPECT_EQ(m.FN, 1);
+    EXPECT_EQ(m.FP, 0);
     EXPECT_EQ(m.IDSW, 0);
 }


### PR DESCRIPTION
- All tracker setters now throw ParameterError on invalid input (min_iou/iou_threshold outside [0,1], max_age < 0, min_hits < 1, conf thresholds outside [0,1])
- ByteTracker::update() throws when low_conf_threshold >= high_conf_threshold (cross-invariant checked at call time to avoid setter order-dependency)
- 11 new tests: throw cases for all 4 trackers/eval, empty-detection on fresh tracker, and HungarianHandlesMoreTracksThanGTs which explicitly documents the n>m OOB fix (35 tests total, up from 24)