### PR TITLE
docs(core): update pipeline.hpp @brief list — add v0.10.0 ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,9 @@ target_link_libraries(demo_pose PRIVATE improc)
 add_executable(demo_stereo examples/calib/demo_stereo.cpp)
 target_link_libraries(demo_stereo PRIVATE improc)
 
+add_executable(demo_aruco examples/calib/demo_aruco.cpp)
+target_link_libraries(demo_aruco PRIVATE improc)
+
 # ONNX inference demo
 if(IMPROC_WITH_ONNX)
     add_executable(demo_onnx_inference examples/ml/demo_onnx_inference.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,9 @@ target_link_libraries(demo_calibrate PRIVATE improc)
 add_executable(demo_pose examples/calib/demo_pose.cpp)
 target_link_libraries(demo_pose PRIVATE improc)
 
+add_executable(demo_stereo examples/calib/demo_stereo.cpp)
+target_link_libraries(demo_stereo PRIVATE improc)
+
 # ONNX inference demo
 if(IMPROC_WITH_ONNX)
     add_executable(demo_onnx_inference examples/ml/demo_onnx_inference.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,9 @@ target_link_libraries(demo_views_m4 PRIVATE improc)
 add_executable(demo_calibrate examples/calib/demo_calibrate.cpp)
 target_link_libraries(demo_calibrate PRIVATE improc)
 
+add_executable(demo_pose examples/calib/demo_pose.cpp)
+target_link_libraries(demo_pose PRIVATE improc)
+
 # ONNX inference demo
 if(IMPROC_WITH_ONNX)
     add_executable(demo_onnx_inference examples/ml/demo_onnx_inference.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,10 @@ target_link_libraries(demo_views_m3 PRIVATE improc)
 add_executable(demo_views_m4 examples/views/demo_views_m4.cpp)
 target_link_libraries(demo_views_m4 PRIVATE improc)
 
+# Calibration demos
+add_executable(demo_calibrate examples/calib/demo_calibrate.cpp)
+target_link_libraries(demo_calibrate PRIVATE improc)
+
 # ONNX inference demo
 if(IMPROC_WITH_ONNX)
     add_executable(demo_onnx_inference examples/ml/demo_onnx_inference.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,14 @@ target_link_libraries(demo_morph_extras PRIVATE improc)
 add_executable(demo_harris_laplacian examples/core/demo_harris_laplacian.cpp)
 target_link_libraries(demo_harris_laplacian PRIVATE improc)
 
+# Optical flow demo (SparseLKFlow, DenseFarnebackFlow, DenseDISFlow)
+add_executable(demo_optical_flow examples/core/demo_optical_flow.cpp)
+target_link_libraries(demo_optical_flow PRIVATE improc)
+
+# CamShift / MeanShift / PhaseCorrelate demo
+add_executable(demo_camshift examples/core/demo_camshift.cpp)
+target_link_libraries(demo_camshift PRIVATE improc)
+
 # Threading demos
 add_executable(demo_thread_pool examples/threading/demo_thread_pool.cpp)
 target_link_libraries(demo_thread_pool PRIVATE improc)

--- a/docs/tutorials/aruco-markers.md
+++ b/docs/tutorials/aruco-markers.md
@@ -1,0 +1,195 @@
+# ArUco Markers
+
+This tutorial explains how to generate, detect, and estimate the pose of ArUco and ChArUco markers with improc++. ArUco markers are square binary patterns that can be identified and localised in a single camera image without any additional reference object. They are widely used in robotics, augmented reality, and camera calibration.
+
+All operations are in `#include "improc/calib/pipeline.hpp"`.
+
+## Prerequisites
+
+- Completed [Camera Calibration](camera-calibration.md)
+- `improc/calib/pipeline.hpp`
+
+## What Are ArUco Markers?
+
+An ArUco marker is a square image with a black border and a binary grid inside. Each pattern in a **dictionary** has a unique ID. Because the four corners of a square marker are always visible and geometrically well-defined, a single marker gives you all the information needed to estimate a camera's pose relative to the marker — as long as you know the physical side length and camera intrinsics.
+
+**ChArUco boards** combine an ArUco dictionary with a standard chessboard: ArUco markers are embedded inside chessboard squares. This gives you the best of both worlds — the reliable ID detection of ArUco and the sub-pixel corner accuracy of chessboard corners. ChArUco boards are the recommended target for high-precision camera calibration.
+
+Common use cases:
+- Robot arm end-effector tracking
+- Augmented reality object placement
+- Camera-to-world extrinsic calibration
+- Stereo rig hand-eye calibration
+
+## Dictionaries
+
+A dictionary defines the set of valid marker patterns. Use `ArucoDict` to obtain one:
+
+```cpp
+#include "improc/calib/pipeline.hpp"
+using namespace improc::calib;
+
+// ArucoDict: returns a cv::aruco::Dictionary for the requested predefined type
+cv::aruco::Dictionary dict = ArucoDict{}(cv::aruco::DICT_4X4_50);
+// DICT_4X4_50: 50 unique markers on a 4×4 bit grid — small, fast, low capacity
+```
+
+Commonly used dictionary types:
+
+| Dictionary | Grid | Markers | Notes |
+|---|---|---|---|
+| `DICT_4X4_50` | 4×4 | 50 | Fast detection, small set |
+| `DICT_4X4_250` | 4×4 | 250 | Larger set, same grid |
+| `DICT_5X5_100` | 5×5 | 100 | More robust to printing errors |
+| `DICT_6X6_250` | 6×6 | 250 | Good balance of size and robustness |
+| `DICT_ARUCO_ORIGINAL` | 5×5 | 1024 | Original ArUco library dictionary |
+
+Choose the smallest dictionary that covers your ID range — smaller grids are detected more reliably at a distance.
+
+## Generating Markers
+
+`GenerateAruco` renders a single marker as a `Image<Gray>`:
+
+```cpp
+// GenerateAruco: renders marker ID from the dictionary as a square grayscale image
+Image<Gray> marker = GenerateAruco{}
+    .border_bits(1)    // white border width in bit-cell units (default: 1)
+    (dict, 7, 200);    // dict, marker ID, output side in pixels
+// Returns Image<Gray>: 200×200 px square including the white border
+```
+
+The `border_bits` parameter controls the quiet zone — a white border surrounding the pattern that aids detection. One bit cell at standard resolution is usually sufficient. For small printed markers, increase to 2 for more reliable detection.
+
+To save a marker for printing:
+
+```cpp
+// cv::imwrite works directly with .mat()
+cv::imwrite("marker_id7.png", marker.mat());
+
+// Or display it
+cv::imshow("Marker ID 7", marker.mat());
+cv::waitKey(0);
+```
+
+Print at a known physical size. If you print a 200 px image at 200 dpi, each cell is 1 mm. Record the physical side length — you will need it for pose estimation.
+
+## Detecting Markers
+
+`DetectAruco` finds all markers from the dictionary in a BGR scene image:
+
+```cpp
+Image<BGR> scene = ...;
+
+// DetectAruco: searches the whole image for markers from the given dictionary
+ArucoResult res = DetectAruco{}(scene, dict);
+
+std::cout << "Found " << res.ids.size() << " marker(s)\n";
+for (std::size_t i = 0; i < res.ids.size(); ++i)
+    std::cout << "  ID " << res.ids[i] << "\n";
+```
+
+`ArucoResult` fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ids` | `vector<int>` | ID of each detected marker |
+| `corners` | `vector<vector<cv::Point2f>>` | Four corner points per marker (clockwise from top-left) |
+| `rejected` | `vector<vector<cv::Point2f>>` | Candidate regions that failed ID decoding |
+
+Corner order is always: top-left, top-right, bottom-right, bottom-left. This convention lets you determine marker orientation unambiguously.
+
+### Drawing Detected Markers
+
+`DrawAruco` has two overloads. The first draws corner outlines and IDs:
+
+```cpp
+// DrawAruco overload 1: draw corner outlines and ID text on a BGR image
+cv::Mat annotated = DrawAruco{}(scene.mat().clone(), res);
+// Pass .clone() to avoid modifying the original image
+cv::imshow("Detected markers", annotated);
+```
+
+This is useful for verifying detection during development — you can see which markers were found and whether their corners are accurate.
+
+## Marker Pose Estimation
+
+With a calibrated camera, you can recover the 3-D pose of each detected marker relative to the camera:
+
+```cpp
+// Load or use calibration results from CalibrateCamera
+cv::Mat K    = cal.camera_matrix;
+cv::Mat dist = cal.dist_coeffs;
+
+float marker_length = 0.05f;   // physical side length in metres (must match your print)
+
+// ArucoPose: estimates 6-DOF pose for each detected marker
+std::vector<ArucoPoseResult> poses = ArucoPose{}(res, K, dist, marker_length);
+```
+
+`ArucoPoseResult` fields per marker:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `int` | Marker ID |
+| `rvec` | `cv::Mat` (3×1) | Rotation vector (Rodrigues) — axis × angle |
+| `tvec` | `cv::Mat` (3×1) | Translation vector in metres (camera frame) |
+
+`tvec` gives the position of the marker origin (its centre) in the camera coordinate system. The Z component is the distance along the optical axis.
+
+Convert a rotation vector to a rotation matrix when needed:
+
+```cpp
+cv::Mat R;
+cv::Rodrigues(poses[0].rvec, R);   // 3×3 rotation matrix
+```
+
+Draw 3-D coordinate axes on each marker to visualise pose:
+
+```cpp
+// DrawAruco overload 2: add 3-D axis frames per detected marker
+cv::Mat with_axes = DrawAruco{}
+    .axis_length(0.03f)    // axis length in world units (default: 0.05)
+    (scene.mat().clone(), res, poses, K, dist);
+// Draws X (red), Y (green), Z (blue) axes originating from each marker centre
+cv::imshow("Marker poses", with_axes);
+```
+
+The axes confirm orientation: Z points out of the marker face toward the camera; X and Y follow the marker plane.
+
+## ChArUco Boards
+
+A ChArUco board provides more accurate calibration than either a plain chessboard or individual ArUco markers alone. The chessboard sub-pixel corner accuracy makes it suitable for high-quality single-camera and stereo calibration; the ArUco markers handle partial occlusion gracefully (a plain chessboard fails if any square is covered).
+
+```cpp
+Image<BGR> scene = ...;
+
+// CharucoBoard: detects both ArUco markers and chessboard corners in the scene
+CharucoResult cr = CharucoBoard{}
+    .board_size({5, 7})       // chessboard inner corners (cols, rows)
+    .square_length(0.04f)     // chessboard square side in metres
+    .marker_length(0.02f)     // ArUco marker side in metres (must be ≤ square_length)
+    (scene, dict);
+```
+
+`CharucoResult` fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `charuco_corners` | `vector<cv::Point2f>` | Sub-pixel chessboard corner positions |
+| `charuco_ids` | `vector<int>` | ID of each detected chessboard corner |
+| `marker_corners` | `vector<vector<cv::Point2f>>` | Corner points of each ArUco marker |
+| `marker_ids` | `vector<int>` | ID of each detected ArUco marker |
+
+`charuco_corners` and `charuco_ids` are what you pass to a calibration solver. Unlike plain chessboard detection, partial visibility is fine — corners that are visible alongside their neighbouring ArUco markers are still usable. This makes ChArUco calibration practical with handheld boards where the edges are sometimes cropped.
+
+Collect ChArUco frames for calibration the same way as with a plain chessboard — capture at multiple angles, distances, and positions across the frame, then pass the accumulated `charuco_corners` as image points and the matching 3-D object points to `CalibrateCamera`.
+
+## Complete Example
+
+See `examples/calib/demo_aruco.cpp` for a self-contained demo that generates a marker, embeds it in a synthetic scene, runs detection, and visualises both corner outlines and 3-D pose axes.
+
+## Next Steps
+
+- [Camera Calibration](camera-calibration.md) — single-camera intrinsic calibration with chessboards
+- [Stereo Vision](stereo-vision.md) — two-camera depth estimation
+- [Feature Detection](feature-detection.md) — alternative keypoint-based localisation

--- a/docs/tutorials/camera-calibration.md
+++ b/docs/tutorials/camera-calibration.md
@@ -1,0 +1,207 @@
+# Camera Calibration
+
+This tutorial covers how to calibrate a camera with improc++: detecting chessboard corners, collecting calibration data across multiple images, running the calibration solver, and undistorting frames. The whole workflow is driven by the `#include "improc/calib/pipeline.hpp"` umbrella header.
+
+Real cameras deviate from the ideal pinhole model. The lens introduces radial and tangential distortion — straight lines appear curved, and the apparent image centre does not match the principal point. Calibration estimates the **camera matrix** K (focal lengths and principal point) and the **distortion coefficients** that describe these deviations. Once you have those, you can remove distortion from every subsequent frame, project 3-D points accurately onto the image plane, or recover metric depth.
+
+## Prerequisites
+
+- Completed [Building a Pipeline](building-a-pipeline.md)
+- `improc/calib/pipeline.hpp` (includes `improc/core/pipeline.hpp` transitively)
+
+## Detecting Chessboard Corners
+
+A printed chessboard is the standard calibration target because its inner corner positions can be detected precisely and their ground-truth 3-D coordinates are known (they lie on a flat Z = 0 plane).
+
+```cpp
+#include "improc/calib/pipeline.hpp"
+using namespace improc::calib;
+using namespace improc::core;
+
+Image<BGR> img = ...;   // load or capture a calibration frame
+
+// FindChessboardCorners: classic Harris-corner detector, BGR auto-converted to Gray internally
+FindChessboardResult r = img | FindChessboardCorners{}.board_size({9, 6});
+// board_size = inner corners (cols, rows) — a 10×7 square board has 9×6 inner corners
+
+if (r.found) {
+    // r.corners: vector<cv::Point2f> — pixel coordinates of each inner corner
+    std::cout << "Found " << r.corners.size() << " corners\n";
+}
+```
+
+`FindChessboardCornersSB` is the newer, recommended alternative. It uses a different algorithm that provides built-in sub-pixel accuracy and is more robust to uneven lighting:
+
+```cpp
+// FindChessboardCornersSB: newer method with sub-pixel accuracy built in
+FindChessboardResult r = img | FindChessboardCornersSB{}.board_size({9, 6});
+// Prefer this over FindChessboardCorners for new code
+```
+
+When using the classic `FindChessboardCorners`, you can improve corner accuracy with an explicit sub-pixel refinement pass:
+
+```cpp
+// RefineCorners: sub-pixel refinement for corners found by FindChessboardCorners
+// (not needed after FindChessboardCornersSB, which refines internally)
+auto refined = RefineCorners{}
+    .win_size(11)    // half-size of the search window in pixels (default: 11)
+    .max_iter(30)    // maximum number of solver iterations (default: 30)
+    .epsilon(0.001)  // convergence threshold (default: 0.001)
+    (gray, r.corners);  // takes a Gray image and the initial corner list
+// refined: vector<cv::Point2f> with sub-pixel positions
+```
+
+`win_size` controls the neighbourhood searched around each corner. Smaller values are more precise on dense patterns; larger values are more forgiving on blurry images.
+
+## Collecting Calibration Data
+
+Calibration requires the same physical corners to be observed from multiple viewpoints. The more views you collect — and the more you vary tilt, rotation, and distance — the better constrained the problem becomes. Aim for at least 10–15 views in a real workflow.
+
+For each successful view you need a matching pair: the 3-D object points (the same every frame) and the 2-D image points (different every frame).
+
+`make_chessboard_points` generates the Z = 0 object points for a flat board:
+
+```cpp
+// make_chessboard_points: generates inner-corner 3-D coordinates on the Z=0 plane
+// board_size: inner corners (cols, rows)
+// square_size: physical side length of one square in metres (or any consistent unit)
+auto obj_pts_one = make_chessboard_points({9, 6}, 0.025f);
+// Returns vector<cv::Point3f>:
+//   (0, 0, 0), (0.025, 0, 0), (0.050, 0, 0), ..., (0.200, 0.125, 0)
+```
+
+Collecting across multiple frames:
+
+```cpp
+std::vector<std::vector<cv::Point3f>> all_obj;   // one entry per view
+std::vector<std::vector<cv::Point2f>> all_img;   // one entry per view
+
+for (const auto& frame : calibration_frames) {
+    Image<BGR> img(frame);
+
+    auto res = img | FindChessboardCornersSB{}.board_size({9, 6});
+    if (!res.found) continue;   // skip frames where the board is not fully visible
+
+    all_obj.push_back(make_chessboard_points({9, 6}, 0.025f));  // same every frame
+    all_img.push_back(res.corners);                              // pixel positions this frame
+}
+std::cout << "Collected " << all_obj.size() << " valid views\n";
+```
+
+For best results, capture frames with the board:
+- tilted ±20° in both X and Y
+- at several distances (close, mid, far)
+- in the corners and centre of the frame
+- in good, even lighting without glare on the board surface
+
+## Camera Calibration
+
+Once you have at least three views (ideally 10+), pass the accumulated data to `CalibrateCamera`:
+
+```cpp
+// CalibrateCamera: non-linear least-squares solver (Levenberg–Marquardt)
+CalibrationResult cal = CalibrateCamera{}
+    .flags(0)   // 0 = estimate all parameters freely
+                // or: cv::CALIB_FIX_PRINCIPAL_POINT, cv::CALIB_RATIONAL_MODEL, etc.
+    (all_obj, all_img, image_size);
+// image_size: cv::Size — pixel dimensions of all frames (must be the same)
+```
+
+`CalibrationResult` fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `camera_matrix` | `cv::Mat` (3×3 CV_64F) | Intrinsics: `[fx, 0, cx; 0, fy, cy; 0, 0, 1]` |
+| `dist_coeffs` | `cv::Mat` (1×5 CV_64F) | `[k1, k2, p1, p2, k3]` |
+| `rvecs` | `vector<cv::Mat>` | Rotation vector per view (Rodrigues) |
+| `tvecs` | `vector<cv::Mat>` | Translation vector per view |
+| `rms` | `double` | RMS re-projection error in pixels |
+
+The **RMS re-projection error** measures how far projected 3-D corners deviate from the detected 2-D corners on average. A value below 1.0 px indicates a good calibration; above 2.0 px usually means poor coverage, blurry frames, or an incorrect board size.
+
+```cpp
+std::cout << "RMS: " << cal.rms << " px\n";
+std::cout << "K:\n"  << cal.camera_matrix << "\n";
+std::cout << "dist: " << cal.dist_coeffs.t() << "\n";
+```
+
+Common `flags` values:
+- `0` — estimate all parameters, including both focal lengths independently
+- `cv::CALIB_FIX_ASPECT_RATIO` — force `fx == fy`
+- `cv::CALIB_FIX_PRINCIPAL_POINT` — fix the principal point at the image centre
+- `cv::CALIB_RATIONAL_MODEL` — use a more accurate 8-parameter distortion model
+
+## Undistorting Images
+
+With calibration data in hand, you can remove distortion from any frame.
+
+### Undistort pipeline op
+
+The simplest approach: apply the op directly in a pipeline. Internally this builds the remap tables on every call, so it is best suited for single images or low-frame-rate scenarios.
+
+```cpp
+// Undistort: BGR-in, BGR-out pipeline op
+Image<BGR> undist = img
+    | Undistort{}.K(cal.camera_matrix).dist(cal.dist_coeffs);
+// Preserves Image<BGR> semantics; underlying cv::undistort is called internally
+```
+
+### UndistortMap + Remap for video
+
+When processing many frames (e.g. a live camera feed), computing the remap tables once and reusing them is far more efficient:
+
+```cpp
+// UndistortMap: pre-compute remap tables from calibration data — call once
+UndistortMapResult maps = UndistortMap{}
+    .K(cal.camera_matrix)     // 3×3 intrinsic matrix
+    .dist(cal.dist_coeffs)    // distortion coefficients
+    (image_size);
+// maps.map1, maps.map2: cv::Mat remap tables (same size as image_size)
+
+// Remap: apply pre-computed tables — call per frame, very fast
+while (camera.grab(frame)) {
+    Image<BGR> undist = frame | Remap{maps.map1, maps.map2};
+    // process undist ...
+}
+```
+
+`Remap` uses bilinear interpolation by default. The `UndistortMap` / `Remap` split matches OpenCV's own recommended pattern for video pipelines.
+
+For stereo rectification, `UndistortMap` accepts optional `.new_K()` and `.R()` parameters that incorporate the rectification rotation from `StereoRectify`. See the [Stereo Vision](stereo-vision.md) tutorial for that workflow.
+
+## Saving and Loading Calibration
+
+`CalibrateCamera` does not write files — that is handled directly with OpenCV's `cv::FileStorage`. Save after calibration and load before using the camera in production:
+
+```cpp
+// Save
+{
+    cv::FileStorage fs("calibration.yml", cv::FileStorage::WRITE);
+    fs << "camera_matrix" << cal.camera_matrix;
+    fs << "dist_coeffs"   << cal.dist_coeffs;
+    fs << "rms"           << cal.rms;
+}
+
+// Load
+cv::Mat K, dist;
+{
+    cv::FileStorage fs("calibration.yml", cv::FileStorage::READ);
+    fs["camera_matrix"] >> K;
+    fs["dist_coeffs"]   >> dist;
+}
+
+// Use loaded values exactly as you would the CalibrationResult fields
+Image<BGR> undist = frame | Undistort{}.K(K).dist(dist);
+```
+
+The YAML format is human-readable and easy to inspect. Store at least `camera_matrix`, `dist_coeffs`, and `rms` so you can verify calibration quality when loading old files.
+
+## Complete Example
+
+See `examples/calib/demo_calibrate.cpp` for a self-contained demo that synthesises five chessboard views, runs calibration, and shows both undistortion approaches.
+
+## Next Steps
+
+- [Stereo Vision](stereo-vision.md) — two-camera depth estimation and epipolar geometry
+- [ArUco Markers](aruco-markers.md) — fiducial markers for pose estimation and board calibration
+- [Feature Detection](feature-detection.md) — keypoint detection and descriptor matching

--- a/docs/tutorials/motion-analysis.md
+++ b/docs/tutorials/motion-analysis.md
@@ -115,7 +115,7 @@ CamShift (Continuously Adaptive MeanShift) tracks an object described by a colou
 
 ```cpp
 // Step 1 — build hue histogram from the object ROI in frame1
-Image<BGR> hsv1 = bgr1 | ToHSV{};
+Image<HSV> hsv1 = bgr1 | ToHSV{};
 cv::Mat hue1(hsv1.mat().rows, hsv1.mat().cols, CV_8U);
 int from_to[] = {0, 0};
 cv::mixChannels({hsv1.mat()}, {hue1}, from_to, 1);
@@ -130,13 +130,13 @@ cv::calcHist(&roi_hue, 1, nullptr, cv::Mat{}, hist, 1, &histSize, &histRange);
 cv::normalize(hist, hist, 0, 255, cv::NORM_MINMAX);
 ```
 
-`ToHSV{}` converts the BGR image to HSV in-place (stored in an `Image<BGR>` wrapper, matching OpenCV's convention). We extract only the hue channel via `cv::mixChannels` because hue is more invariant to lighting changes than full colour.
+`ToHSV{}` converts the BGR image to `Image<HSV>` (H∈[0,179], S∈[0,255], V∈[0,255]). We extract only the hue channel via `cv::mixChannels` because hue is more invariant to lighting changes than full colour.
 
 ### Back-project and track
 
 ```cpp
 // Step 2 — back-project onto frame2
-Image<BGR> hsv2 = bgr2 | ToHSV{};
+Image<HSV> hsv2 = bgr2 | ToHSV{};
 cv::Mat hue2(hsv2.mat().rows, hsv2.mat().cols, CV_8U);
 cv::mixChannels({hsv2.mat()}, {hue2}, from_to, 1);
 cv::Mat bp_mat;

--- a/docs/tutorials/motion-analysis.md
+++ b/docs/tutorials/motion-analysis.md
@@ -1,0 +1,208 @@
+# Motion Analysis
+
+This tutorial covers motion estimation in improc++: sparse feature tracking with Lucas-Kanade optical flow, dense per-pixel flow with Farneback and DIS, kernel-based object tracking with CamShift and MeanShift, and sub-pixel translation estimation with PhaseCorrelate. Use sparse methods when you only need to track specific feature points; use dense methods when you need the complete motion field for every pixel.
+
+`Image<Flow>` is a `CV_32FC2` image — each pixel stores a `(dx, dy)` displacement vector in floating-point pixels.
+
+## Prerequisites
+
+- Completed [Building a Pipeline](building-a-pipeline.md)
+- `improc/core/pipeline.hpp` (umbrella include for all core ops)
+- `improc/io/image_io.hpp` for `imread`
+
+## Sparse Lucas-Kanade Flow (`SparseLKFlow`)
+
+Lucas-Kanade optical flow tracks a set of user-supplied points from one frame to the next using a pyramid of smoothed images. It is fast, accurate for small-to-medium displacements, and ideal when you already know which points matter — for example, corners detected by `cv::goodFeaturesToTrack`.
+
+```cpp
+#include "improc/core/pipeline.hpp"
+#include "improc/io/image_io.hpp"
+using namespace improc::core;
+using namespace improc::io;
+
+int main() {
+    auto frame1 = imread<BGR>("frame1.png");
+    auto frame2 = imread<BGR>("frame2.png");
+    if (!frame1 || !frame2) return 1;
+
+    Image<Gray> gray1 = convert<Gray>(*frame1);
+    Image<Gray> gray2 = convert<Gray>(*frame2);
+
+    // Detect corners in frame1 to use as tracking seeds
+    std::vector<cv::Point2f> pts1;
+    cv::goodFeaturesToTrack(gray1.mat(), pts1, 200, 0.01, 10);
+
+    SparseLKFlowResult res = SparseLKFlow{}
+        .win_size({21, 21})  // search window per pyramid level (default: {21,21})
+        .max_level(3)        // pyramid depth (default: 3)
+        .max_iter(30)        // max Lucas-Kanade iterations (default: 30)
+        .epsilon(0.01)       // convergence threshold (default: 0.01)
+        (gray1, gray2, pts1);
+
+    // status[i] = 1 if tracked, 0 if lost; points[i] = new position; error[i] = residual
+    int n_tracked = 0;
+    for (std::size_t i = 0; i < res.status.size(); ++i)
+        if (res.status[i]) ++n_tracked;
+
+    std::cout << "Tracked " << n_tracked << " / " << pts1.size() << " points\n";
+}
+```
+
+`SparseLKFlowResult` has three parallel vectors, one entry per input point:
+
+- `points` — new `cv::Point2f` positions in `frame2`
+- `status` — `1` if the point was tracked successfully, `0` if it was lost (e.g., moved out of frame or had insufficient texture)
+- `error` — per-point tracking residual; lower is better
+
+Increase `win_size` and `max_level` when tracking large displacements; decrease them to reduce computation when motion is small.
+
+## Dense Farneback Flow (`DenseFarnebackFlow`)
+
+Farneback's algorithm approximates each image neighbourhood with a polynomial expansion and estimates the flow that minimises the difference between expansions. It produces an `Image<Flow>` covering every pixel — useful for motion segmentation, background subtraction, and action recognition.
+
+```cpp
+Image<Flow> flow = DenseFarnebackFlow{}
+    .pyr_scale(0.5)    // pyramid scale factor (default: 0.5)
+    .levels(3)         // pyramid levels (default: 3)
+    .win_size(15)      // averaging window size (default: 15)
+    .iterations(3)     // iterations per level (default: 3)
+    .poly_n(5)         // polynomial neighbourhood (default: 5)
+    .poly_sigma(1.2)   // Gaussian sigma for poly expansion (default: 1.2)
+    (gray1, gray2);
+```
+
+Visualise the flow field as an HSV colour wheel — hue encodes direction, value encodes magnitude:
+
+```cpp
+// Visualize flow as HSV colour wheel: hue = direction, value = magnitude
+cv::Mat planes[2];
+cv::split(flow.mat(), planes);   // planes[0] = dx, planes[1] = dy
+
+cv::Mat mag, ang;
+cv::cartToPolar(planes[0], planes[1], mag, ang, true);  // true = degrees
+
+cv::normalize(mag, mag, 0, 255, cv::NORM_MINMAX);
+mag.convertTo(mag, CV_8U);
+cv::Mat hue; ang.convertTo(hue, CV_8U, 255.0 / 360.0);
+cv::Mat sat = cv::Mat::ones(mag.size(), CV_8U) * 255;
+
+cv::Mat hsv, vis;
+cv::merge(std::vector<cv::Mat>{hue, sat, mag}, hsv);
+cv::cvtColor(hsv, vis, cv::COLOR_HSV2BGR);
+cv::imshow("Flow", vis);
+```
+
+Larger `win_size` and more `levels` capture bigger displacements at the cost of blurring fine detail. Higher `poly_n` gives a smoother but less localised flow field.
+
+## Dense DIS Flow (`DenseDISFlow`)
+
+DIS (Dense Inverse Search) is significantly faster than Farneback for equal quality — often 5–10× — making it the preferred choice for real-time dense flow. Three presets balance speed against quality:
+
+```cpp
+// Three presets — quality ascending, speed descending
+Image<Flow> dis_uf = DenseDISFlow{}.preset(DenseDISFlow::Preset::UltraFast)(gray1, gray2);
+Image<Flow> dis_f  = DenseDISFlow{}.preset(DenseDISFlow::Preset::Fast)     (gray1, gray2);
+Image<Flow> dis_m  = DenseDISFlow{}.preset(DenseDISFlow::Preset::Medium)   (gray1, gray2);
+```
+
+`UltraFast` runs at several hundred frames per second on HD images; `Medium` is the default and produces Farneback-quality results in a fraction of the time. The output `Image<Flow>` format is identical to Farneback's, so the HSV visualisation above applies unchanged.
+
+## Kernel-Based Tracking / CamShift
+
+CamShift (Continuously Adaptive MeanShift) tracks an object described by a colour histogram. It adapts the search window size and orientation at each frame, returning a `RotatedRect` that approximates the object's pose. The three-step process — build histogram, back-project, track — separates model building from tracking so you can update the histogram online.
+
+### Build the colour model
+
+```cpp
+// Step 1 — build hue histogram from the object ROI in frame1
+Image<BGR> hsv1 = bgr1 | ToHSV{};
+cv::Mat hue1(hsv1.mat().rows, hsv1.mat().cols, CV_8U);
+int from_to[] = {0, 0};
+cv::mixChannels({hsv1.mat()}, {hue1}, from_to, 1);
+
+cv::Mat hist;
+int histSize = 32;
+float range[] = {0.f, 180.f};
+const float* histRange = {range};
+cv::Rect roi{100, 80, 60, 60};
+cv::Mat roi_hue = hue1(roi);
+cv::calcHist(&roi_hue, 1, nullptr, cv::Mat{}, hist, 1, &histSize, &histRange);
+cv::normalize(hist, hist, 0, 255, cv::NORM_MINMAX);
+```
+
+`ToHSV{}` converts the BGR image to HSV in-place (stored in an `Image<BGR>` wrapper, matching OpenCV's convention). We extract only the hue channel via `cv::mixChannels` because hue is more invariant to lighting changes than full colour.
+
+### Back-project and track
+
+```cpp
+// Step 2 — back-project onto frame2
+Image<BGR> hsv2 = bgr2 | ToHSV{};
+cv::Mat hue2(hsv2.mat().rows, hsv2.mat().cols, CV_8U);
+cv::mixChannels({hsv2.mat()}, {hue2}, from_to, 1);
+cv::Mat bp_mat;
+cv::calcBackProject(&hue2, 1, nullptr, hist, bp_mat, &histRange);
+Image<Gray> bp{bp_mat};
+
+// Step 3 — track
+cv::Rect window = roi;
+CamShiftResult res = CamShift{}
+    .epsilon(1.0)    // convergence threshold (default: 1.0)
+    .max_iter(10)    // max iterations (default: 10)
+    (bp, window);    // window updated in-place to new position
+
+cv::RotatedRect obj = res.object;   // tracked location and orientation
+```
+
+`CamShiftResult` contains a single field `object` — a `cv::RotatedRect` with `.center`, `.size`, and `.angle`. Pass `obj` to `cv::ellipse` to draw a tight oriented bounding box around the tracked region.
+
+### MeanShift
+
+MeanShift is the axis-aligned variant: the window does not rotate or resize, making it faster but less expressive. It returns the iteration count rather than a `RotatedRect`.
+
+```cpp
+cv::Rect window2 = roi;
+int iters = MeanShift{}
+    .epsilon(1.0)    // convergence threshold (default: 1.0)
+    .max_iter(10)    // max iterations (default: 10)
+    (bp, window2);   // window2 updated in-place; returns iteration count
+
+std::cout << "Converged in " << iters << " iterations at " << window2 << "\n";
+```
+
+Both `CamShift` and `MeanShift` take `Image<Gray>` as the back-projection argument and mutate the `cv::Rect` window in-place.
+
+## Sub-Pixel Translation (`PhaseCorrelate`)
+
+Phase correlation computes the cross-power spectrum of two images in the frequency domain and finds the peak of the inverse DFT — giving a sub-pixel translation estimate in a single pass. It is ideal for camera stabilisation and image registration when the dominant motion is a global translation.
+
+```cpp
+// PhaseCorrelate requires Image<Float32> (single-channel float)
+Image<Float32> f1 = convert<Gray>(*frame1) | ToFloat32{};
+Image<Float32> f2 = convert<Gray>(*frame2) | ToFloat32{};
+
+PhaseCorrelateResult pc = PhaseCorrelate{}(f1, f2);
+std::cout << "Shift: (" << pc.shift.x << ", " << pc.shift.y << ") px\n";
+std::cout << "Response: " << pc.response << "  (>0.3 = reliable)\n";
+```
+
+`PhaseCorrelateResult` fields:
+
+- `shift` — `cv::Point2d` with sub-pixel `(dx, dy)` displacement
+- `response` — confidence in the range 0..1; values above 0.3 indicate a reliable peak; values below suggest the frames contain little common structure or the shift exceeds the image's Nyquist limit
+
+## Choosing a Method
+
+| Op | Input | Output | Use case |
+|---|---|---|---|
+| `SparseLKFlow` | Gray pair + points | Points + status | Track specific features |
+| `DenseFarnebackFlow` | Gray pair | `Image<Flow>` | Full-frame motion analysis |
+| `DenseDISFlow` | Gray pair | `Image<Flow>` | Same, faster — prefer real-time |
+| `CamShift` | Back-proj + rect | `RotatedRect` | Object tracking with colour model |
+| `MeanShift` | Back-proj + rect | iteration count | Axis-aligned tracking |
+| `PhaseCorrelate` | Float32 pair | shift + response | Camera stabilisation, translation |
+
+## Next Steps
+
+- [Camera Calibration](camera-calibration.md)
+- [Object Detectors](object-detectors.md)
+- [Building a Pipeline](building-a-pipeline.md)

--- a/docs/tutorials/stereo-vision.md
+++ b/docs/tutorials/stereo-vision.md
@@ -1,0 +1,267 @@
+# Stereo Vision
+
+This tutorial explains how to use two calibrated cameras to estimate depth, compute disparity maps, and reconstruct 3-D point clouds with improc++. It also covers the epipolar geometry tools — fundamental matrix, essential matrix, pose recovery, and triangulation — that are useful when you do not have a pre-calibrated stereo rig.
+
+All operations live in `#include "improc/calib/pipeline.hpp"`.
+
+## Prerequisites
+
+- Completed [Camera Calibration](camera-calibration.md)
+- `improc/calib/pipeline.hpp`
+
+## The Stereo Geometry
+
+Two cameras separated by a known horizontal baseline B observe the same 3-D point P. The point projects to pixel x_L in the left image and x_R in the right image. The **disparity** is d = x_L − x_R. Depth follows the thin-lens stereo formula:
+
+```
+Z = f · B / d
+```
+
+where f is the focal length (in pixels). Larger disparity means closer depth; infinite depth means zero disparity. After **rectification** both image rows are aligned, so matching is reduced to a 1-D horizontal search — this is the key step that makes disparity computation tractable.
+
+## Stereo Calibration
+
+`StereoCalibrate` estimates the relative pose (rotation R and translation T) between two cameras, refining their individual intrinsics at the same time. Collect paired chessboard views exactly as in the single-camera case, but detect corners in both images simultaneously:
+
+```cpp
+#include "improc/calib/pipeline.hpp"
+using namespace improc::calib;
+using namespace improc::core;
+
+std::vector<std::vector<cv::Point3f>> all_obj;
+std::vector<std::vector<cv::Point2f>> all_img1, all_img2;
+
+for (auto& [left, right] : paired_frames) {
+    auto r1 = left  | FindChessboardCornersSB{}.board_size({9, 6});
+    auto r2 = right | FindChessboardCornersSB{}.board_size({9, 6});
+
+    if (!r1.found || !r2.found) continue;   // both must succeed
+
+    all_obj.push_back(make_chessboard_points({9, 6}, 0.025f));
+    all_img1.push_back(r1.corners);
+    all_img2.push_back(r2.corners);
+}
+
+// StereoCalibrate: joint optimisation of both cameras and their relative pose
+StereoCalibrationResult sr = StereoCalibrate{}
+    // Optionally seed with individual calibrations:
+    // .K1(cal1.camera_matrix).dist1(cal1.dist_coeffs)
+    // .K2(cal2.camera_matrix).dist2(cal2.dist_coeffs)
+    // .flags(cv::CALIB_FIX_INTRINSIC)   // fix intrinsics, only solve for R, T
+    (all_obj, all_img1, all_img2, image_size);
+```
+
+`StereoCalibrationResult` fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `K1`, `K2` | `cv::Mat` (3×3) | Left and right camera matrices |
+| `dist1`, `dist2` | `cv::Mat` | Left and right distortion coefficients |
+| `R` | `cv::Mat` (3×3) | Rotation from camera 1 to camera 2 |
+| `T` | `cv::Mat` (3×1) | Translation from camera 1 to camera 2 (in metres if sq=0.025) |
+| `E` | `cv::Mat` (3×3) | Essential matrix |
+| `F` | `cv::Mat` (3×3) | Fundamental matrix |
+| `rms` | `double` | RMS re-projection error across both cameras |
+
+If you already have good individual calibrations, pass `cv::CALIB_FIX_INTRINSIC` to freeze K1, K2, dist1, dist2 and solve only for R and T — this converges faster and avoids over-parameterising the problem.
+
+## Stereo Rectification
+
+Rectification warps both images so that corresponding epipolar lines become horizontal and co-planar. After rectification, a point at column x in the left row r has its match somewhere on the same row r in the right image — a horizontal scan suffices.
+
+```cpp
+// StereoRectify: compute rectification transforms from stereo calibration results
+StereoRectifyResult rr = StereoRectify{}
+    .alpha(-1.0)   // -1 = keep all valid pixels (crops less); 0 = keep only fully valid
+                   //  values between 0..1 trade off cropping vs. black borders
+    (sr.K1, sr.dist1, sr.K2, sr.dist2, sr.R, sr.T, image_size);
+```
+
+`StereoRectifyResult` fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `R1`, `R2` | `cv::Mat` (3×3) | Rectification rotations for left and right |
+| `P1`, `P2` | `cv::Mat` (3×4) | Projection matrices in the rectified coordinate system |
+| `Q` | `cv::Mat` (4×4) | Disparity-to-depth reprojection matrix |
+| `validROI1`, `validROI2` | `cv::Rect` | Valid pixel regions after rectification |
+
+Apply rectification using `UndistortMap` and `Remap`, which combine undistortion and rectification in a single pass:
+
+```cpp
+// Left rectification maps: combine undistortion + rectification rotation
+UndistortMapResult maps1 = UndistortMap{}
+    .K(sr.K1)
+    .dist(sr.dist1)
+    .new_K(rr.P1)   // rectified projection matrix as new K
+    .R(rr.R1)       // rectification rotation
+    (image_size);
+
+// Right rectification maps
+UndistortMapResult maps2 = UndistortMap{}
+    .K(sr.K2)
+    .dist(sr.dist2)
+    .new_K(rr.P2)
+    .R(rr.R2)
+    (image_size);
+
+// Apply per frame — very fast, tables are pre-computed
+Image<BGR> rect_left  = left_frame  | Remap{maps1.map1, maps1.map2};
+Image<BGR> rect_right = right_frame | Remap{maps2.map1, maps2.map2};
+```
+
+After this step, horizontal scan lines in `rect_left` and `rect_right` are guaranteed to be epipolar lines.
+
+## Computing Disparity
+
+Disparity algorithms operate on grayscale images. improc++ wraps two OpenCV stereo matchers.
+
+### StereoBM — fast block matching
+
+`StereoBM` uses fixed-size block matching with a hardware-friendly sliding-window approach. It is the fastest option and works well for scenes with strong texture:
+
+```cpp
+Image<Gray> left_gray  = rect_left  | ToGray{};
+Image<Gray> right_gray = rect_right | ToGray{};
+
+cv::Mat disp_bm = StereoBM{}
+    .num_disparities(64)   // disparity search range; must be divisible by 16 (default: 16)
+    .block_size(15)        // matching block size; odd number in [5, 255] (default: 15)
+    (left_gray, right_gray);
+// Returns CV_16S; true disparity (in pixels) = value / 16.0
+```
+
+Larger `num_disparities` covers a wider depth range but is slower. Larger `block_size` is more robust to noise but blurs depth edges.
+
+Convert to a visualisable 8-bit map:
+
+```cpp
+cv::Mat disp_vis;
+disp_bm.convertTo(disp_vis, CV_8U, 255.0 / (16.0 * num_disparities));
+```
+
+### StereoSGBM — semi-global block matching
+
+`StereoSGBM` (Semi-Global Block Matching) aggregates matching costs along multiple scanline paths. It produces significantly smoother and more complete disparity maps, at the cost of higher CPU usage:
+
+```cpp
+const int bsz = 5;
+cv::Mat disp_sgbm = StereoSGBM{}
+    .min_disparity(0)              // minimum disparity value (default: 0)
+    .num_disparities(64)           // number of disparity levels (default: 64)
+    .block_size(bsz)               // matched block size, must be odd (default: 3)
+    .p1(8  * bsz * bsz)           // smoothness penalty for 1-pixel disparity change
+    .p2(32 * bsz * bsz)           // smoothness penalty for larger changes (p2 > p1)
+    .mode(cv::StereoSGBM::MODE_SGBM_3WAY)   // 3-way is faster than full SGBM
+    (left_gray, right_gray);
+// Returns CV_16S, same scaling as StereoBM: divide by 16 for float disparity
+```
+
+P1 and P2 are the SGBM smoothness penalties. The rule of thumb `P1 = 8·bsz²` and `P2 = 32·bsz²` gives good results on natural scenes.
+
+## 3-D Reconstruction
+
+With the disparity map and the Q matrix from `StereoRectify`, you can lift every pixel to a 3-D point:
+
+```cpp
+cv::Mat pts3d = ReprojectTo3D{}
+    .handle_missing(false)   // false = include all points; true = skip invalid disparity
+    (disp_sgbm, rr.Q);       // returns CV_32FC3: each pixel → (X, Y, Z) in metres
+```
+
+Filter out invalid points before use — pixels with zero or negative disparity produce infinity or NaN:
+
+```cpp
+for (int y = 0; y < pts3d.rows; ++y)
+    for (int x = 0; x < pts3d.cols; ++x) {
+        auto& p = pts3d.at<cv::Vec3f>(y, x);
+        if (!std::isinf(p[2]) && p[2] > 0 && p[2] < max_depth) {
+            // p[0], p[1], p[2]: X, Y, Z in the same units as the baseline
+            point_cloud.push_back({p[0], p[1], p[2]});
+        }
+    }
+```
+
+The Q matrix encodes baseline, focal length, and principal point shift, so the recovered 3-D coordinates are in the same physical unit as the baseline (metres if you used 0.025 m squares).
+
+## Epipolar Geometry
+
+If you do not have a calibrated stereo rig — for example, when working with two uncalibrated images or tracking a moving camera — you can still recover the relative pose from feature point correspondences.
+
+### Fundamental Matrix
+
+The fundamental matrix F relates corresponding points in two uncalibrated images: for every pair (x1, x2), x2^T · F · x1 = 0.
+
+```cpp
+// FindFundamentalMat: RANSAC-based estimation from ≥8 point pairs
+FundamentalMatResult fm = FindFundamentalMat{}
+    .method(cv::FM_RANSAC)       // robust estimator (default)
+    .ransac_threshold(3.0)       // reprojection threshold in pixels (default: 3.0)
+    .confidence(0.99)            // required probability that result is correct
+    (pts1, pts2);                // vector<cv::Point2f>, ≥8 matched pairs required
+// fm.F: 3×3 CV_64F fundamental matrix
+// fm.mask: CV_8U inlier flags (1 = inlier, 0 = outlier)
+```
+
+### Essential Matrix
+
+When camera intrinsics K are known, the essential matrix E = K^T · F · K encodes the metric rotation and translation (up to scale):
+
+```cpp
+EssentialMatResult em = FindEssentialMat{}
+    .method(cv::RANSAC)
+    .threshold(1.0)     // reprojection threshold (default: 1.0)
+    .confidence(0.99)
+    (pts1, pts2, K);    // same K for both cameras (single-camera motion case)
+// em.E: 3×3 CV_64F; em.mask: inlier flags
+```
+
+### Recovering Camera Pose
+
+Decompose E into rotation and (unit) translation:
+
+```cpp
+// RecoverPose: decomposes E and selects the physically consistent solution
+RecoverPoseResult rp = RecoverPose{}(em.E, pts1, pts2, K);
+// rp.R: 3×3 rotation matrix
+// rp.t: 3×1 unit translation (direction only, scale unknown)
+// rp.inliers: count of points in front of both cameras
+```
+
+Translation is recovered only up to scale. To get metric depth you need a known distance in the scene, stereo baseline, or IMU data.
+
+### Triangulating Points
+
+Given two projection matrices P1 and P2, triangulate 3-D positions from matched 2-D points:
+
+```cpp
+// Build projection matrices from intrinsics and recovered pose
+cv::Mat P1 = K * cv::Mat::eye(3, 4, CV_64F);         // left camera: no rotation/translation
+cv::Mat P2_34 = cv::Mat::zeros(3, 4, CV_64F);
+rp.R.copyTo(P2_34.colRange(0, 3));
+rp.t.copyTo(P2_34.col(3));
+cv::Mat P2 = K * P2_34;
+
+cv::Mat hom = TriangulatePoints{}(P1, P2, pts1, pts2);
+// Returns 4×N CV_32F in homogeneous coordinates
+// Convert to Euclidean: X/W, Y/W, Z/W for each column
+for (int i = 0; i < hom.cols; ++i) {
+    float w = hom.at<float>(3, i);
+    cv::Point3f pt3d(hom.at<float>(0, i) / w,
+                     hom.at<float>(1, i) / w,
+                     hom.at<float>(2, i) / w);
+    // use pt3d ...
+}
+```
+
+Triangulation accuracy degrades when the baseline angle between views is small (near-parallel cameras). For best results, choose well-separated viewpoints.
+
+## Complete Example
+
+See `examples/calib/demo_stereo.cpp` for a self-contained demo that builds a synthetic textured scene, computes disparity with both `StereoBM` and `StereoSGBM`, and reconstructs a 3-D point cloud with `ReprojectTo3D`.
+
+## Next Steps
+
+- [ArUco Markers](aruco-markers.md) — fiducial markers for pose estimation with a single camera
+- [Camera Calibration](camera-calibration.md) — single-camera calibration workflow
+- [Feature Detection](feature-detection.md) — keypoint matching for epipolar geometry inputs

--- a/examples/calib/demo_aruco.cpp
+++ b/examples/calib/demo_aruco.cpp
@@ -1,0 +1,74 @@
+// examples/calib/demo_aruco.cpp
+//
+// Demo: ArucoDict, GenerateAruco, DetectAruco, DrawAruco, ArucoPose
+//
+// Generates a DICT_4X4_50 marker (ID 7), embeds it in a white canvas,
+// detects it in the same image (round-trip), draws corners + ID, then
+// estimates pose using a synthetic camera matrix.
+// Press any key to advance.
+
+#include "improc/calib/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::calib;
+using namespace improc::core;
+
+static void show(const std::string& t, const cv::Mat& m) {
+    cv::imshow(t, m); cv::waitKey(0);
+}
+
+int main() {
+    // ── Dictionary and marker ─────────────────────────────────────────────────
+    cv::aruco::Dictionary dict = ArucoDict{}(cv::aruco::DICT_4X4_50);
+
+    Image<Gray> marker = GenerateAruco{}
+        .border_bits(1)    // white border width in bits (default: 1)
+        (dict, 7, 200);    // marker ID 7, 200×200 px output image
+
+    show("1 — Generated marker (ID 7)", marker.mat());
+
+    // ── Embed marker in a scene ───────────────────────────────────────────────
+    cv::Mat scene(400, 400, CV_8UC3, cv::Scalar(240, 240, 240));
+    cv::Mat marker_bgr;
+    cv::cvtColor(marker.mat(), marker_bgr, cv::COLOR_GRAY2BGR);
+    marker_bgr.copyTo(scene(cv::Rect{100, 100, 200, 200}));
+    Image<BGR> scene_img(scene);
+
+    show("2 — Scene with embedded marker", scene);
+
+    // ── Detect markers ────────────────────────────────────────────────────────
+    ArucoResult res = DetectAruco{}(scene_img, dict);
+    std::cout << "Detected " << res.ids.size() << " marker(s)\n";
+    for (std::size_t i = 0; i < res.ids.size(); ++i)
+        std::cout << "  ID " << res.ids[i] << "\n";
+
+    // DrawAruco overload 1: corner outlines + ID text
+    cv::Mat annotated = DrawAruco{}(scene.clone(), res);
+    show("3 — Detected marker (corners + ID)", annotated);
+
+    // ── Pose estimation ───────────────────────────────────────────────────────
+    // Synthetic K for 400×400 image
+    cv::Mat K = (cv::Mat_<double>(3, 3)
+        << 400, 0, 200,
+             0, 400, 200,
+             0, 0, 1);
+    cv::Mat dist = cv::Mat::zeros(5, 1, CV_64F);
+
+    if (!res.ids.empty()) {
+        std::vector<ArucoPoseResult> poses = ArucoPose{}(res, K, dist, 0.05f);
+        for (const auto& p : poses)
+            std::cout << "Marker " << p.id
+                      << "  rvec=" << p.rvec.t()
+                      << "  tvec=" << p.tvec.t() << "\n";
+
+        // DrawAruco overload 2: adds 3-D axis frames per marker
+        cv::Mat with_axes = DrawAruco{}
+            .axis_length(0.03f)    // axis length in world units (default: 0.05)
+            (scene.clone(), res, poses, K, dist);
+        show("4 — Marker with 3-D pose axes", with_axes);
+    }
+
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/examples/calib/demo_calibrate.cpp
+++ b/examples/calib/demo_calibrate.cpp
@@ -1,0 +1,98 @@
+// examples/calib/demo_calibrate.cpp
+//
+// Demo: FindChessboardCornersSB, CalibrateCamera, Undistort, UndistortMap + Remap
+//
+// Synthesises 5 chessboard views by warping a generated board image,
+// runs calibration, prints K and RMS, shows undistorted result.
+// In a real workflow, replace synthetic views with imread<BGR> from disk.
+// Press any key to advance.
+
+#include "improc/calib/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::calib;
+using namespace improc::core;
+
+static void show(const std::string& t, const cv::Mat& m) {
+    cv::imshow(t, m); cv::waitKey(0);
+}
+
+int main() {
+    const cv::Size board{9, 6};
+    const float    sq = 0.025f;
+
+    // ── Synthesise a reference chessboard image ───────────────────────────────
+    const int cell = 40, pad = cell;
+    int W = board.width  * cell + 2 * pad;
+    int H = board.height * cell + 2 * pad;
+    cv::Mat ref(H, W, CV_8UC3, cv::Scalar(255, 255, 255));
+    for (int r = 0; r <= board.height; ++r)
+        for (int c = 0; c <= board.width; ++c)
+            if ((r + c) % 2 == 0)
+                cv::rectangle(ref,
+                    {c * cell + pad, r * cell + pad},
+                    {(c+1)*cell + pad, (r+1)*cell + pad},
+                    {0, 0, 0}, -1);
+    Image<BGR> ref_img(ref);
+
+    // ── Collect calibration views via slight warps ────────────────────────────
+    std::vector<std::vector<cv::Point3f>> all_obj;
+    std::vector<std::vector<cv::Point2f>> all_img;
+    Image<BGR> last_view(ref);
+
+    const std::vector<std::pair<double,double>> angles = {
+        {0.0, 0.0}, {5.0, 0.0}, {-5.0, 0.0}, {0.0, 5.0}, {3.0, -3.0}
+    };
+    for (auto [ax, ay] : angles) {
+        double rad = ax * CV_PI / 180.0;
+        cv::Mat M = (cv::Mat_<double>(2, 3)
+            << std::cos(rad), -std::sin(rad), W * 0.02 * ax,
+               std::sin(rad),  std::cos(rad), H * 0.02 * ay);
+        cv::Mat warped;
+        cv::warpAffine(ref, warped, M, ref.size(), cv::INTER_LINEAR,
+                       cv::BORDER_CONSTANT, cv::Scalar(200, 200, 200));
+        Image<BGR> view(warped);
+
+        // FindChessboardCornersSB: newer method, sub-pixel built-in
+        auto res = view | FindChessboardCornersSB{}.board_size(board);
+        if (!res.found) continue;
+
+        all_obj.push_back(make_chessboard_points(board, sq));
+        all_img.push_back(res.corners);
+        last_view = view;
+    }
+    std::cout << "Collected " << all_obj.size() << " valid calibration views\n";
+    if (all_obj.size() < 3) {
+        std::cerr << "Too few views for calibration (need >= 3)\n";
+        return 1;
+    }
+    show("1 — Example calibration view", last_view.mat());
+
+    // ── CalibrateCamera ───────────────────────────────────────────────────────
+    CalibrationResult cal = CalibrateCamera{}
+        .flags(0)    // 0 = estimate all parameters freely
+        (all_obj, all_img, ref.size());
+
+    std::cout << "RMS re-projection error: " << cal.rms << " px\n";
+    std::cout << "Camera matrix:\n" << cal.camera_matrix << "\n";
+    std::cout << "Dist coeffs: " << cal.dist_coeffs.t() << "\n";
+
+    // ── Undistort: single image via pipeline op ───────────────────────────────
+    Image<BGR> undist = last_view
+        | Undistort{}.K(cal.camera_matrix).dist(cal.dist_coeffs);
+    show("2 — Original view", last_view.mat());
+    show("3 — Undistorted (Undistort pipeline op)", undist.mat());
+
+    // ── UndistortMap + Remap: preferred for video (maps computed once) ─────────
+    UndistortMapResult maps = UndistortMap{}
+        .K(cal.camera_matrix)     // 3×3 camera intrinsics
+        .dist(cal.dist_coeffs)    // distortion coefficients
+        (ref.size());
+
+    Image<BGR> undist2 = last_view | Remap{maps.map1, maps.map2};
+    show("4 — Undistorted (UndistortMap + Remap)", undist2.mat());
+
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/examples/calib/demo_pose.cpp
+++ b/examples/calib/demo_pose.cpp
@@ -1,0 +1,82 @@
+// examples/calib/demo_pose.cpp
+//
+// Demo: SolvePnP, SolvePnPRansac, ProjectPoints
+//
+// Defines a 3-D cube's corners, projects them with a known K and pose,
+// then recovers the pose via SolvePnP and re-projects to verify round-trip.
+// Press any key to close.
+
+#include "improc/calib/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::calib;
+
+int main() {
+    // ── Synthetic K for a 640×480 image ──────────────────────────────────────
+    cv::Mat K = (cv::Mat_<double>(3, 3)
+        << 500, 0, 320,
+           0, 500, 240,
+           0,   0,   1);
+    cv::Mat dist = cv::Mat::zeros(5, 1, CV_64F);
+
+    // ── 3-D object: front + back face of a 1 m cube ───────────────────────────
+    std::vector<cv::Point3f> obj_pts = {
+        {-0.5f, -0.5f, 0.f}, { 0.5f, -0.5f, 0.f},
+        { 0.5f,  0.5f, 0.f}, {-0.5f,  0.5f, 0.f},
+        {-0.5f, -0.5f, 1.f}, { 0.5f, -0.5f, 1.f},
+        { 0.5f,  0.5f, 1.f}, {-0.5f,  0.5f, 1.f}
+    };
+
+    // ── Ground-truth pose: ~10° rotation around Y, 3 m along Z ───────────────
+    cv::Mat rvec_gt = (cv::Mat_<double>(3, 1) << 0, 0.174533, 0);
+    cv::Mat tvec_gt = (cv::Mat_<double>(3, 1) << 0, 0, 3.0);
+
+    // ── Project 3-D → 2-D with known pose ────────────────────────────────────
+    std::vector<cv::Point2f> img_pts = ProjectPoints{}(obj_pts, rvec_gt, tvec_gt, K, dist);
+    std::cout << "Projected " << img_pts.size() << " points\n";
+
+    // ── SolvePnP: recover pose from 2-D/3-D correspondences ──────────────────
+    PnPResult res = SolvePnP{}
+        .method(cv::SOLVEPNP_ITERATIVE)   // default method
+        (obj_pts, img_pts, K, dist);
+
+    if (!res.success) { std::cerr << "SolvePnP failed\n"; return 1; }
+    std::cout << "Recovered rvec: " << res.rvec.t() << "\n";
+    std::cout << "Expected  rvec: " << rvec_gt.t()  << "\n";
+    std::cout << "Recovered tvec: " << res.tvec.t() << "\n";
+    std::cout << "Expected  tvec: " << tvec_gt.t()  << "\n";
+
+    // ── Re-project with recovered pose (should match img_pts) ─────────────────
+    auto reproj = ProjectPoints{}(obj_pts, res.rvec, res.tvec, K, dist);
+    double max_err = 0;
+    for (std::size_t i = 0; i < img_pts.size(); ++i)
+        max_err = std::max(max_err, (double)cv::norm(img_pts[i] - reproj[i]));
+    std::cout << "Max re-projection error: " << max_err << " px\n";
+
+    // ── SolvePnPRansac: robust to outliers ────────────────────────────────────
+    PnPRansacResult rr = SolvePnPRansac{}
+        .method(cv::SOLVEPNP_ITERATIVE)
+        .confidence(0.99)           // desired probability (default: 0.99)
+        .reprojection_error(8.0f)   // inlier threshold in px (default: 8.0)
+        .iterations(100)            // RANSAC iterations (default: 100)
+        (obj_pts, img_pts, K, dist);
+    std::cout << "RANSAC success: " << rr.success
+              << "  inliers: " << cv::countNonZero(rr.inliers) << "\n";
+
+    // ── Visualise projected cube ──────────────────────────────────────────────
+    cv::Mat canvas(480, 640, CV_8UC3, cv::Scalar(30, 30, 30));
+    const std::vector<std::pair<int,int>> edges = {
+        {0,1},{1,2},{2,3},{3,0},
+        {4,5},{5,6},{6,7},{7,4},
+        {0,4},{1,5},{2,6},{3,7}
+    };
+    for (auto [a, b] : edges)
+        cv::line(canvas, reproj[a], reproj[b], {0, 255, 0}, 2);
+
+    cv::imshow("Projected cube (recovered pose)", canvas);
+    cv::waitKey(0);
+
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/examples/calib/demo_stereo.cpp
+++ b/examples/calib/demo_stereo.cpp
@@ -1,0 +1,99 @@
+// examples/calib/demo_stereo.cpp
+//
+// Demo: StereoBM, StereoSGBM, ReprojectTo3D
+//
+// Creates a textured synthetic scene and a right image offset by a known
+// horizontal baseline. Computes disparity with both methods and shows a
+// side-by-side comparison. ReprojectTo3D demonstrates depth reconstruction.
+// Press any key to advance.
+
+#include "improc/calib/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::calib;
+using namespace improc::core;
+
+static void show(const std::string& t, const cv::Mat& m) {
+    cv::imshow(t, m); cv::waitKey(0);
+}
+
+int main() {
+    // ── Synthetic textured scene ──────────────────────────────────────────────
+    const int W = 640, H = 480;
+    cv::Mat scene(H, W, CV_8UC3, cv::Scalar(80, 80, 80));
+    cv::rectangle(scene, {50,  50},  {200, 200}, {200,  80,  80}, -1);
+    cv::rectangle(scene, {250, 100}, {350, 300}, { 80, 200,  80}, -1);
+    cv::circle(scene,    {500, 240}, 80,          { 80,  80, 200}, -1);
+    cv::rectangle(scene, {0,  400},  {640, 480},  {120, 120,  40}, -1);
+
+    // Add texture via random noise
+    cv::Mat noise(H, W, CV_8UC3);
+    cv::randu(noise, 0, 30);
+    scene += noise;
+
+    Image<BGR> left_bgr(scene);
+    Image<Gray> left_gray = left_bgr | ToGray{};
+
+    // Right image: shift left by baseline_px (simulates positive disparity)
+    const int baseline_px = 20;
+    cv::Mat M = (cv::Mat_<double>(2, 3) << 1, 0, -baseline_px, 0, 1, 0);
+    cv::Mat right_mat;
+    cv::warpAffine(scene, right_mat, M, scene.size());
+    Image<BGR> right_bgr(right_mat);
+    Image<Gray> right_gray = right_bgr | ToGray{};
+
+    show("1 — Left frame",  left_bgr.mat());
+    show("2 — Right frame (shifted left by 20px)", right_bgr.mat());
+
+    // ── StereoBM ──────────────────────────────────────────────────────────────
+    std::cout << "\n--- StereoBM ---\n";
+    cv::Mat disp_bm = StereoBM{}
+        .num_disparities(64)   // disparity search range, must be divisible by 16 (default: 16)
+        .block_size(15)        // matching block size, odd number 5-255 (default: 15)
+        (left_gray, right_gray);   // returns CV_16S; divide by 16 for float disparity
+
+    cv::Mat disp_bm_vis;
+    disp_bm.convertTo(disp_bm_vis, CV_8U, 255.0 / (16.0 * 64));
+    show("3 — StereoBM disparity", disp_bm_vis);
+
+    // ── StereoSGBM ────────────────────────────────────────────────────────────
+    std::cout << "\n--- StereoSGBM ---\n";
+    const int bsz = 5;
+    cv::Mat disp_sgbm = StereoSGBM{}
+        .min_disparity(0)              // minimum disparity (default: 0)
+        .num_disparities(64)           // disparity range (default: 64)
+        .block_size(bsz)               // block size, must be odd (default: 3)
+        .p1(8  * bsz * bsz)           // smoothness penalty 1 (default: 0)
+        .p2(32 * bsz * bsz)           // smoothness penalty 2 (default: 0)
+        .mode(cv::StereoSGBM::MODE_SGBM_3WAY)  // (default: MODE_SGBM)
+        (left_gray, right_gray);       // returns CV_16S
+
+    cv::Mat disp_sgbm_vis;
+    disp_sgbm.convertTo(disp_sgbm_vis, CV_8U, 255.0 / (16.0 * 64));
+    show("4 — StereoSGBM disparity (higher quality)", disp_sgbm_vis);
+
+    // ── ReprojectTo3D ─────────────────────────────────────────────────────────
+    std::cout << "\n--- ReprojectTo3D ---\n";
+    // Synthetic Q matrix (normally from StereoRectify)
+    double f = 500.0;
+    cv::Mat Q = (cv::Mat_<double>(4, 4)
+        << 1,  0,  0,   -W / 2.0,
+           0,  1,  0,   -H / 2.0,
+           0,  0,  0,    f,
+           0,  0, 1.0 / 0.05, 0);
+
+    cv::Mat pts3d = ReprojectTo3D{}
+        .handle_missing(false)   // false = keep all points including invalid ones (default)
+        (disp_sgbm, Q);          // returns CV_32FC3 point cloud
+
+    int valid = 0;
+    for (int y = 0; y < pts3d.rows; ++y)
+        for (int x = 0; x < pts3d.cols; ++x)
+            if (!std::isinf(pts3d.at<cv::Vec3f>(y, x)[2])) ++valid;
+    std::cout << "Valid 3-D points: " << valid
+              << " / " << pts3d.rows * pts3d.cols << "\n";
+
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/examples/core/demo_camshift.cpp
+++ b/examples/core/demo_camshift.cpp
@@ -1,0 +1,101 @@
+// examples/core/demo_camshift.cpp
+//
+// Demo: CamShift, MeanShift, PhaseCorrelate
+//
+// Creates a synthetic orange circle on a grey background, generates a second
+// frame with the circle shifted by (30, 20) px. Tracks with CamShift
+// (rotation-aware rotated rect) and MeanShift (axis-aligned rect), then
+// verifies the global frame shift with PhaseCorrelate.
+// Press any key to advance.
+
+#include "improc/core/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::core;
+
+static void show(const std::string& title, const cv::Mat& m) {
+    cv::imshow(title, m);
+    cv::waitKey(0);
+}
+
+int main() {
+    // ── Synthetic scene: orange circle on grey ────────────────────────────────
+    const int W = 320, H = 240;
+    cv::Mat raw1(H, W, CV_8UC3, cv::Scalar(60, 60, 60));
+    cv::circle(raw1, {120, 110}, 40, {30, 120, 220}, -1);  // orange (BGR)
+    Image<BGR> bgr1(raw1);
+
+    cv::Mat raw2(H, W, CV_8UC3, cv::Scalar(60, 60, 60));
+    cv::circle(raw2, {150, 130}, 40, {30, 120, 220}, -1);  // shifted +30, +20
+    Image<BGR> bgr2(raw2);
+
+    show("1 — frame1", bgr1.mat());
+    show("2 — frame2 (circle +30px right, +20px down)", bgr2.mat());
+
+    // ── Build hue histogram from the object ROI in frame1 ────────────────────
+    Image<HSV> hsv1 = bgr1 | ToHSV{};
+    cv::Mat hue1(H, W, CV_8U);
+    int from_to[] = {0, 0};
+    cv::mixChannels({hsv1.mat()}, {hue1}, from_to, 1);
+
+    cv::Rect roi{95, 85, 55, 55};
+    cv::Mat roi_hue = hue1(roi);
+    cv::Mat hist;
+    int histSize = 32;
+    float range[] = {0.f, 180.f};
+    const float* histRange = {range};
+    cv::calcHist(&roi_hue, 1, nullptr, cv::Mat{}, hist, 1, &histSize, &histRange);
+    cv::normalize(hist, hist, 0, 255, cv::NORM_MINMAX);
+
+    // ── Back-project onto frame2 ───────────────────────────────────────────────
+    Image<HSV> hsv2 = bgr2 | ToHSV{};
+    cv::Mat hue2(H, W, CV_8U);
+    cv::mixChannels({hsv2.mat()}, {hue2}, from_to, 1);
+    cv::Mat bp_mat;
+    cv::calcBackProject(&hue2, 1, nullptr, hist, bp_mat, &histRange);
+    Image<Gray> bp{bp_mat};
+
+    // ── CamShift ──────────────────────────────────────────────────────────────
+    std::cout << "\n--- CamShift ---\n";
+    cv::Rect cam_win = roi;
+    CamShiftResult cam = CamShift{}
+        .epsilon(1.0)    // convergence threshold (default: 1.0)
+        .max_iter(10)    // max iterations (default: 10)
+        (bp, cam_win);
+
+    std::cout << "Tracked centre: ("
+              << cam.object.center.x << ", " << cam.object.center.y << ")\n";
+    std::cout << "Expected:       (150, 130)\n";
+    cv::Mat vis1 = raw2.clone();
+    cv::ellipse(vis1, cam.object, {0, 255, 0}, 2);
+    show("3 — CamShift result (green ellipse)", vis1);
+
+    // ── MeanShift ─────────────────────────────────────────────────────────────
+    std::cout << "\n--- MeanShift ---\n";
+    cv::Rect ms_win = roi;
+    int iters = MeanShift{}
+        .epsilon(1.0)    // convergence threshold (default: 1.0)
+        .max_iter(10)    // max iterations (default: 10)
+        (bp, ms_win);
+
+    std::cout << "Converged in " << iters << " iterations\n";
+    std::cout << "Window centre: (" << (ms_win.x + ms_win.width / 2)
+              << ", "               << (ms_win.y + ms_win.height / 2) << ")\n";
+    cv::Mat vis2 = raw2.clone();
+    cv::rectangle(vis2, ms_win, {0, 0, 255}, 2);
+    show("4 — MeanShift result (red rect)", vis2);
+
+    // ── PhaseCorrelate ────────────────────────────────────────────────────────
+    std::cout << "\n--- PhaseCorrelate ---\n";
+    Image<Float32> f1 = (bgr1 | ToGray{}) | ToFloat32{};
+    Image<Float32> f2 = (bgr2 | ToGray{}) | ToFloat32{};
+
+    PhaseCorrelateResult pc = PhaseCorrelate{}(f1, f2);
+    std::cout << "Detected shift: (" << pc.shift.x << ", " << pc.shift.y << ")\n";
+    std::cout << "Response:       " << pc.response << "  (>0.3 = reliable)\n";
+    std::cout << "Expected:       (30, 20)\n";
+
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/examples/core/demo_optical_flow.cpp
+++ b/examples/core/demo_optical_flow.cpp
@@ -1,0 +1,102 @@
+// examples/core/demo_optical_flow.cpp
+//
+// Demo: SparseLKFlow (Lucas-Kanade), DenseFarnebackFlow, DenseDISFlow
+//
+// Creates two synthetic frames shifted by (20, 10) px, tracks with all three
+// methods, prints flow estimates, shows dense flow as an HSV colour map.
+// Press any key to advance.
+
+#include "improc/core/pipeline.hpp"
+#include <opencv2/highgui.hpp>
+#include <iostream>
+
+using namespace improc::core;
+
+static void show(const std::string& title, const cv::Mat& m) {
+    cv::imshow(title, m);
+    cv::waitKey(0);
+}
+
+static cv::Mat flow_to_hsv(const Image<Flow>& flow) {
+    cv::Mat planes[2];
+    cv::split(flow.mat(), planes);
+    cv::Mat mag, ang;
+    cv::cartToPolar(planes[0], planes[1], mag, ang, true);
+    cv::normalize(mag, mag, 0, 255, cv::NORM_MINMAX);
+    mag.convertTo(mag, CV_8U);
+    cv::Mat hue; ang.convertTo(hue, CV_8U, 255.0 / 360.0);
+    cv::Mat hsv, bgr;
+    cv::merge(std::vector<cv::Mat>{hue, cv::Mat::ones(mag.size(), CV_8U) * 255, mag}, hsv);
+    cv::cvtColor(hsv, bgr, cv::COLOR_HSV2BGR);
+    return bgr;
+}
+
+int main() {
+    // ── Synthetic frame pair: frame2 = frame1 shifted right 20px, down 10px ──
+    cv::Mat raw(240, 320, CV_8UC3, cv::Scalar(40, 40, 40));
+    cv::rectangle(raw, {60,  60},  {140, 140}, {200, 100,  50}, -1);
+    cv::circle(raw,    {220, 120}, 45,          { 50, 150, 200}, -1);
+
+    const double gt_dx = 20.0, gt_dy = 10.0;
+    cv::Mat M = (cv::Mat_<double>(2, 3) << 1, 0, gt_dx, 0, 1, gt_dy);
+    cv::Mat raw2;
+    cv::warpAffine(raw, raw2, M, raw.size());
+
+    Image<BGR>  bgr1(raw), bgr2(raw2);
+    Image<Gray> gray1 = bgr1 | ToGray{};
+    Image<Gray> gray2 = bgr2 | ToGray{};
+
+    show("1 — frame1", bgr1.mat());
+    show("2 — frame2 (shifted +20px right, +10px down)", bgr2.mat());
+
+    // ── Sparse Lucas-Kanade ───────────────────────────────────────────────────
+    std::cout << "\n--- SparseLKFlow ---\n";
+    std::vector<cv::Point2f> pts1;
+    cv::goodFeaturesToTrack(gray1.mat(), pts1, 100, 0.01, 10);
+
+    SparseLKFlowResult lk = SparseLKFlow{}
+        .win_size({21, 21})  // search window per pyramid level (default: {21,21})
+        .max_level(3)        // pyramid depth (default: 3)
+        .max_iter(30)        // max LK iterations (default: 30)
+        .epsilon(0.01)       // convergence threshold (default: 0.01)
+        (gray1, gray2, pts1);
+
+    double sum_dx = 0, sum_dy = 0;
+    int tracked = 0;
+    for (std::size_t i = 0; i < lk.status.size(); ++i) {
+        if (!lk.status[i]) continue;
+        sum_dx += lk.points[i].x - pts1[i].x;
+        sum_dy += lk.points[i].y - pts1[i].y;
+        ++tracked;
+    }
+    if (tracked)
+        std::cout << "Avg shift: dx=" << sum_dx / tracked
+                  << "  dy=" << sum_dy / tracked
+                  << "  (expected dx=" << gt_dx << ", dy=" << gt_dy << ")\n";
+
+    // ── Dense Farneback ───────────────────────────────────────────────────────
+    std::cout << "\n--- DenseFarnebackFlow ---\n";
+    Image<Flow> farne = DenseFarnebackFlow{}
+        .pyr_scale(0.5)    // pyramid scale per level (default: 0.5)
+        .levels(3)         // pyramid depth (default: 3)
+        .win_size(15)      // averaging window size (default: 15)
+        .iterations(3)     // iterations per level (default: 3)
+        .poly_n(5)         // polynomial neighbourhood (default: 5)
+        .poly_sigma(1.2)   // Gaussian sigma for poly expansion (default: 1.2)
+        (gray1, gray2);
+    cv::Scalar fmean = cv::mean(farne.mat());
+    std::cout << "Mean flow: dx=" << fmean[0] << "  dy=" << fmean[1] << "\n";
+    show("3 — Farneback flow (HSV colour wheel)", flow_to_hsv(farne));
+
+    // ── Dense DIS ─────────────────────────────────────────────────────────────
+    std::cout << "\n--- DenseDISFlow (Fast preset) ---\n";
+    Image<Flow> dis = DenseDISFlow{}
+        .preset(DenseDISFlow::Preset::Fast)  // balanced speed/quality (default)
+        (gray1, gray2);
+    cv::Scalar dmean = cv::mean(dis.mat());
+    std::cout << "DIS mean flow: dx=" << dmean[0] << "  dy=" << dmean[1] << "\n";
+    show("4 — DIS flow (HSV colour wheel)", flow_to_hsv(dis));
+
+    std::cout << "Done.\n";
+    return 0;
+}

--- a/include/improc/core/pipeline.hpp
+++ b/include/improc/core/pipeline.hpp
@@ -24,7 +24,12 @@
  * Add, Subtract, Multiply, Divide,
  * IntegralImage, MinMaxLoc, MeanStdDev, CountNonZero, Reduce,
  * DetectFAST, DetectBlob, DetectMSER, DetectLines, DetectQR, DetectBarcode,
- * DetectFaceYN, RecognizeFace)
+ * DetectFaceYN, RecognizeFace,
+ * EdgePreservingFilter, DetailEnhance, Stylize, PencilSketch, SeamlessClone,
+ * NLMeansDenoisingMulti, MergeHDR, ToneMap, Stitch,
+ * PSNR, SSIM, GMSD, MSE,
+ * AverageHash, PHash, MarrHildrethHash, RadialVarianceHash,
+ * ColorMomentHash, BlockMeanHash)
  * and the generic `operator|` pipeline dispatch.
  *
  * @code


### PR DESCRIPTION
## Summary
- Updated the `@brief` doc comment in `include/improc/core/pipeline.hpp` to include all 20 ops added in v0.10.0
- Added photo ops (EdgePreservingFilter, DetailEnhance, Stylize, PencilSketch, SeamlessClone, NLMeansDenoisingMulti, MergeHDR, ToneMap)
- Added stitching op (Stitch)
- Added quality assessment ops (PSNR, SSIM, GMSD, MSE)
- Added image hashing ops (AverageHash, PHash, MarrHildrethHash, RadialVarianceHash, ColorMomentHash, BlockMeanHash)

## Verification
- Build completes without errors
- Documentation comment is correctly formatted for Doxygen
