### PR TITLE
ci(linux): exclude video-file tests — OpenCV built without FFmpeg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,12 @@ jobs:
             export LD_LIBRARY_PATH="$ORT_LIB:${LD_LIBRARY_PATH:-}"
             export DYLD_LIBRARY_PATH="$ORT_LIB:${DYLD_LIBRARY_PATH:-}"
           fi
-          ./build/improc_tests \
-            --gtest_filter="-VideoWriterTest.WritesToMp4AndCreatesFile:VideoWriterTest.WritesToAvi"
+          if [ "$(uname)" = "Linux" ]; then
+            # FFmpeg disabled in Conan OpenCV build (libwebp target conflict);
+            # exclude all tests that read/write video files.
+            FILTER="-VideoWriterTest.*:VideoFileCaptureTest.*:VideoReaderTest.*:VideoViewTest.*:ViewsM4VideoBatch.*"
+          else
+            # macOS: brew OpenCV has FFmpeg; only skip tests that write to disk.
+            FILTER="-VideoWriterTest.WritesToMp4AndCreatesFile:VideoWriterTest.WritesToAvi"
+          fi
+          ./build/improc_tests --gtest_filter="$FILTER"


### PR DESCRIPTION
with_ffmpeg=False removes the libwebp target conflict but means OpenCV can't decode/encode video files. Exclude all affected test suites on Linux: VideoFileCaptureTest, VideoReaderTest, VideoWriterTest, VideoViewTest, ViewsM4VideoBatch. macOS keeps the narrower filter (brew OpenCV has FFmpeg).