### PR TITLE
chore(deps): migrate onnxruntime and nlohmann_json from FetchContent to Conan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,15 @@ jobs:
         run: |
           printf "\n[conf]\ntools.system.package_manager:mode=install\ntools.system.package_manager:sudo=True\n" >> ~/.conan2/profiles/default
 
-      - name: Remove OpenCV from Conan requirements (macOS only — Homebrew provides 4.8+)
+      - name: Remove OpenCV and onnxruntime from Conan requirements (macOS — Homebrew provides both)
         if: runner.os == 'macOS'
         run: |
           python3 -c "
           import pathlib
           f = pathlib.Path('conandata.yml')
-          f.write_text(''.join(l for l in f.read_text().splitlines(keepends=True) if 'opencv' not in l.lower()))
+          skip = {'opencv', 'onnxruntime'}
+          f.write_text(''.join(l for l in f.read_text().splitlines(keepends=True)
+              if not any(s in l.lower() for s in skip)))
           "
 
       - name: Cache Conan packages
@@ -59,21 +61,15 @@ jobs:
           key: conan-${{ matrix.os }}-${{ hashFiles('conandata.yml') }}
           restore-keys: conan-${{ matrix.os }}-
 
-      - name: Cache ONNX Runtime download
-        uses: actions/cache@v4
-        with:
-          path: ~/.cmake-fetchcontent
-          key: ort-${{ matrix.os }}-1.20.1
-
       - name: Install system build dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y --no-install-recommends \
             build-essential ffmpeg
 
-      - name: Install system OpenCV (macOS)
+      - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install opencv
+        run: brew install opencv onnxruntime
 
       - name: Configure CMake
         run: |
@@ -94,7 +90,6 @@ jobs:
             -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="conan_provider.cmake" \
             -DCONAN_COMMAND=$(which conan) \
             -DCMAKE_BUILD_TYPE=Release \
-            -DFETCHCONTENT_BASE_DIR=$HOME/.cmake-fetchcontent \
             "-DCONAN_INSTALL_ARGS=${CONAN_ARGS}" \
             $EXTRA \
             -B build .
@@ -110,11 +105,6 @@ jobs:
 
       - name: Run tests
         run: |
-          ORT_LIB=$(find $HOME/.cmake-fetchcontent -name "libonnxruntime*" -not -name "*.dSYM" | head -1 | xargs dirname 2>/dev/null || true)
-          if [ -n "$ORT_LIB" ]; then
-            export LD_LIBRARY_PATH="$ORT_LIB:${LD_LIBRARY_PATH:-}"
-            export DYLD_LIBRARY_PATH="$ORT_LIB:${DYLD_LIBRARY_PATH:-}"
-          fi
           if [ "$(uname)" = "Linux" ]; then
             # FFmpeg disabled in Conan OpenCV build (libwebp target conflict);
             # exclude all tests that read/write video files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- `onnxruntime` dependency migrated from FetchContent binary download to Conan (`onnxruntime/1.24.4`), upgrading from v1.20.1; `eigen` upgraded to 5.0.1 to satisfy onnxruntime's requirements
