### PR TITLE
fix(cmake): rename project from improc__ to improc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.30)
-project(improc__ VERSION 0.11.0)
+project(improc VERSION 0.11.0)
 
 if(APPLE)
     string(REPLACE "--as-needed" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")


### PR DESCRIPTION
## Summary

- `project(improc__ VERSION 0.11.0)` → `project(improc VERSION 0.11.0)`
- The double underscore was a holdover from the early days when the directory was named `improc++` and `+` isn't a valid CMake identifier character
- The library target, install exports, CMake namespace, and config file templates were already consistently using `improc` — only the `project()` line was inconsistent

## Type of change

- [x] `fix` — bug fix

## Ops / APIs added or changed

n/a

## Test plan

- [x] `cmake --build build --parallel` — no errors (reconfigured + built clean)
- [x] `cd build && ctest --output-on-failure` — all tests pass
- [x] No C++ code changed

## Pre-existing test failures (if any)

`VideoWriterTest` (6 tests) — pre-existing macOS FFmpeg issue, unrelated

## CHANGELOG updated?

- [x] N/a — single-line CMake rename, no API change
