### PR TITLE
chore(github): add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- 2-4 bullets: what changed and why -->
+
+-
+-
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] `feat` — new op / feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — tutorial, example, or doc comment
+- [ ] `bench` — benchmark
+- [ ] `chore` — version bump, CI, build system, release
+
+## Ops / APIs added or changed
+
+<!-- List new or modified op names, or "n/a" for pure docs/chore -->
+
+| Op | Namespace | Header |
+|---|---|---|
+| | | |
+
+## Test plan
+
+- [ ] `cmake --build build --parallel` — no errors
+- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
+- [ ] New ops have GTest coverage in `tests/`
+- [ ] New examples build and run without crashing
+
+## Pre-existing test failures (if any)
+
+<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->
+
+None
+
+## CHANGELOG updated?
+
+- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
+- [ ] N/a — docs / chore only


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` so every new PR on GitHub pre-fills with a structured body
- Template covers: type of change, ops/APIs table, test checklist, pre-existing failures note, CHANGELOG checkbox

## Type of change

- [x] `chore` — CI, build system, release

## Ops / APIs added or changed

n/a

## Test plan

- [x] `cmake --build build --parallel` — no errors
- [x] `cd build && ctest --output-on-failure` — all tests pass (VideoWriterTest failures pre-existing)
- [x] No new C++ code

## Pre-existing test failures (if any)

`VideoWriterTest` (6 tests) — subprocess abort due to macOS FFmpeg mpeg4 encoder timebase issue, unrelated to this PR

## CHANGELOG updated?

- [x] N/a — chore only