+- `nlohmann_json` dependency migrated from FetchContent to Conan (`nlohmann_json/3.11.3`)
+- `IMPROC_WITH_ONNX` CMake option removed — ONNX Runtime is now always available via Conan
+- `opencv` built without protobuf (resolves Conan graph conflict; Caffe model loading was unused)
+
 ---
 
 ## [0.11.0] — 2026-05-28

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,10 @@ target_include_directories(improc PUBLIC
 
 target_link_libraries(improc PUBLIC
         opencv::opencv
-        onnxruntime::onnxruntime
         $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>
+)
+target_link_libraries(improc PRIVATE
+        onnxruntime::onnxruntime
 )
 
 # === depthai-core (optional) ===

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Dependencies
 find_package(OpenCV REQUIRED)
 find_package(GTest REQUIRED)
+find_package(onnxruntime REQUIRED)
+find_package(nlohmann_json REQUIRED)
 
 # Compatibility shim: system OpenCV uses OpenCV_LIBS, Conan uses opencv::opencv
 if(NOT TARGET opencv::opencv)
@@ -22,63 +24,8 @@ if(NOT TARGET opencv::opencv)
     target_include_directories(opencv::opencv INTERFACE ${OpenCV_INCLUDE_DIRS})
 endif()
 
-# === ONNX Runtime (optional, CPU + CoreML on Apple) ===
-option(IMPROC_WITH_ONNX "Build with ONNX Runtime inference support" ON)
-
 # === OAK-D depth camera support (optional) ===
 option(IMPROC_WITH_DEPTHAI "Build with OAK-D support via depthai-core v2" OFF)
-
-if(IMPROC_WITH_ONNX)
-    set(ORT_VERSION "1.20.1")
-
-    if(APPLE)
-        if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-            set(_ort_archive "onnxruntime-osx-arm64-${ORT_VERSION}.tgz")
-        else()
-            set(_ort_archive "onnxruntime-osx-x86_64-${ORT_VERSION}.tgz")
-        endif()
-    elseif(UNIX)
-        set(_ort_archive "onnxruntime-linux-x64-${ORT_VERSION}.tgz")
-    else()
-        message(FATAL_ERROR "IMPROC_WITH_ONNX: unsupported platform")
-    endif()
-
-    include(FetchContent)
-    FetchContent_Declare(onnxruntime
-        URL      "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${_ort_archive}"
-        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-    )
-    FetchContent_MakeAvailable(onnxruntime)
-
-    # The archive extracts with a named top-level directory inside SOURCE_DIR
-    file(GLOB _ort_candidates LIST_DIRECTORIES true "${onnxruntime_SOURCE_DIR}/onnxruntime-*")
-    if(_ort_candidates)
-        list(GET _ort_candidates 0 ORT_ROOT)
-    else()
-        set(ORT_ROOT "${onnxruntime_SOURCE_DIR}")
-    endif()
-
-    find_library(ORT_LIBRARY NAMES onnxruntime
-        PATHS "${ORT_ROOT}/lib" NO_DEFAULT_PATH REQUIRED)
-
-    add_library(onnxruntime::onnxruntime SHARED IMPORTED GLOBAL)
-    set_target_properties(onnxruntime::onnxruntime PROPERTIES
-        IMPORTED_LOCATION             "${ORT_LIBRARY}"
-        IMPORTED_NO_SONAME            TRUE
-        INTERFACE_INCLUDE_DIRECTORIES "${ORT_ROOT}/include"
-    )
-
-    message(STATUS "ONNX Runtime ${ORT_VERSION}: ${ORT_LIBRARY}")
-endif()
-
-# === nlohmann/json (header-only, FetchContent) ===
-include(FetchContent)
-FetchContent_Declare(nlohmann_json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-set(JSON_BuildTests OFF CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(nlohmann_json)
 
 # === improc LIBRARY ===
 file(GLOB_RECURSE IMPROC_HEADERS CONFIGURE_DEPENDS include/improc/**/*.hpp)
@@ -93,12 +40,8 @@ target_include_directories(improc PUBLIC
 
 target_link_libraries(improc PUBLIC
         opencv::opencv
-        $<$<BOOL:${IMPROC_WITH_ONNX}>:onnxruntime::onnxruntime>
+        onnxruntime::onnxruntime
         $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>
-)
-
-target_compile_definitions(improc PUBLIC
-        $<$<BOOL:${IMPROC_WITH_ONNX}>:IMPROC_WITH_ONNX>
 )
 
 # === depthai-core (optional) ===
@@ -162,11 +105,6 @@ file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS tests/*.cpp)
 
 add_executable(improc_tests ${TEST_SOURCES})
 target_link_libraries(improc_tests PRIVATE improc GTest::gtest GTest::gtest_main)
-
-if(IMPROC_WITH_ONNX)
-    list(APPEND CMAKE_BUILD_RPATH "${ORT_ROOT}/lib")
-    set_property(TARGET improc_tests APPEND PROPERTY BUILD_RPATH "${ORT_ROOT}/lib")
-endif()
 
 include(GoogleTest)
 gtest_discover_tests(improc_tests)
@@ -448,11 +386,8 @@ add_executable(demo_aruco examples/calib/demo_aruco.cpp)
 target_link_libraries(demo_aruco PRIVATE improc)
 
 # ONNX inference demo
-if(IMPROC_WITH_ONNX)
-    add_executable(demo_onnx_inference examples/ml/demo_onnx_inference.cpp)
-    target_link_libraries(demo_onnx_inference PRIVATE improc)
-    set_property(TARGET demo_onnx_inference APPEND PROPERTY BUILD_RPATH "${ORT_ROOT}/lib")
-endif()
+add_executable(demo_onnx_inference examples/ml/demo_onnx_inference.cpp)
+target_link_libraries(demo_onnx_inference PRIVATE improc)
 
 # Benchmarks (opt-in: cmake -DIMPROC_BENCHMARKS=ON ...)
 if(IMPROC_BENCHMARKS)

--- a/cmake/improcConfig.cmake.in
+++ b/cmake/improcConfig.cmake.in
@@ -3,10 +3,5 @@
 include(CMakeFindDependencyMacro)
 find_dependency(OpenCV REQUIRED)
 
-# Note: ONNX Runtime is currently fetched at build time via FetchContent.
-# Downstream consumers using find_package(improc) need ONNX Runtime in their
-# path separately if they use improc::onnx features. Resolving this fully is
-# part of the v1.0.0 Conan Center / vcpkg milestone.
-
 include("${CMAKE_CURRENT_LIST_DIR}/improcTargets.cmake")
 check_required_components(improc)

--- a/conandata.yml
+++ b/conandata.yml
@@ -3,5 +3,7 @@
 
 requirements:
   - "gtest/1.16.0"
-  - "eigen/3.4.0"
+  - "eigen/5.0.1"
   - "opencv/4.8.1"
+  - "onnxruntime/1.24.4"
+  - "nlohmann_json/3.11.3"

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,3 +18,12 @@ class ConanApplication(ConanFile):
         requirements = self.conan_data.get('requirements', [])
         for requirement in requirements:
             self.requires(requirement)
+
+    def configure(self):
+        self.options["opencv"].with_protobuf = False
+        # Disable opencv's eigen to resolve conflict with onnxruntime which needs eigen >= 5.0.1
+        # We use eigen/5.0.1 as an explicit requirement instead
+        try:
+            self.options["opencv"].with_eigen = False
+        except:
+            pass  # Option might not exist in all versions

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,5 +25,5 @@ class ConanApplication(ConanFile):
         # We use eigen/5.0.1 as an explicit requirement instead
         try:
             self.options["opencv"].with_eigen = False
-        except:
+        except Exception:
             pass  # Option might not exist in all versions


### PR DESCRIPTION
## Summary
- Remove 70-line FetchContent block that downloaded a pre-built ORT binary from GitHub — replaced with `find_package(onnxruntime REQUIRED)` via Conan
- Remove FetchContent for `nlohmann_json` — replaced with `find_package(nlohmann_json REQUIRED)` via Conan
- Resolve Conan dependency conflict: `opencv/4.8.1` + `onnxruntime/1.24.4` both need protobuf — disabled protobuf in OpenCV (used only for Caffe model loading, which improc++ does not use); disable opencv's bundled eigen to use `eigen/5.0.1` from Conan (required by onnxruntime)
- Remove `IMPROC_WITH_ONNX` CMake option — ORT is now always available (was always-ON anyway; `IMPROC_WITH_ONNX` define was not used in any source file)
- Link `onnxruntime::onnxruntime` as `PRIVATE` (ORT types are fully hidden behind pimpl in `onnx_session.cpp`)
- Clean stale FetchContent comment from `cmake/improcConfig.cmake.in`

## Type of change
- [x] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed
| Op | Namespace | Header |
|---|---|---|
| n/a — build system only | | |

## Test plan
- [x] `cmake --build build --parallel` — no errors
- [x] `cd build && ctest --output-on-failure -R "Onnx"` — 30/30 ONNX tests pass (real .onnx inference)
- [x] `cd build && ctest --output-on-failure` — 1565/1570 pass; 5 VideoWriterTest failures are pre-existing macOS FFmpeg codec issue

## Pre-existing test failures (if any)
VideoWriterTest (5 tests) — macOS 26.5 FFmpeg mpeg4 timebase issue, unrelated to this PR.

## CHANGELOG updated?
- [x] Yes — new `### Changed` entry under `## [Unreleased]`