### PR TITLE
docs(v0.12.0): 100% Doxygen coverage across all 51 public headers

### DIFF
--- a/include/improc/calib/ops/aruco.hpp
+++ b/include/improc/calib/ops/aruco.hpp
@@ -15,12 +15,24 @@ using improc::core::Gray;
 
 // ── ArucoDict ─────────────────────────────────────────────────────────────────
 
+/**
+ * @brief Retrieves a predefined ArUco dictionary by type.
+ *
+ * @code
+ * auto dict = ArucoDict()(cv::aruco::DICT_4X4_50);
+ * @endcode
+ */
 struct ArucoDict {
     cv::aruco::Dictionary operator()(cv::aruco::PredefinedDictionaryType type) const;
 };
 
 // ── DetectAruco ───────────────────────────────────────────────────────────────
 
+/**
+ * @brief Detects ArUco markers in a BGR or Gray image.
+ *
+ * @return `ArucoResult` containing corners, IDs, and rejected candidates.
+ */
 struct DetectAruco {
     ArucoResult operator()(Image<BGR>  img, const cv::aruco::Dictionary& dict) const;
     ArucoResult operator()(Image<Gray> img, const cv::aruco::Dictionary& dict) const;
@@ -28,8 +40,11 @@ struct DetectAruco {
 
 // ── DrawAruco ─────────────────────────────────────────────────────────────────
 
+/**
+ * @brief Draws ArUco marker outlines, IDs, and optionally 3-D pose axes onto an image.
+ */
 struct DrawAruco {
-    /// Sets the axis length used when drawing 3D axes (world units). Default: 0.05.
+    /// @brief Sets the axis length used when drawing 3-D frames (default: 0.05 world units).
     DrawAruco& axis_length(float l) { axis_length_ = l; return *this; }
 
     // Overload 1: draws marker outlines + ID numbers only.
@@ -49,12 +64,15 @@ private:
 
 // ── GenerateAruco ─────────────────────────────────────────────────────────────
 
+/**
+ * @brief Renders a single ArUco marker as a square grayscale image.
+ */
 struct GenerateAruco {
-    /// Sets the number of border bits. Default: 1.
+    /// @brief Sets the number of border bits (default: 1).
     GenerateAruco& border_bits(int b) { border_bits_ = b; return *this; }
 
-    // Returns a square Gray image of size side_pixels × side_pixels.
-    // Throws std::invalid_argument if id < 0 or side_pixels < 1.
+    /// @brief Renders marker `id` from `dict` at `side_pixels × side_pixels`.
+    /// @throws std::invalid_argument if `id` < 0 or `side_pixels` < 1.
     Image<Gray> operator()(const cv::aruco::Dictionary& dict,
                            int id,
                            int side_pixels) const;
@@ -65,12 +83,20 @@ private:
 
 // ── ArucoPose ─────────────────────────────────────────────────────────────────
 
+/**
+ * @brief Estimates the 6-DoF pose of each detected ArUco marker via `cv::solvePnP`.
+ *
+ * Object points are defined with the marker centre at the origin:
+ * top-left = (-half, half, 0), top-right = (half, half, 0),
+ * bottom-right = (half, -half, 0), bottom-left = (-half, -half, 0).
+ */
 struct ArucoPose {
-    // Estimates pose per detected marker via cv::solvePnP (not deprecated estimatePoseSingleMarkers).
-    // Object points per marker (half = marker_length/2):
-    //   top-left=(-half, half, 0), top-right=(half, half, 0),
-    //   bottom-right=(half, -half, 0), bottom-left=(-half, -half, 0)
-    // Returns one ArucoPoseResult per detected marker (same order as ArucoResult).
+    /// @brief Estimates poses for all markers in `result`.
+    /// @param result       Detected markers from `DetectAruco`.
+    /// @param K            3×3 camera matrix.
+    /// @param dist         Distortion coefficients.
+    /// @param marker_length Physical marker side length in world units.
+    /// @return One `ArucoPoseResult` per detected marker, in the same order as `result`.
     std::vector<ArucoPoseResult> operator()(const ArucoResult& result,
                                             const cv::Mat& K,
                                             const cv::Mat& dist,
@@ -79,16 +105,29 @@ struct ArucoPose {
 
 // ── CharucoBoard ──────────────────────────────────────────────────────────────
 
+/**
+ * @brief Detects ChArUco board corners with optional subpixel refinement.
+ *
+ * @code
+ * auto result = CharucoBoard()
+ *     .board_size({5, 7})
+ *     .square_length(0.04f)
+ *     .marker_length(0.02f)
+ *     (img, dict);
+ * @endcode
+ */
 struct CharucoBoard {
-    // board_size: number of squares (cols × rows), e.g. {5, 7} = 5 columns, 7 rows.
+    /// @brief Sets the board dimensions as (cols, rows) of chessboard squares.
     CharucoBoard& board_size(cv::Size s) { board_size_    = s; has_size_ = true; return *this; }
+    /// @brief Sets the physical square side length in world units (e.g. metres).
     CharucoBoard& square_length(float s) { square_length_ = s; return *this; }
+    /// @brief Sets the physical ArUco marker side length in world units.
     CharucoBoard& marker_length(float m) { marker_length_ = m; return *this; }
 
-    // Throws std::invalid_argument if board_size not set, square_length <= 0, or marker_length <= 0.
-    // Overload 1: basic detection, no subpixel refinement.
+    /// @brief Detects board corners (no subpixel refinement).
+    /// @throws std::invalid_argument if `board_size` not set, or lengths <= 0.
     CharucoResult operator()(Image<BGR> img, const cv::aruco::Dictionary& dict) const;
-    // Overload 2: enables subpixel corner refinement via CharucoParameters.
+    /// @brief Detects board corners with subpixel refinement using camera intrinsics.
     CharucoResult operator()(Image<BGR> img,
                              const cv::aruco::Dictionary& dict,
                              const cv::Mat& K,

--- a/include/improc/calib/ops/calib_types.hpp
+++ b/include/improc/calib/ops/calib_types.hpp
@@ -5,37 +5,56 @@
 
 namespace improc::calib {
 
+/**
+ * @brief Result of `cv::findChessboardCorners`.
+ */
 struct FindChessboardResult {
     bool found = false;
     std::vector<cv::Point2f> corners;
 };
 
+/**
+ * @brief Output of `CalibrateCamera`: intrinsics, distortion, per-view poses, and RMS error.
+ */
 struct CalibrationResult {
-    cv::Mat camera_matrix;
-    cv::Mat dist_coeffs;
-    std::vector<cv::Mat> rvecs;
-    std::vector<cv::Mat> tvecs;
-    double rms = 0.0;
+    cv::Mat camera_matrix;         ///< 3×3 CV_64F camera intrinsic matrix.
+    cv::Mat dist_coeffs;           ///< Distortion coefficients (OpenCV convention).
+    std::vector<cv::Mat> rvecs;    ///< Per-view rotation vectors.
+    std::vector<cv::Mat> tvecs;    ///< Per-view translation vectors.
+    double rms = 0.0;              ///< RMS reprojection error in pixels.
 };
 
+/**
+ * @brief Undistortion maps produced by `cv::initUndistortRectifyMap`.
+ * Pass both maps to `cv::remap` (or `improc::core::Remap`) to undistort images.
+ */
 struct UndistortMapResult {
-    cv::Mat map1; ///< x-map (CV_32FC1); use with Remap
-    cv::Mat map2; ///< y-map (CV_32FC1); use with Remap
+    cv::Mat map1; ///< x-map (CV_32FC1); pass to `Remap`.
+    cv::Mat map2; ///< y-map (CV_32FC1); pass to `Remap`.
 };
 
+/**
+ * @brief Result of `SolvePnP`: success flag and pose vectors.
+ */
 struct PnPResult {
-    bool success = false;
-    cv::Mat rvec;
-    cv::Mat tvec;
+    bool success = false; ///< True if PnP converged.
+    cv::Mat rvec;         ///< 3×1 rotation vector (Rodrigues).
+    cv::Mat tvec;         ///< 3×1 translation vector.
 };
 
+/**
+ * @brief Result of `SolvePnPRansac`: pose vectors and inlier mask.
+ */
 struct PnPRansacResult {
-    bool success = false;
-    cv::Mat rvec;
-    cv::Mat tvec;
-    cv::Mat inliers; ///< CV_32S — indices of inlier correspondences
+    bool success = false; ///< True if RANSAC found a valid pose.
+    cv::Mat rvec;         ///< 3×1 rotation vector (Rodrigues).
+    cv::Mat tvec;         ///< 3×1 translation vector.
+    cv::Mat inliers;      ///< CV_32S — indices of inlier correspondences.
 };
 
+/**
+ * @brief Output of `StereoCalibrate`: per-camera intrinsics, relative pose, and epipolar matrices.
+ */
 struct StereoCalibrationResult {
     cv::Mat K1;    ///< 3×3 CV_64F — left camera intrinsics
     cv::Mat dist1; ///< distortion coefficients, left camera
@@ -48,6 +67,9 @@ struct StereoCalibrationResult {
     double rms = 0.0;
 };
 
+/**
+ * @brief Output of `StereoRectify`: rectification transforms, projection matrices, and Q matrix.
+ */
 struct StereoRectifyResult {
     cv::Mat R1, R2;        ///< 3×3 rectification transforms
     cv::Mat P1, P2;        ///< 3×4 projection matrices in rectified space
@@ -56,34 +78,52 @@ struct StereoRectifyResult {
     cv::Rect validROI2;    ///< valid pixel region after rectification, right
 };
 
+/**
+ * @brief Fundamental matrix F and inlier mask from `FindFundamentalMat`.
+ */
 struct FundamentalMatResult {
     cv::Mat F;    ///< 3×3 CV_64F fundamental matrix
     cv::Mat mask; ///< CV_8U — 1 = inlier, 0 = outlier
 };
 
+/**
+ * @brief Essential matrix E and inlier mask from `FindEssentialMat`.
+ */
 struct EssentialMatResult {
     cv::Mat E;    ///< 3×3 CV_64F essential matrix
     cv::Mat mask; ///< CV_8U — 1 = inlier, 0 = outlier
 };
 
+/**
+ * @brief Rotation and (unit) translation recovered from an essential matrix.
+ */
 struct RecoverPoseResult {
-    cv::Mat R;        ///< 3×3 rotation matrix
-    cv::Mat t;        ///< 3×1 translation vector (unit length)
-    int inliers = 0;
+    cv::Mat R;        ///< 3×3 rotation matrix.
+    cv::Mat t;        ///< 3×1 translation vector (unit length).
+    int inliers = 0;  ///< Number of inlier correspondences.
 };
 
+/**
+ * @brief Detected ArUco markers: corner positions, IDs, and rejected candidates.
+ */
 struct ArucoResult {
     std::vector<std::vector<cv::Point2f>> corners;  ///< 4 corners per detected marker
     std::vector<int>                      ids;      ///< detected marker IDs (one per corners entry)
     std::vector<std::vector<cv::Point2f>> rejected; ///< corner candidates that failed validation
 };
 
+/**
+ * @brief Per-marker pose: ID, rotation vector, and translation vector.
+ */
 struct ArucoPoseResult {
     int     id;   ///< marker ID (from ArucoResult)
     cv::Mat rvec; ///< 3×1 rotation vector
     cv::Mat tvec; ///< 3×1 translation vector
 };
 
+/**
+ * @brief Result of `CharucoBoard`: ChArUco corners and detected ArUco markers.
+ */
 struct CharucoResult {
     std::vector<cv::Point2f>              charuco_corners; ///< interpolated ChArUco board corners
     std::vector<int>                      charuco_ids;     ///< board corner IDs (per charuco_corners entry)

--- a/include/improc/calib/ops/calibrate.hpp
+++ b/include/improc/calib/ops/calibrate.hpp
@@ -6,9 +6,11 @@
 
 namespace improc::calib {
 
-// Generates object points for one flat chessboard view (Z=0 plane).
-// board_size = inner corners; square_size in any consistent unit.
-// Returns board_size.width × board_size.height points.
+/// @brief Generates 3-D object points for a flat chessboard (Z = 0 plane).
+/// @param board_size Inner corner count; `board_size.width × board_size.height` points are returned.
+/// @param square_size Physical side length of one square in any consistent unit.
+/// @return `board_size.width * board_size.height` points in row-major order.
+/// @throws std::invalid_argument if any dimension of `board_size` <= 0 or `square_size` <= 0.
 inline std::vector<cv::Point3f> make_chessboard_points(cv::Size board_size,
                                                         float square_size) {
     if (board_size.width <= 0 || board_size.height <= 0)
@@ -25,10 +27,21 @@ inline std::vector<cv::Point3f> make_chessboard_points(cv::Size board_size,
     return pts;
 }
 
+/**
+ * @brief Calibrates a single camera from a set of chessboard views.
+ *
+ * @code
+ * auto pts3d = make_chessboard_points({9, 6}, 0.025f);
+ * std::vector obj_pts(views.size(), pts3d);
+ * auto result = CalibrateCamera()(obj_pts, img_pts, image_size);
+ * @endcode
+ */
 struct CalibrateCamera {
+    /// @brief Sets OpenCV calibration flags (default: 0).
     CalibrateCamera& flags(int f) { flags_ = f; return *this; }
 
-    // Throws std::invalid_argument if sizes mismatch or fewer than 3 views.
+    /// @brief Runs the calibration.
+    /// @throws std::invalid_argument if sizes mismatch or fewer than 3 views are provided.
     CalibrationResult operator()(const std::vector<std::vector<cv::Point3f>>& obj_pts,
                                  const std::vector<std::vector<cv::Point2f>>& img_pts,
                                  cv::Size image_size) const;

--- a/include/improc/calib/ops/epipolar.hpp
+++ b/include/improc/calib/ops/epipolar.hpp
@@ -10,12 +10,19 @@ namespace improc::calib {
 
 // ── FindFundamentalMat ────────────────────────────────────────────────────────
 
+/**
+ * @brief Estimates the fundamental matrix from point correspondences using RANSAC.
+ */
 struct FindFundamentalMat {
+    /// @brief Sets the estimation method (default: `cv::FM_RANSAC`).
     FindFundamentalMat& method(int m)              { method_           = m; return *this; }
+    /// @brief Sets the RANSAC reprojection threshold in pixels (default: 3.0).
     FindFundamentalMat& ransac_threshold(double t) { ransac_threshold_ = t; return *this; }
+    /// @brief Sets the desired solution confidence in [0, 1] (default: 0.99).
     FindFundamentalMat& confidence(double c)       { confidence_       = c; return *this; }
 
-    // Throws std::invalid_argument if pts1.size() != pts2.size() or < 8 points.
+    /// @brief Estimates the fundamental matrix.
+    /// @throws std::invalid_argument if `pts1.size() != pts2.size()` or fewer than 8 points.
     FundamentalMatResult operator()(const std::vector<cv::Point2f>& pts1,
                                     const std::vector<cv::Point2f>& pts2) const;
 
@@ -27,12 +34,20 @@ private:
 
 // ── FindEssentialMat ──────────────────────────────────────────────────────────
 
+/**
+ * @brief Estimates the essential matrix from point correspondences and a shared camera matrix.
+ */
 struct FindEssentialMat {
+    /// @brief Sets the estimation method (default: `cv::RANSAC`).
     FindEssentialMat& method(int m)       { method_     = m; return *this; }
+    /// @brief Sets the RANSAC reprojection threshold in pixels (default: 1.0).
     FindEssentialMat& threshold(double t) { threshold_  = t; return *this; }
+    /// @brief Sets the desired solution confidence in [0, 1] (default: 0.99).
     FindEssentialMat& confidence(double c){ confidence_ = c; return *this; }
 
-    // K: 3×3 camera matrix. Throws if sizes mismatch or < 5 points.
+    /// @brief Estimates the essential matrix.
+    /// @param K 3×3 camera intrinsic matrix (same for both views).
+    /// @throws std::invalid_argument if sizes mismatch or fewer than 5 points.
     EssentialMatResult operator()(const std::vector<cv::Point2f>& pts1,
                                   const std::vector<cv::Point2f>& pts2,
                                   const cv::Mat& K) const;
@@ -45,9 +60,13 @@ private:
 
 // ── RecoverPose ───────────────────────────────────────────────────────────────
 
+/**
+ * @brief Recovers rotation and (unit) translation from an essential matrix via cheirality check.
+ */
 struct RecoverPose {
-    // E: essential matrix; pts1/pts2: same correspondences used to compute E.
-    // K: camera matrix (same for both views if shared intrinsics).
+    /// @brief Recovers R and t.
+    /// @param E Essential matrix (from `FindEssentialMat`).
+    /// @param K Camera matrix (shared intrinsics assumed).
     RecoverPoseResult operator()(const cv::Mat& E,
                                  const std::vector<cv::Point2f>& pts1,
                                  const std::vector<cv::Point2f>& pts2,
@@ -56,9 +75,14 @@ struct RecoverPose {
 
 // ── TriangulatePoints ─────────────────────────────────────────────────────────
 
+/**
+ * @brief Triangulates 3-D points from matched 2-D correspondences and two projection matrices.
+ */
 struct TriangulatePoints {
-    // P1, P2: 3×4 projection matrices.
-    // Returns 4×N homogeneous coordinates (CV_32F).
+    /// @brief Triangulates `pts1`/`pts2` using `P1`/`P2`.
+    /// @param P1 3×4 projection matrix of the first camera.
+    /// @param P2 3×4 projection matrix of the second camera.
+    /// @return 4×N homogeneous point cloud (CV_32F); divide by row 3 for Euclidean coordinates.
     cv::Mat operator()(const cv::Mat& P1, const cv::Mat& P2,
                        const std::vector<cv::Point2f>& pts1,
                        const std::vector<cv::Point2f>& pts2) const;

--- a/include/improc/calib/ops/project.hpp
+++ b/include/improc/calib/ops/project.hpp
@@ -8,7 +8,12 @@
 
 namespace improc::calib {
 
+/**
+ * @brief Projects 3-D object points onto a 2-D image plane.
+ */
 struct ProjectPoints {
+    /// @brief Projects `obj_pts` using the given pose and camera parameters.
+    /// @return Projected 2-D points in pixel coordinates.
     std::vector<cv::Point2f> operator()(const std::vector<cv::Point3f>& obj_pts,
                                         const cv::Mat& rvec,
                                         const cv::Mat& tvec,
@@ -16,10 +21,15 @@ struct ProjectPoints {
                                         const cv::Mat& dist) const;
 };
 
+/**
+ * @brief Solves the Perspective-n-Point problem to recover camera pose from 3-D/2-D correspondences.
+ */
 struct SolvePnP {
+    /// @brief Sets the PnP solver algorithm (default: `cv::SOLVEPNP_ITERATIVE`).
     SolvePnP& method(int m) { method_ = m; return *this; }
 
-    // Throws std::invalid_argument if sizes mismatch or fewer than 4 points.
+    /// @brief Estimates the pose.
+    /// @throws std::invalid_argument if sizes mismatch or fewer than 4 points.
     PnPResult operator()(const std::vector<cv::Point3f>& obj_pts,
                          const std::vector<cv::Point2f>& img_pts,
                          const cv::Mat& K,
@@ -29,12 +39,20 @@ private:
     int method_ = cv::SOLVEPNP_ITERATIVE;
 };
 
+/**
+ * @brief RANSAC-robust variant of `SolvePnP` that also returns an inlier mask.
+ */
 struct SolvePnPRansac {
+    /// @brief Sets the PnP solver algorithm (default: `cv::SOLVEPNP_ITERATIVE`).
     SolvePnPRansac& method(int m)               { method_             = m; return *this; }
+    /// @brief Sets the required solution confidence in [0, 1] (default: 0.99).
     SolvePnPRansac& confidence(double c)        { confidence_         = c; return *this; }
+    /// @brief Sets the maximum reprojection error (pixels) to count a point as inlier (default: 8.0).
     SolvePnPRansac& reprojection_error(float e) { reprojection_error_ = e; return *this; }
+    /// @brief Sets the maximum number of RANSAC iterations (default: 100).
     SolvePnPRansac& iterations(int n)           { iterations_         = n; return *this; }
 
+    /// @brief Estimates the pose with RANSAC.
     PnPRansacResult operator()(const std::vector<cv::Point3f>& obj_pts,
                                const std::vector<cv::Point2f>& img_pts,
                                const cv::Mat& K,

--- a/include/improc/calib/ops/stereo.hpp
+++ b/include/improc/calib/ops/stereo.hpp
@@ -14,19 +14,31 @@ using improc::core::Gray;
 
 // ── StereoCalibrate ───────────────────────────────────────────────────────────
 
+/**
+ * @brief Calibrates a stereo rig from multi-view chessboard correspondences.
+ *
+ * @code
+ * auto result = StereoCalibrate()
+ *     .flags(cv::CALIB_FIX_INTRINSIC)
+ *     .K1(left_K).dist1(left_dist)
+ *     .K2(right_K).dist2(right_dist)
+ *     (obj_pts, img_pts_left, img_pts_right, image_size);
+ * @endcode
+ */
 struct StereoCalibrate {
-    // K1/dist1/K2/dist2 are optional initial estimates; if not set OpenCV initialises them.
-    // Set flags = cv::CALIB_FIX_INTRINSIC when providing pre-calibrated intrinsics.
+    /// @brief Sets initial left camera matrix (optional).
     StereoCalibrate& K1(cv::Mat k)    { K1_    = std::move(k); return *this; }
+    /// @brief Sets initial left distortion coefficients (optional).
     StereoCalibrate& dist1(cv::Mat d) { dist1_ = std::move(d); return *this; }
+    /// @brief Sets initial right camera matrix (optional).
     StereoCalibrate& K2(cv::Mat k)    { K2_    = std::move(k); return *this; }
+    /// @brief Sets initial right distortion coefficients (optional).
     StereoCalibrate& dist2(cv::Mat d) { dist2_ = std::move(d); return *this; }
+    /// @brief Sets OpenCV stereo calibration flags (default: 0).
     StereoCalibrate& flags(int f)     { flags_ = f;             return *this; }
 
-    // Throws std::invalid_argument if:
-    //   - obj_pts / img_pts1 / img_pts2 sizes differ
-    //   - fewer than 3 views
-    //   - image_size dimensions not positive
+    /// @brief Runs stereo calibration.
+    /// @throws std::invalid_argument if point set sizes mismatch, fewer than 3 views, or image_size is non-positive.
     StereoCalibrationResult operator()(
         const std::vector<std::vector<cv::Point3f>>& obj_pts,
         const std::vector<std::vector<cv::Point2f>>& img_pts1,
@@ -40,11 +52,17 @@ private:
 
 // ── StereoRectify ─────────────────────────────────────────────────────────────
 
+/**
+ * @brief Computes rectification transforms, projection matrices, and disparity-to-depth matrix Q.
+ */
 struct StereoRectify {
+    /// @brief Sets the free scaling parameter in [-1, 1] (default: -1 = OpenCV default).
     StereoRectify& alpha(double a)            { alpha_          = a; return *this; }
+    /// @brief Sets the new image size after rectification (default: {0,0} = same as input).
     StereoRectify& new_image_size(cv::Size s) { new_image_size_ = s; return *this; }
 
-    // Throws std::invalid_argument if any of K1/dist1/K2/dist2/R/T is empty.
+    /// @brief Computes stereo rectification.
+    /// @throws std::invalid_argument if any of the input matrices is empty.
     StereoRectifyResult operator()(const cv::Mat& K1, const cv::Mat& dist1,
                                    const cv::Mat& K2, const cv::Mat& dist2,
                                    const cv::Mat& R,  const cv::Mat& T,
@@ -57,12 +75,18 @@ private:
 
 // ── StereoBM ──────────────────────────────────────────────────────────────────
 
+/**
+ * @brief Block-matching stereo disparity computation.
+ * @return CV_16S disparity map. Divide values by 16 for actual disparity in pixels.
+ */
 struct StereoBM {
+    /// @brief Sets the number of disparities (must be divisible by 16; default: 16).
     StereoBM& num_disparities(int n) { num_disparities_ = n; return *this; }
+    /// @brief Sets the block size (must be odd; default: 15).
     StereoBM& block_size(int s)      { block_size_      = s; return *this; }
 
-    // Returns CV_16S disparity map; divide by 16.0 for actual disparity values.
-    // Throws std::invalid_argument if left/right sizes differ.
+    /// @brief Computes the disparity map.
+    /// @throws std::invalid_argument if `left` and `right` have different sizes.
     cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
 
 private:
@@ -72,16 +96,26 @@ private:
 
 // ── StereoSGBM ────────────────────────────────────────────────────────────────
 
+/**
+ * @brief Semi-global block-matching stereo disparity computation (Hirschmuller).
+ * @return CV_16S disparity map. Divide values by 16 for actual disparity in pixels.
+ */
 struct StereoSGBM {
+    /// @brief Sets the minimum disparity value (default: 0).
     StereoSGBM& min_disparity(int n)   { min_disparity_   = n; return *this; }
+    /// @brief Sets the disparity search range (must be divisible by 16; default: 64).
     StereoSGBM& num_disparities(int n) { num_disparities_ = n; return *this; }
+    /// @brief Sets the matched block size (default: 3).
     StereoSGBM& block_size(int s)      { block_size_      = s; return *this; }
+    /// @brief Sets P1 smoothness penalty (default: 0; recommended: 8×blockSize²).
     StereoSGBM& p1(int p)              { p1_              = p; return *this; }
+    /// @brief Sets P2 smoothness penalty (default: 0; recommended: 32×blockSize²).
     StereoSGBM& p2(int p)              { p2_              = p; return *this; }
+    /// @brief Sets the SGBM mode (default: `cv::StereoSGBM::MODE_SGBM`).
     StereoSGBM& mode(int m)            { mode_            = m; return *this; }
 
-    // Returns CV_16S disparity map; divide by 16.0 for actual disparity values.
-    // Throws std::invalid_argument if left/right sizes differ.
+    /// @brief Computes the disparity map.
+    /// @throws std::invalid_argument if `left` and `right` have different sizes.
     cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
 
 private:
@@ -95,11 +129,17 @@ private:
 
 // ── ReprojectTo3D ─────────────────────────────────────────────────────────────
 
+/**
+ * @brief Reprojects a disparity map to a 3-D point cloud using the Q matrix from `StereoRectify`.
+ */
 struct ReprojectTo3D {
+    /// @brief If true, handles missing (invalid) disparity values (default: false).
     ReprojectTo3D& handle_missing(bool h) { handle_missing_ = h; return *this; }
 
-    // disparity: CV_16S or CV_32F; Q: 4×4 matrix from StereoRectify.
-    // Returns CV_32FC3 point cloud; same size as disparity.
+    /// @brief Reprojects disparity to 3-D.
+    /// @param disparity CV_16S or CV_32F disparity map.
+    /// @param Q         4×4 disparity-to-depth matrix from `StereoRectify`.
+    /// @return CV_32FC3 point cloud; same size as `disparity`.
     cv::Mat operator()(const cv::Mat& disparity, const cv::Mat& Q) const;
 
 private:

--- a/include/improc/core/ops/analysis.hpp
+++ b/include/improc/core/ops/analysis.hpp
@@ -7,35 +7,57 @@
 
 namespace improc::core {
 
+/**
+ * @brief Result of `IntegralImage`.
+ */
 struct IntegralResult {
-    cv::Mat sum;     // CV_32SC1; size is (rows+1)×(cols+1)
-    cv::Mat sq_sum;  // CV_64FC1; empty if with_sq_sum = false
+    cv::Mat sum;     ///< CV_32SC1 integral image; size is (rows+1)×(cols+1).
+    cv::Mat sq_sum;  ///< CV_64FC1 squared integral image; empty if with_sq_sum was false.
 };
 
+/**
+ * @brief Computes the integral (summed-area) image of a grayscale image.
+ */
 struct IntegralImage {
+    /// @brief Also computes the squared integral image (default: false).
     IntegralImage& with_sq_sum(bool b) { with_sq_sum_ = b; return *this; }
 
+    /// @brief Computes and returns the integral image.
     IntegralResult operator()(const Image<Gray>& img) const;
 
 private:
     bool with_sq_sum_ = false;
 };
 
+/**
+ * @brief Result of `MinMaxLoc`: minimum and maximum pixel values and their locations.
+ */
 struct MinMaxLocResult {
-    double    min_val, max_val;
-    cv::Point min_loc, max_loc;
+    double    min_val, max_val; ///< Minimum and maximum pixel values.
+    cv::Point min_loc, max_loc; ///< Pixel coordinates of the minimum and maximum.
 };
 
+/**
+ * @brief Finds the minimum and maximum values and their locations in a grayscale image or matrix.
+ */
 struct MinMaxLoc {
+    /// @brief Finds min/max in a `Gray` image.
     MinMaxLocResult operator()(const Image<Gray>& img) const;
+    /// @brief Finds min/max in an arbitrary `cv::Mat`.
     MinMaxLocResult operator()(const cv::Mat& mat) const;
 };
 
+/**
+ * @brief Result of `MeanStdDev`: per-channel mean and standard deviation.
+ */
 struct MeanStdDevResult {
-    cv::Scalar mean;
-    cv::Scalar stddev;
+    cv::Scalar mean;   ///< Per-channel mean (up to 4 channels).
+    cv::Scalar stddev; ///< Per-channel standard deviation.
 };
 
+/**
+ * @brief Computes per-channel mean and standard deviation for any image format.
+ */
 struct MeanStdDev {
     template<AnyFormat F>
     MeanStdDevResult operator()(const Image<F>& img) const {
@@ -45,14 +67,25 @@ struct MeanStdDev {
     }
 };
 
+/**
+ * @brief Counts non-zero pixels in a grayscale image.
+ */
 struct CountNonZero {
+    /// @return Number of non-zero pixels.
     int operator()(const Image<Gray>& img) const;
 };
 
+/// @brief Reduction operation used by `Reduce`.
 enum class ReduceOp { Sum, Avg, Max, Min };
 
+/**
+ * @brief Reduces a grayscale image along rows or columns using a `ReduceOp`.
+ */
 struct Reduce {
+    /// @brief Sets the reduction operation (default: Sum).
     Reduce& op(ReduceOp o) { op_  = o; return *this; }
+    /// @brief Sets the reduction dimension: 0 = reduce rows → single row; 1 = reduce cols → single col.
+    /// @throws std::invalid_argument if dim is not 0 or 1.
     Reduce& dim(int d) {
         if (d != 0 && d != 1)
             throw std::invalid_argument("Reduce: dim must be 0 (reduce rows) or 1 (reduce cols)");
@@ -60,6 +93,7 @@ struct Reduce {
         return *this;
     }
 
+    /// @return Single-row or single-column cv::Mat.
     cv::Mat operator()(const Image<Gray>& img) const;
 
 private:

--- a/include/improc/core/ops/arithmetic.hpp
+++ b/include/improc/core/ops/arithmetic.hpp
@@ -9,9 +9,14 @@
 
 namespace improc::core {
 
+/**
+ * @brief Computes the absolute difference between an image and a fixed matrix.
+ */
 struct AbsDiff {
+    /// @brief Constructs with the subtrahend matrix.
     explicit AbsDiff(cv::Mat other) : other_(std::move(other)) {}
 
+    /// @throws std::invalid_argument if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
@@ -25,9 +30,15 @@ private:
     cv::Mat other_;
 };
 
+/**
+ * @brief Applies element-wise bitwise AND with a fixed mask.
+ * Requires an integer-format image (BGR, Gray, BGRA).
+ */
 struct BitwiseAnd {
+    /// @brief Constructs with the mask matrix.
     explicit BitwiseAnd(cv::Mat other) : other_(std::move(other)) {}
 
+    /// @throws std::invalid_argument if sizes or types differ.
     template<IntegerFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
@@ -41,9 +52,15 @@ private:
     cv::Mat other_;
 };
 
+/**
+ * @brief Applies element-wise bitwise OR with a fixed mask.
+ * Requires an integer-format image (BGR, Gray, BGRA).
+ */
 struct BitwiseOr {
+    /// @brief Constructs with the mask matrix.
     explicit BitwiseOr(cv::Mat other) : other_(std::move(other)) {}
 
+    /// @throws std::invalid_argument if sizes or types differ.
     template<IntegerFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
@@ -57,16 +74,30 @@ private:
     cv::Mat other_;
 };
 
+/// @brief Alias for `Invert` — applies element-wise bitwise NOT.
 using BitwiseNot = Invert;
 
+/**
+ * @brief Applies a 2-D convolution with a custom kernel via `cv::filter2D`.
+ *
+ * @code
+ * cv::Mat sobel_x = (cv::Mat_<float>(3,3) << -1,0,1, -2,0,2, -1,0,1);
+ * auto edges = Convolve(sobel_x)(img);
+ * @endcode
+ */
 struct Convolve {
+    /// @brief Constructs with the convolution kernel.
+    /// @throws std::invalid_argument if kernel is empty.
     explicit Convolve(cv::Mat kernel) : kernel_(std::move(kernel)) {
         if (kernel_.empty())
             throw std::invalid_argument("Convolve: kernel must not be empty");
     }
 
+    /// @brief Sets the anchor point (default: {-1,-1} = kernel centre).
     Convolve& anchor(cv::Point a) { anchor_ = a; return *this; }
+    /// @brief Sets the optional value added to the filtered result (default: 0).
     Convolve& delta(double d)     { delta_  = d; return *this; }
+    /// @brief Sets the border extrapolation method (default: cv::BORDER_REFLECT_101).
     Convolve& border(int t)       { border_ = t; return *this; }
 
     template<AnyFormat F>
@@ -83,12 +114,18 @@ private:
     int      border_  = cv::BORDER_REFLECT_101;
 };
 
-// Takes a raw cv::Mat (e.g. Sobel gradient output CV_16S) rather than Image<F> —
-// its primary purpose is converting signed/float gradient data to displayable uint8.
+/**
+ * @brief Converts a signed/float matrix to displayable 8-bit via `cv::convertScaleAbs`.
+ *
+ * Primary use case: converting CV_16S Sobel/Laplacian output for visualisation.
+ */
 struct ConvertScaleAbs {
+    /// @brief Sets the multiplicative scale factor (default: 1.0).
     ConvertScaleAbs& alpha(double a) { alpha_ = a; return *this; }
+    /// @brief Sets the additive shift (default: 0.0).
     ConvertScaleAbs& beta(double b)  { beta_  = b; return *this; }
 
+    /// @return Grayscale Image<Gray> (CV_8UC1).
     Image<Gray> operator()(const cv::Mat& src) const {
         cv::Mat result;
         cv::convertScaleAbs(src, result, alpha_, beta_);
@@ -100,9 +137,14 @@ private:
     double beta_  = 0.0;
 };
 
+/**
+ * @brief Adds two images element-wise via `cv::add`.
+ */
 struct Add {
+    /// @brief Constructs with the addend matrix.
     explicit Add(cv::Mat other) : other_(std::move(other)) {}
 
+    /// @throws std::invalid_argument if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
@@ -116,9 +158,14 @@ private:
     cv::Mat other_;
 };
 
+/**
+ * @brief Subtracts a fixed matrix from an image element-wise via `cv::subtract`.
+ */
 struct Subtract {
+    /// @brief Constructs with the subtrahend matrix.
     explicit Subtract(cv::Mat other) : other_(std::move(other)) {}
 
+    /// @throws std::invalid_argument if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
@@ -132,10 +179,16 @@ private:
     cv::Mat other_;
 };
 
+/**
+ * @brief Multiplies two images element-wise via `cv::multiply`.
+ */
 struct Multiply {
+    /// @brief Constructs with the multiplicand matrix.
     explicit Multiply(cv::Mat other) : other_(std::move(other)) {}
+    /// @brief Sets an optional scale factor applied after multiplication (default: 1.0).
     Multiply& scale(double s) { scale_ = s; return *this; }
 
+    /// @throws std::invalid_argument if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
@@ -150,10 +203,16 @@ private:
     double  scale_ = 1.0;
 };
 
+/**
+ * @brief Divides an image by a fixed matrix element-wise via `cv::divide`.
+ */
 struct Divide {
+    /// @brief Constructs with the divisor matrix.
     explicit Divide(cv::Mat other) : other_(std::move(other)) {}
+    /// @brief Sets an optional scale factor applied after division (default: 1.0).
     Divide& scale(double s) { scale_ = s; return *this; }
 
+    /// @throws std::invalid_argument if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())

--- a/include/improc/core/ops/channels.hpp
+++ b/include/improc/core/ops/channels.hpp
@@ -7,14 +7,26 @@
 
 namespace improc::core {
 
+/**
+ * @brief Splits a multi-channel image into individual grayscale channel images.
+ */
 struct SplitChannels {
+    /// @brief Splits BGR into B, G, R channels.
+    /// @return Array of three single-channel Image<Gray> in B, G, R order.
     std::array<Image<Gray>, 3> operator()(const Image<BGR>&  img) const;
+    /// @brief Splits BGRA into B, G, R, A channels.
+    /// @return Array of four single-channel Image<Gray> in B, G, R, A order.
     std::array<Image<Gray>, 4> operator()(const Image<BGRA>& img) const;
 };
 
+/**
+ * @brief Merges individual grayscale channel images into a multi-channel image.
+ */
 struct MergeChannels {
+    /// @brief Merges three single-channel images into a BGR image.
     Image<BGR>  operator()(const Image<Gray>& b, const Image<Gray>& g,
                             const Image<Gray>& r) const;
+    /// @brief Merges four single-channel images into a BGRA image.
     Image<BGRA> operator()(const Image<Gray>& b, const Image<Gray>& g,
                             const Image<Gray>& r, const Image<Gray>& a) const;
 };

--- a/include/improc/core/ops/detector_types.hpp
+++ b/include/improc/core/ops/detector_types.hpp
@@ -8,42 +8,57 @@
 namespace improc::core {
 
 // ── MSER ─────────────────────────────────────────────────────────────────────
+/**
+ * @brief Result of MSER (Maximally Stable Extremal Regions) detection.
+ */
 struct MSERResult {
-    std::vector<std::vector<cv::Point>> regions;
-    std::vector<cv::Rect>               bboxes;
+    std::vector<std::vector<cv::Point>> regions; ///< Pixel sets, one per detected region.
+    std::vector<cv::Rect>               bboxes;  ///< Axis-aligned bounding box per region.
     std::size_t size()  const { return regions.size(); }
     bool        empty() const { return regions.empty(); }
 };
 
 // ── LSD lines ────────────────────────────────────────────────────────────────
+/**
+ * @brief Result of LSD (Line Segment Detector) line detection.
+ */
 struct LineSet {
-    std::vector<cv::Vec4f> lines; ///< each entry: (x1, y1, x2, y2)
+    std::vector<cv::Vec4f> lines; ///< Each entry: (x1, y1, x2, y2) in pixel coordinates.
     std::size_t size()  const { return lines.size(); }
     bool        empty() const { return lines.empty(); }
 };
 
 // ── QR codes ─────────────────────────────────────────────────────────────────
+/**
+ * @brief Result of QR code detection and decoding.
+ */
 struct QRResult {
-    std::vector<std::string> decoded; ///< one decoded string per QR code
-    std::vector<cv::Mat>     points;  ///< 4-corner mat (CV_32FC2, 4×1) per code
+    std::vector<std::string> decoded; ///< Decoded content strings, one per detected code.
+    std::vector<cv::Mat>     points;  ///< 4-corner matrices (CV_32FC2, 4×1) per code.
     std::size_t size()  const { return decoded.size(); }
     bool        empty() const { return decoded.empty(); }
 };
 
 // ── Barcodes ─────────────────────────────────────────────────────────────────
+/**
+ * @brief Result of barcode detection and decoding.
+ */
 struct BarcodeResult {
-    std::vector<std::string>     decoded; ///< one decoded string per barcode
-    std::vector<std::string>     types;   ///< barcode format name per entry
-    std::vector<cv::RotatedRect> bboxes;  ///< oriented bbox per entry
+    std::vector<std::string>     decoded; ///< Decoded content strings.
+    std::vector<std::string>     types;   ///< Format name per decoded entry (e.g. "EAN_13").
+    std::vector<cv::RotatedRect> bboxes;  ///< Oriented bounding box per entry.
     std::size_t size()  const { return decoded.size(); }
     bool        empty() const { return decoded.empty(); }
 };
 
 // ── Face detection ───────────────────────────────────────────────────────────
+/**
+ * @brief Single face detection with landmark points.
+ */
 struct FaceDetection {
-    cv::Rect2f                 bbox;        ///< face bounding box (float coords)
-    float                      confidence;  ///< detection score
-    std::array<cv::Point2f, 5> landmarks;   ///< right-eye, left-eye, nose, right-mouth, left-mouth
+    cv::Rect2f                 bbox;       ///< Face bounding box in float pixel coordinates.
+    float                      confidence; ///< Detection confidence score in [0, 1].
+    std::array<cv::Point2f, 5> landmarks;  ///< Facial landmarks: right-eye, left-eye, nose, right-mouth, left-mouth.
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/flood_fill.hpp
+++ b/include/improc/core/ops/flood_fill.hpp
@@ -5,11 +5,24 @@
 
 namespace improc::core {
 
+/**
+ * @brief Fills a connected region starting at a seed pixel with a new colour.
+ *
+ * lo_diff and up_diff define the pixel value tolerance for region membership.
+ *
+ * @code
+ * auto filled = FloodFill().lo_diff({10,10,10}).up_diff({10,10,10})(img, {100, 100}, {0,0,255});
+ * @endcode
+ */
 struct FloodFill {
+    /// @brief Sets the lower boundary of the colour difference for region membership.
     FloodFill& lo_diff(cv::Scalar lo) { lo_diff_ = lo; return *this; }
+    /// @brief Sets the upper boundary of the colour difference for region membership.
     FloodFill& up_diff(cv::Scalar hi) { up_diff_ = hi; return *this; }
 
+    /// @brief Fills a connected region in a BGR image.
     Image<BGR>  operator()(const Image<BGR>&  img, cv::Point seed, cv::Scalar new_color) const;
+    /// @brief Fills a connected region in a Gray image.
     Image<Gray> operator()(const Image<Gray>& img, cv::Point seed, uchar      new_val)   const;
 
 private:

--- a/include/improc/core/ops/grabcut.hpp
+++ b/include/improc/core/ops/grabcut.hpp
@@ -6,9 +6,20 @@
 
 namespace improc::core {
 
+/**
+ * @brief Segments the foreground from the background using the GrabCut algorithm.
+ *
+ * @code
+ * auto mask = GrabCut().iterations(5)(img, cv::Rect{50, 50, 200, 300});
+ * @endcode
+ */
 struct GrabCut {
+    /// @brief Sets the number of EM iterations (default: 5).
     GrabCut& iterations(int n);
 
+    /// @brief Runs GrabCut and returns a binary foreground mask.
+    /// @param roi Rectangle containing the foreground object.
+    /// @return Image<Gray> where 255 = foreground, 0 = background.
     Image<Gray> operator()(const Image<BGR>& img, cv::Rect roi) const;
 
 private:

--- a/include/improc/core/ops/hist.hpp
+++ b/include/improc/core/ops/hist.hpp
@@ -6,11 +6,20 @@
 
 namespace improc::core {
 
+/**
+ * @brief Computes a 1-D histogram for a grayscale or BGR image.
+ *
+ * For BGR images, per-channel histograms are concatenated along columns.
+ */
 struct CalcHist {
+    /// @brief Sets the number of histogram bins (default: 256).
     CalcHist& bins(int b);
+    /// @brief Sets the value range [lo, hi) covered by the histogram (default: [0, 256)).
     CalcHist& range(float lo, float hi);
 
+    /// @brief Computes a 1-D histogram for a grayscale image.
     cv::Mat operator()(const Image<Gray>& img) const;
+    /// @brief Computes per-channel histograms for a BGR image, concatenated along columns.
     cv::Mat operator()(const Image<BGR>& img) const;
 
 private:
@@ -19,9 +28,14 @@ private:
     float range_hi_ = 256.0f;
 };
 
+/**
+ * @brief Compares two histograms using a configurable comparison method.
+ */
 struct CompareHist {
+    /// @brief Sets the comparison method (default: cv::HISTCMP_CORREL).
     CompareHist& method(int m);
 
+    /// @return Scalar result whose meaning depends on the chosen method.
     double operator()(const cv::Mat& h1, const cv::Mat& h2) const;
 
 private:

--- a/include/improc/core/ops/hough.hpp
+++ b/include/improc/core/ops/hough.hpp
@@ -7,13 +7,26 @@
 
 namespace improc::core {
 
+/**
+ * @brief Detects line segments in a grayscale (edge) image using the probabilistic Hough transform.
+ *
+ * @code
+ * auto lines = HoughLinesP().threshold(50).min_line_length(30.0)(edge_img);
+ * @endcode
+ */
 struct HoughLinesP {
+    /// @brief Sets the distance resolution of the accumulator in pixels (default: 1.0).
     HoughLinesP& rho(double r);
+    /// @brief Sets the angle resolution of the accumulator in radians (default: 1 degree).
     HoughLinesP& theta(double t);
+    /// @brief Sets the accumulator threshold — only lines with enough votes are returned (default: 80).
     HoughLinesP& threshold(int t);
+    /// @brief Sets the minimum accepted line length in pixels (default: 0.0).
     HoughLinesP& min_line_length(double l);
+    /// @brief Sets the maximum allowed gap between collinear points to link them (default: 0.0).
     HoughLinesP& max_line_gap(double g);
 
+    /// @return Detected line segments as cv::Vec4i (x1, y1, x2, y2).
     std::vector<cv::Vec4i> operator()(const Image<Gray>& img) const;
 
 private:
@@ -24,13 +37,26 @@ private:
     double max_line_gap_    = 0.0;
 };
 
+/**
+ * @brief Detects circles in a grayscale image using the Hough gradient method.
+ *
+ * @code
+ * auto circles = HoughCircles().min_dist(20.0).param2(30.0)(gray_img);
+ * @endcode
+ */
 struct HoughCircles {
+    /// @brief Sets the minimum distance between detected circle centres (default: 20.0).
     HoughCircles& min_dist(double d);
+    /// @brief Sets the higher threshold for the Canny edge detector (default: 100.0).
     HoughCircles& param1(double p);
+    /// @brief Sets the accumulator threshold for circle centres (default: 30.0).
     HoughCircles& param2(double p);
+    /// @brief Sets the minimum circle radius in pixels (default: 0).
     HoughCircles& min_radius(int r);
+    /// @brief Sets the maximum circle radius in pixels; 0 means no upper limit (default: 0).
     HoughCircles& max_radius(int r);
 
+    /// @return Detected circles as cv::Vec3f (cx, cy, radius).
     std::vector<cv::Vec3f> operator()(const Image<Gray>& img) const;
 
 private:

--- a/include/improc/core/ops/img_hash.hpp
+++ b/include/improc/core/ops/img_hash.hpp
@@ -1,41 +1,73 @@
+/** @file img_hash.hpp
+ *  @brief Perceptual image hash algorithms for similarity comparison.
+ *
+ *  All hash ops expose `operator()(Image<BGR>) → cv::Mat` and a static `distance()`.
+ *  Hamming-based hashes return CV_8U; L2-based hashes return CV_64F.
+ */
 #pragma once
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 
 namespace improc::core {
 
-// All hash ops: operator()(Image<BGR>) → cv::Mat hash.
-// Static distance() uses the metric native to each algorithm.
-// Hamming-based hashes return CV_8U; L2-based return CV_64F.
-
+/**
+ * @brief Average Hash — fast 64-bit perceptual hash based on mean pixel value.
+ */
 struct AverageHash {
-    cv::Mat operator()(const Image<BGR>&) const; // → 1×8 CV_8U (64 bits)
-    static double distance(const cv::Mat& a, const cv::Mat& b); // Hamming
+    /// @return 1×8 CV_8U hash matrix (64 bits).
+    cv::Mat operator()(const Image<BGR>&) const;
+    /// @brief Computes the Hamming distance between two AverageHash digests.
+    static double distance(const cv::Mat& a, const cv::Mat& b);
 };
 
+/**
+ * @brief Perceptual Hash (pHash) — 64-bit DCT-based hash robust to minor image changes.
+ */
 struct PHash {
-    cv::Mat operator()(const Image<BGR>&) const; // → 1×8 CV_8U (64 bits, DCT-based)
-    static double distance(const cv::Mat& a, const cv::Mat& b); // Hamming
+    /// @return 1×8 CV_8U hash matrix (64 bits, DCT-based).
+    cv::Mat operator()(const Image<BGR>&) const;
+    /// @brief Computes the Hamming distance between two PHash digests.
+    static double distance(const cv::Mat& a, const cv::Mat& b);
 };
 
+/**
+ * @brief Marr-Hildreth Hash — 576-bit hash based on LoG zero-crossings.
+ */
 struct MarrHildrethHash {
-    cv::Mat operator()(const Image<BGR>&) const; // → 1×72 CV_8U (LoG zero-crossing)
-    static double distance(const cv::Mat& a, const cv::Mat& b); // Hamming
+    /// @return 1×72 CV_8U hash matrix (576 bits, LoG zero-crossing).
+    cv::Mat operator()(const Image<BGR>&) const;
+    /// @brief Computes the Hamming distance between two MarrHildrethHash digests.
+    static double distance(const cv::Mat& a, const cv::Mat& b);
 };
 
+/**
+ * @brief Radial Variance Hash — L2-based hash using radial variance projections.
+ */
 struct RadialVarianceHash {
-    cv::Mat operator()(const Image<BGR>&) const; // → 1×40 CV_64F (radial variances)
-    static double distance(const cv::Mat& a, const cv::Mat& b); // L2
+    /// @return 1×40 CV_64F hash matrix (radial variances).
+    cv::Mat operator()(const Image<BGR>&) const;
+    /// @brief Computes the L2 distance between two RadialVarianceHash digests.
+    static double distance(const cv::Mat& a, const cv::Mat& b);
 };
 
+/**
+ * @brief Color Moment Hash — L2-based hash encoding colour distribution moments.
+ */
 struct ColorMomentHash {
-    cv::Mat operator()(const Image<BGR>&) const; // → 1×42 CV_64F (color moments)
-    static double distance(const cv::Mat& a, const cv::Mat& b); // L2
+    /// @return 1×42 CV_64F hash matrix (color moments).
+    cv::Mat operator()(const Image<BGR>&) const;
+    /// @brief Computes the L2 distance between two ColorMomentHash digests.
+    static double distance(const cv::Mat& a, const cv::Mat& b);
 };
 
+/**
+ * @brief Block Mean Hash — 256-bit hash based on mean values of image blocks.
+ */
 struct BlockMeanHash {
-    cv::Mat operator()(const Image<BGR>&) const; // → 1×32 CV_8U (256 bits, block means)
-    static double distance(const cv::Mat& a, const cv::Mat& b); // Hamming
+    /// @return 1×32 CV_8U hash matrix (256 bits, block means).
+    cv::Mat operator()(const Image<BGR>&) const;
+    /// @brief Computes the Hamming distance between two BlockMeanHash digests.
+    static double distance(const cv::Mat& a, const cv::Mat& b);
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/inpaint.hpp
+++ b/include/improc/core/ops/inpaint.hpp
@@ -6,12 +6,26 @@
 
 namespace improc::core {
 
-enum class InpaintMethod { TELEA, NS };
+/// @brief Inpainting algorithm choices.
+enum class InpaintMethod {
+    TELEA, ///< Fast Marching Method (Telea 2004) — good for thin regions.
+    NS,    ///< Navier-Stokes fluid dynamics method — better for large holes.
+};
 
+/**
+ * @brief Restores damaged or masked regions of a BGR image using inpainting.
+ *
+ * @code
+ * auto restored = Inpaint().radius(5.0).method(InpaintMethod::TELEA)(img, mask);
+ * @endcode
+ */
 struct Inpaint {
+    /// @brief Sets the inpainting neighbourhood radius in pixels (default: 3.0).
     Inpaint& radius(double r);
+    /// @brief Sets the inpainting algorithm (default: InpaintMethod::TELEA).
     Inpaint& method(InpaintMethod m);
 
+    /// @brief Inpaints regions where mask is non-zero.
     Image<BGR> operator()(const Image<BGR>& img, const Image<Gray>& mask) const;
 
 private:

--- a/include/improc/core/ops/match_template.hpp
+++ b/include/improc/core/ops/match_template.hpp
@@ -7,9 +7,18 @@
 
 namespace improc::core {
 
+/**
+ * @brief Slides a template over an image and returns the best match location.
+ *
+ * @code
+ * auto [pt, score] = MatchTemplate().method(cv::TM_CCOEFF_NORMED)(img, templ);
+ * @endcode
+ */
 struct MatchTemplate {
+    /// @brief Sets the matching method (default: cv::TM_CCOEFF_NORMED).
     MatchTemplate& method(int m);
 
+    /// @return {best_match_top_left, match_score}.
     std::pair<cv::Point, double> operator()(const Image<BGR>& img,
                                              const Image<BGR>& templ) const;
 

--- a/include/improc/core/ops/moments.hpp
+++ b/include/improc/core/ops/moments.hpp
@@ -7,9 +7,13 @@
 
 namespace improc::core {
 
+/**
+ * @brief Computes image moments (spatial, central, and Hu) for a grayscale image.
+ */
 struct Moments {
-    bool binary = false;
+    bool binary = false; ///< If true, treats the image as binary before moment computation.
 
+    /// @return cv::Moments containing spatial, central, and normalised central moments.
     cv::Moments operator()(const Image<Gray>& img) const {
         return cv::moments(img.mat(), binary);
     }

--- a/include/improc/core/ops/optical_flow.hpp
+++ b/include/improc/core/ops/optical_flow.hpp
@@ -6,16 +6,26 @@
 
 namespace improc::core {
 
+/**
+ * @brief Result of sparse Lucas-Kanade optical flow tracking.
+ */
 struct SparseLKFlowResult {
-    std::vector<cv::Point2f> points;
-    std::vector<uchar>       status;
-    std::vector<float>       error;
+    std::vector<cv::Point2f> points; ///< Tracked point positions in the next frame.
+    std::vector<uchar>       status; ///< 1 if the corresponding point was found, 0 otherwise.
+    std::vector<float>       error;  ///< Tracking error for each point.
 };
 
+/**
+ * @brief Tracks sparse feature points between two grayscale frames using Lucas-Kanade optical flow.
+ */
 struct SparseLKFlow {
+    /// @brief Sets the search window size at each pyramid level (default: {21, 21}).
     SparseLKFlow& win_size(cv::Size s)  { win_size_  = s; return *this; }
+    /// @brief Sets the maximum pyramid level (default: 3).
     SparseLKFlow& max_level(int n)      { max_level_ = n; return *this; }
+    /// @brief Sets the maximum number of iterations per pyramid level (default: 30).
     SparseLKFlow& max_iter(int n)       { max_iter_  = n; return *this; }
+    /// @brief Sets the convergence epsilon for the iterative search (default: 0.01).
     SparseLKFlow& epsilon(double e)     { epsilon_   = e; return *this; }
 
     SparseLKFlowResult operator()(const Image<Gray>& prev,
@@ -29,14 +39,26 @@ private:
     double   epsilon_   = 0.01;
 };
 
+/**
+ * @brief Computes dense optical flow using the Farneback polynomial expansion method.
+ *
+ * @return Image<Flow> (CV_32FC2) where each pixel contains the (dx, dy) displacement vector.
+ */
 struct DenseFarnebackFlow {
+    /// @brief Sets the image scale for pyramid construction (default: 0.5).
     DenseFarnebackFlow& pyr_scale(double s)  { pyr_scale_  = s; return *this; }
+    /// @brief Sets the number of pyramid levels (default: 3).
     DenseFarnebackFlow& levels(int n)        { levels_     = n; return *this; }
+    /// @brief Sets the averaging window size in pixels (default: 15).
     DenseFarnebackFlow& win_size(int n)      { win_size_   = n; return *this; }
+    /// @brief Sets the number of iterations at each pyramid level (default: 3).
     DenseFarnebackFlow& iterations(int n)    { iterations_ = n; return *this; }
+    /// @brief Sets the size of the pixel neighbourhood for polynomial expansion (default: 5).
     DenseFarnebackFlow& poly_n(int n)        { poly_n_     = n; return *this; }
+    /// @brief Sets the standard deviation for the Gaussian smoothing of polynomial coefficients (default: 1.2).
     DenseFarnebackFlow& poly_sigma(double s) { poly_sigma_ = s; return *this; }
 
+    /// @return Image<Flow> (CV_32FC2) displacement field.
     Image<Flow> operator()(const Image<Gray>& prev, const Image<Gray>& next) const;
 
 private:
@@ -48,11 +70,21 @@ private:
     double poly_sigma_ = 1.2;
 };
 
+/**
+ * @brief Computes dense optical flow using the DIS (Dense Inverse Search) algorithm.
+ */
 struct DenseDISFlow {
-    enum class Preset { UltraFast, Fast, Medium };
+    /// @brief Quality/speed preset for DIS optical flow.
+    enum class Preset {
+        UltraFast, ///< Lowest quality, fastest computation.
+        Fast,      ///< Balanced quality and speed.
+        Medium,    ///< Higher quality, slower computation (default).
+    };
 
+    /// @brief Sets the quality/speed preset (default: Preset::Medium).
     DenseDISFlow& preset(Preset p) { preset_ = p; return *this; }
 
+    /// @return Image<Flow> (CV_32FC2) displacement field.
     Image<Flow> operator()(const Image<Gray>& prev, const Image<Gray>& next) const;
 
 private:

--- a/include/improc/core/ops/phase_correlate.hpp
+++ b/include/improc/core/ops/phase_correlate.hpp
@@ -6,12 +6,24 @@
 
 namespace improc::core {
 
+/**
+ * @brief Result of phase correlation: sub-pixel translation shift and peak response.
+ */
 struct PhaseCorrelateResult {
-    cv::Point2d shift;
-    double      response;
+    cv::Point2d shift;    ///< Sub-pixel translation (dx, dy) of next relative to prev.
+    double      response; ///< Peak correlation response in [0, 1]; higher means more reliable.
 };
 
+/**
+ * @brief Estimates the translation between two float grayscale frames using phase correlation.
+ *
+ * @code
+ * auto result = PhaseCorrelate()(prev_f32, next_f32);
+ * // result.shift is the sub-pixel (dx, dy) translation
+ * @endcode
+ */
 struct PhaseCorrelate {
+    /// @return PhaseCorrelateResult with the sub-pixel shift and peak response strength.
     PhaseCorrelateResult operator()(const Image<Float32>& prev,
                                     const Image<Float32>& next) const;
 };

--- a/include/improc/core/ops/photo.hpp
+++ b/include/improc/core/ops/photo.hpp
@@ -6,14 +6,27 @@
 
 namespace improc::core {
 
+/**
+ * @brief Result of PencilSketch containing both the grayscale and colour sketch outputs.
+ */
 struct PencilSketchResult {
-    Image<Gray> gray;
-    Image<BGR>  color;
+    Image<Gray> gray;  ///< Grayscale pencil-sketch rendition.
+    Image<BGR>  color; ///< Colour pencil-sketch rendition.
 };
 
+/**
+ * @brief Clones a region from a source image into a destination image with seamless blending.
+ */
 struct SeamlessClone {
-    enum class Mode { Normal, Mixed, Monochrome };
+    /// @brief Blending mode for SeamlessClone.
+    enum class Mode {
+        Normal,     ///< Standard seamless cloning (cv::NORMAL_CLONE).
+        Mixed,      ///< Mixed seamless cloning preserving destination gradients (cv::MIXED_CLONE).
+        Monochrome, ///< Monochrome transfer (cv::MONOCHROME_TRANSFER).
+    };
+    /// @brief Sets the blending mode (default: Mode::Normal).
     SeamlessClone& mode(Mode m) { mode_ = m; return *this; }
+    /// @brief Clones the masked region of src into dst centred at center.
     Image<BGR> operator()(const Image<BGR>& src,
                           const Image<BGR>& dst,
                           const Image<Gray>& mask,
@@ -22,11 +35,22 @@ private:
     Mode mode_ = Mode::Normal;
 };
 
+/**
+ * @brief Smooths an image while preserving edges using cv::edgePreservingFilter.
+ */
 struct EdgePreservingFilter {
-    enum class Filter { Recursive, NormConv };
+    /// @brief Filter type for edge-preserving smoothing.
+    enum class Filter {
+        Recursive, ///< Recursive filter (default, faster).
+        NormConv,  ///< Normalised convolution filter (higher quality).
+    };
+    /// @brief Sets the spatial standard deviation (range: 0–200; default: 60).
     EdgePreservingFilter& sigma_s(float s) { sigma_s_ = s; return *this; }
+    /// @brief Sets the colour standard deviation (range: 0–1; default: 0.4).
     EdgePreservingFilter& sigma_r(float r) { sigma_r_ = r; return *this; }
+    /// @brief Sets the filter type (default: Filter::Recursive).
     EdgePreservingFilter& filter(Filter f) { filter_  = f; return *this; }
+    /// @return Smoothed BGR image with preserved edges.
     Image<BGR> operator()(const Image<BGR>&) const;
 private:
     float  sigma_s_ = 60.f;
@@ -34,28 +58,47 @@ private:
     Filter filter_  = Filter::Recursive;
 };
 
+/**
+ * @brief Enhances fine detail in an image using cv::detailEnhance.
+ */
 struct DetailEnhance {
+    /// @brief Sets the spatial standard deviation (default: 10).
     DetailEnhance& sigma_s(float s) { sigma_s_ = s; return *this; }
+    /// @brief Sets the colour standard deviation (default: 0.15).
     DetailEnhance& sigma_r(float r) { sigma_r_ = r; return *this; }
+    /// @return Detail-enhanced BGR image.
     Image<BGR> operator()(const Image<BGR>&) const;
 private:
     float sigma_s_ = 10.f;
     float sigma_r_ = 0.15f;
 };
 
+/**
+ * @brief Renders a painterly stylisation of a BGR image using cv::stylization.
+ */
 struct Stylize {
+    /// @brief Sets the spatial standard deviation (default: 60).
     Stylize& sigma_s(float s) { sigma_s_ = s; return *this; }
+    /// @brief Sets the colour standard deviation (default: 0.45).
     Stylize& sigma_r(float r) { sigma_r_ = r; return *this; }
+    /// @return Stylised BGR image.
     Image<BGR> operator()(const Image<BGR>&) const;
 private:
     float sigma_s_ = 60.f;
     float sigma_r_ = 0.45f;
 };
 
+/**
+ * @brief Renders a pencil-sketch stylisation of a BGR image using cv::pencilSketch.
+ */
 struct PencilSketch {
+    /// @brief Sets the spatial standard deviation (default: 60).
     PencilSketch& sigma_s(float s)      { sigma_s_      = s; return *this; }
+    /// @brief Sets the colour standard deviation (default: 0.07).
     PencilSketch& sigma_r(float r)      { sigma_r_      = r; return *this; }
+    /// @brief Sets the shading intensity for the colour sketch (default: 0.05).
     PencilSketch& shade_factor(float f) { shade_factor_ = f; return *this; }
+    /// @return PencilSketchResult containing grayscale and colour sketch images.
     PencilSketchResult operator()(const Image<BGR>&) const;
 private:
     float sigma_s_      = 60.f;
@@ -63,28 +106,58 @@ private:
     float shade_factor_ = 0.05f;
 };
 
+/**
+ * @brief Denoises a BGR image sequence using Non-Local Means over a temporal window.
+ */
 struct NLMeansDenoisingMulti {
+    /// @brief Sets the filter strength — higher h removes more noise but blurs more (default: 3).
     NLMeansDenoisingMulti& h(float h)                  { h_   = h; return *this; }
+    /// @brief Sets the number of surrounding frames in the temporal window (default: 3).
     NLMeansDenoisingMulti& temporal_window_size(int w) { tws_ = w; return *this; }
+    /// @return Denoised BGR image of the middle frame.
     Image<BGR> operator()(const std::vector<Image<BGR>>&) const;
 private:
     float h_   = 3.f;
     int   tws_ = 3;
 };
 
+/**
+ * @brief Merges multiple exposures into a single HDR/LDR image.
+ *
+ * Method::Mertens (default): exposure fusion — no exposure times required.
+ * Method::Debevec: camera response recovery — requires exposure times.
+ */
 struct MergeHDR {
-    enum class Method { Mertens, Debevec };
+    /// @brief Merge algorithm selection.
+    enum class Method {
+        Mertens, ///< Exposure fusion (Mertens et al.) — produces a tone-mapped LDR result.
+        Debevec, ///< Debevec HDR reconstruction — requires exposure times vector.
+    };
+    /// @brief Sets the merge algorithm (default: Method::Mertens).
     MergeHDR& method(Method m) { method_ = m; return *this; }
+    /// @return Image<Float32C3> HDR image.
     Image<Float32C3> operator()(const std::vector<Image<BGR>>& images,
                                 const std::vector<float>& times = {}) const;
 private:
     Method method_ = Method::Mertens;
 };
 
+/**
+ * @brief Maps an HDR float image to displayable 8-bit range using a tone-mapping operator.
+ */
 struct ToneMap {
-    enum class Algorithm { Linear, Drago, Reinhard, Mantiuk };
+    /// @brief Tone-mapping algorithm selection.
+    enum class Algorithm {
+        Linear,   ///< Simple linear scaling.
+        Drago,    ///< Drago logarithmic tone mapping.
+        Reinhard, ///< Reinhard global tone mapping (default).
+        Mantiuk,  ///< Mantiuk contrast-preserving tone mapping.
+    };
+    /// @brief Sets the output gamma correction (default: 1.0 = no correction).
     ToneMap& gamma(float g)        { gamma_ = g; return *this; }
+    /// @brief Sets the tone-mapping algorithm (default: Algorithm::Reinhard).
     ToneMap& algorithm(Algorithm a) { algo_ = a; return *this; }
+    /// @return Tone-mapped BGR image (CV_8UC3).
     Image<BGR> operator()(const Image<Float32C3>&) const;
 private:
     float     gamma_ = 1.f;

--- a/include/improc/core/ops/quality.hpp
+++ b/include/improc/core/ops/quality.hpp
@@ -1,3 +1,9 @@
+/**
+ * @file quality.hpp
+ * @brief Full-reference image quality metrics (PSNR, SSIM, GMSD, MSE).
+ *
+ * All ops throw improc::ParameterError when ref.size() != cmp.size().
+ */
 #pragma once
 #include <limits>
 #include <opencv2/core.hpp>
@@ -7,28 +13,38 @@
 
 namespace improc::core {
 
-// All reference-based ops throw ParameterError when ref.size() != cmp.size().
-
+/**
+ * @brief Peak Signal-to-Noise Ratio — higher is better.
+ *
+ * @return INFINITY when images are identical (MSE == 0).
+ */
 struct PSNR {
-    // Returns INFINITY when images are identical (MSE == 0).
     double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
     double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };
 
+/**
+ * @brief Structural Similarity Index — higher is better; maximum is 1.0.
+ *
+ * @return 1.0 for identical images.
+ */
 struct SSIM {
-    // Returns 1.0 for identical images.
     double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
     double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };
 
+/**
+ * @brief Gradient Magnitude Similarity Deviation — lower is better; 0 for identical images.
+ */
 struct GMSD {
-    // Lower = better quality. Returns 0.0 for identical images.
     double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
     double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };
 
+/**
+ * @brief Mean Squared Error — lower is better; 0 for identical images.
+ */
 struct MSE {
-    // Returns 0.0 for identical images.
     double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
     double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };

--- a/include/improc/core/ops/stitching.hpp
+++ b/include/improc/core/ops/stitching.hpp
@@ -6,14 +6,31 @@
 
 namespace improc::core {
 
+/**
+ * @brief Result of image stitching.
+ */
 struct StitchResult {
-    bool       ok;
-    Image<BGR> panorama;
+    bool       ok;       ///< True if stitching succeeded; false if feature matching or blending failed.
+    Image<BGR> panorama; ///< The stitched panorama image (valid only when ok is true).
 };
 
+/**
+ * @brief Stitches a sequence of overlapping BGR images into a single panorama.
+ *
+ * @code
+ * auto result = Stitch().mode(Stitch::Mode::Panorama)(images);
+ * if (result.ok) display(result.panorama);
+ * @endcode
+ */
 struct Stitch {
-    enum class Mode { Panorama, Scans };
+    /// @brief Stitching mode.
+    enum class Mode {
+        Panorama, ///< Full 360° panorama mode using spherical warp (default).
+        Scans,    ///< Flat document / scan stitching mode using affine warp.
+    };
+    /// @brief Sets the stitching mode (default: Mode::Panorama).
     Stitch& mode(Mode m) { mode_ = m; return *this; }
+    /// @return StitchResult; ok is false if feature matching or blending fails.
     StitchResult operator()(const std::vector<Image<BGR>>&) const;
 private:
     Mode mode_ = Mode::Panorama;

--- a/include/improc/core/ops/watershed.hpp
+++ b/include/improc/core/ops/watershed.hpp
@@ -6,7 +6,22 @@
 
 namespace improc::core {
 
+/**
+ * @brief Applies the Watershed algorithm to segment an image using a marker image.
+ *
+ * Markers must be a CV_32S matrix where non-zero values indicate known regions
+ * and zeros indicate unknown regions to be filled. After the call, markers are
+ * updated in-place: boundaries are marked with -1.
+ *
+ * @code
+ * cv::Mat markers = cv::Mat::zeros(img.mat().size(), CV_32S);
+ * markers.at<int>(50, 50) = 1;
+ * markers.at<int>(200, 200) = 2;
+ * Watershed()(img, markers);
+ * @endcode
+ */
 struct Watershed {
+    /// @brief Runs Watershed. Modifies markers in-place; boundary pixels are set to -1.
     void operator()(const Image<BGR>& img, cv::Mat& markers) const;
 };
 

--- a/include/improc/io/any_camera_source.hpp
+++ b/include/improc/io/any_camera_source.hpp
@@ -32,10 +32,24 @@ struct CameraSourceImpl final : ICameraSourceErased {
 
 } // namespace detail
 
+/**
+ * @brief Type-erased wrapper for any `CameraSourceType` — holds a webcam, IP cam, OAK-D, or other source.
+ *
+ * The wrapped source is heap-allocated via `make<T>(args...)`. Copying is disabled; move is allowed.
+ *
+ * @code
+ * auto src = AnyCameraSource::make<WebcamCapture>(0);
+ * src.start();
+ * while (auto frame = src.getFrame()) { ... }
+ * src.stop();
+ * @endcode
+ */
 class AnyCameraSource {
 public:
+    /// @brief Constructs an empty (no-op) source. getFrame() returns CameraUnavailable.
     AnyCameraSource() = default;
 
+    /// @brief Constructs an AnyCameraSource wrapping a new instance of T built from args.
     template<CameraSourceType T, typename... Args>
     static AnyCameraSource make(Args&&... args) {
         AnyCameraSource any;
@@ -44,8 +58,12 @@ public:
         return any;
     }
 
+    /// @brief Starts the wrapped source. No-op if empty.
     void start() { if (impl_) impl_->start(); }
+    /// @brief Stops the wrapped source. No-op if empty.
     void stop()  { if (impl_) impl_->stop(); }
+    /// @brief Returns the next frame from the wrapped source.
+    /// @return CameraUnavailable error if the source is empty; otherwise delegates to the wrapped source.
     std::expected<CameraFrame, improc::Error> getFrame() {
         if (!impl_)
             return std::unexpected(improc::Error{
@@ -54,6 +72,7 @@ public:
         return impl_->getFrame();
     }
 
+    /// @brief Returns true if a camera source has been wrapped.
     explicit operator bool() const noexcept { return impl_ != nullptr; }
 
 private:

--- a/include/improc/io/camera_capture.hpp
+++ b/include/improc/io/camera_capture.hpp
@@ -1,7 +1,9 @@
 // include/improc/io/camera_capture.hpp
-// Backward-compat alias — existing code using CameraCapture compiles unchanged.
-// New code should use WebcamCapture directly.
 #pragma once
+/** @file camera_capture.hpp
+ *  @brief Backward-compatibility alias: `improc::io::CameraCapture` → `WebcamCapture`.
+ *  @deprecated New code should use `WebcamCapture` directly.
+ */
 #include "improc/io/webcam_capture.hpp"
 
 namespace improc::io {

--- a/include/improc/io/io.hpp
+++ b/include/improc/io/io.hpp
@@ -1,5 +1,11 @@
 // include/improc/io/io.hpp
 #pragma once
+/** @file io.hpp
+ *  @brief Convenience header — includes all `improc::io` types:
+ *         CameraFrame, CameraSource, WebcamCapture, IPCameraCapture,
+ *         AnyCameraSource, OakDCapture, CameraCapture, ImageIO,
+ *         VideoReader, VideoWriter, VideoFileCapture.
+ */
 
 #include "improc/io/camera_frame.hpp"
 #include "improc/io/camera_source.hpp"

--- a/include/improc/io/ip_camera_capture.hpp
+++ b/include/improc/io/ip_camera_capture.hpp
@@ -12,8 +12,23 @@
 
 namespace improc::io {
 
+/**
+ * @brief Threaded RTSP / HTTP camera source that streams from a URL.
+ *
+ * Starts a background thread on `start()` that continuously reads frames
+ * via `cv::VideoCapture`. `getFrame()` returns the most recent decoded frame.
+ * Non-copyable and non-movable (owns a `std::thread`).
+ *
+ * @code
+ * IPCameraCapture cam("rtsp://192.168.1.100:554/stream");
+ * cam.start();
+ * auto frame = cam.getFrame();
+ * cam.stop();
+ * @endcode
+ */
 class IPCameraCapture {
 public:
+    /// @brief Constructs the capture for the given URL (RTSP, HTTP, or any OpenCV-compatible URI).
     explicit IPCameraCapture(std::string url);
     ~IPCameraCapture();
 
@@ -22,8 +37,12 @@ public:
     IPCameraCapture(IPCameraCapture&&) = delete;
     IPCameraCapture& operator=(IPCameraCapture&&) = delete;
 
+    /// @brief Opens the stream and starts the background capture thread.
     void start();
+    /// @brief Stops the capture thread and closes the stream.
     void stop();
+    /// @brief Returns the most recently decoded frame.
+    /// @return CameraUnavailable if start() was not called or the stream has no frames yet.
     std::expected<CameraFrame, improc::Error> getFrame();
 
 private:

--- a/include/improc/io/oak_d_capture.hpp
+++ b/include/improc/io/oak_d_capture.hpp
@@ -15,29 +15,32 @@
 
 namespace improc::io {
 
-// OakDCapture — streams aligned RGB + metric depth from an OAK-D camera.
-// Only available when compiled with -DIMPROC_WITH_DEPTHAI=ON.
-// Satisfies CameraSourceType<OakDCapture>.
-//
-// Usage:
-//   OakDCapture oak;                          // first found device
-//   OakDCapture oak("14442C10D13B8D1300");   // specific MX ID
-//   oak.start();
-//   auto frame = oak.getFrame();
-//   oak.stop();
-//
-// getFrame() blocks until both RGB and depth are available (up to timeout_ms_).
-// Returns Error::Code::Timeout if either queue times out.
-// Returns Error::Code::CameraUnavailable if start() was not called.
+/**
+ * @brief Streams aligned RGB + metric depth from a Luxonis OAK-D camera.
+ *
+ * Requires the library to be built with `-DIMPROC_WITH_DEPTHAI=ON`.
+ * Without it, all methods throw `std::runtime_error` at runtime.
+ * Satisfies `CameraSourceType<OakDCapture>`.
+ *
+ * @code
+ * OakDCapture oak;   // first available device
+ * oak.start();
+ * if (auto f = oak.getFrame()) {
+ *     cv::imshow("rgb",   f->rgb.mat());
+ *     cv::imshow("depth", f->depth->mat());
+ * }
+ * oak.stop();
+ * @endcode
+ */
 
 #ifdef IMPROC_WITH_DEPTHAI
 
 class OakDCapture {
 public:
-    // Constructs OakDCapture targeting the first available device.
+    /// @brief Constructs targeting the first available OAK-D device.
     OakDCapture();
 
-    // Constructs OakDCapture targeting a specific device by MX ID.
+    /// @brief Constructs targeting a specific device identified by MX ID.
     explicit OakDCapture(std::string mx_id);
 
     ~OakDCapture();
@@ -47,19 +50,14 @@ public:
     OakDCapture(OakDCapture&&) = delete;
     OakDCapture& operator=(OakDCapture&&) = delete;
 
-    // Opens the device and starts the pipeline. Idempotent.
+    /// @brief Opens the device and starts the DepthAI pipeline. Idempotent.
     void start();
 
-    // Stops the pipeline and closes the device. Idempotent.
+    /// @brief Stops the pipeline and closes the device. Idempotent.
     void stop();
 
-    // Blocks until an aligned RGB+depth pair is available, up to timeout_ms_.
-    // Returns a CameraFrame with both rgb and depth populated on success.
-    // Returns Error::Code::Timeout if either queue times out.
-    // Returns Error::Code::CameraUnavailable if not started.
-    //
-    // Thread safety: getFrame() and stop() must not be called concurrently.
-    // FramePipeline guarantees this — it stops the pipeline before joining workers.
+    /// @brief Returns an aligned RGB+depth frame, blocking up to 1000 ms per queue.
+    /// @return Error::Code::Timeout if either queue times out; CameraUnavailable if not started.
     std::expected<CameraFrame, improc::Error> getFrame();
 
 private:
@@ -77,9 +75,7 @@ static_assert(CameraSourceType<OakDCapture>);
 
 #else  // !IMPROC_WITH_DEPTHAI
 
-// Stub that fails at runtime when OAK-D support was not compiled in.
-// Provides the same interface so code can be written against it and
-// the build failure only happens at the call site when depthai is OFF.
+/// @brief Stub — OAK-D support not compiled in. All methods throw `std::runtime_error`.
 class OakDCapture {
 public:
     OakDCapture() = default;

--- a/include/improc/ml/augment/bbox_compose.hpp
+++ b/include/improc/ml/augment/bbox_compose.hpp
@@ -9,10 +9,18 @@
 
 namespace improc::ml {
 
+/**
+ * @brief Sequential pipeline of augmentation ops applied to `AnnotatedImage<Format>` (image + bounding boxes).
+ *
+ * Each op receives and returns the full annotated image, allowing ops to update box coordinates.
+ * Inherits `bind(rng)` from `BindMixin`.
+ */
 template<AnyFormat Format>
 struct BBoxCompose : detail::BindMixin<BBoxCompose<Format>> {
     using Op = std::function<AnnotatedImage<Format>(AnnotatedImage<Format>, std::mt19937&)>;
 
+    /// @brief Appends an annotated-image augmentation op.
+    /// @throws improc::ParameterError if `op` is null.
     BBoxCompose& add(Op op) {
         if (!op) throw ParameterError{"op", "must not be null", "BBoxCompose"};
         ops_.push_back(std::move(op));

--- a/include/improc/ml/augment/blur.hpp
+++ b/include/improc/ml/augment/blur.hpp
@@ -16,14 +16,34 @@ namespace improc::ml {
 using improc::core::AnyFormat;
 using improc::core::Image;
 
+/**
+ * @brief Randomly applies one of {Gaussian, Median, Bilateral} blur with a randomly sampled odd kernel size.
+ *
+ * @code
+ * std::mt19937 rng(42);
+ * auto aug = RandomBlur()
+ *     .types({RandomBlur::Type::Gaussian, RandomBlur::Type::Median})
+ *     .kernel_size(3, 7);
+ * img = img | aug.bind(rng);
+ * @endcode
+ */
 struct RandomBlur : detail::BindMixin<RandomBlur> {
-    enum class Type { Gaussian, Median, Bilateral };
+    /// @brief Blur algorithm choices.
+    enum class Type {
+        Gaussian,  ///< Gaussian blur via cv::GaussianBlur.
+        Median,    ///< Median blur via cv::medianBlur.
+        Bilateral  ///< Bilateral filter via cv::bilateralFilter.
+    };
 
+    /// @brief Sets the blur type pool to sample from (default: {Gaussian, Median}).
+    /// @throws improc::ParameterError if `t` is empty.
     RandomBlur& types(std::vector<Type> t) {
         if (t.empty())
             throw ParameterError{"types", "must not be empty", "RandomBlur"};
         types_ = std::move(t); return *this;
     }
+    /// @brief Sets the odd kernel-size range in [3, 31] (default: [3, 7]).
+    /// @throws improc::ParameterError if values are out of range or even.
     RandomBlur& kernel_size(int min_k, int max_k) {
         if (min_k < 3 || max_k > 31 || min_k % 2 == 0 || max_k % 2 == 0 || min_k > max_k)
             throw ParameterError{"kernel_size", "must be odd, in [3, 31], min <= max", "RandomBlur"};
@@ -73,12 +93,20 @@ private:
     int               max_k_  = 7;
 };
 
+/**
+ * @brief Randomly applies unsharp masking to enhance image sharpness.
+ * Applies with probability `p`; strength is sampled uniformly from [min_s, max_s].
+ */
 struct RandomSharpness : detail::BindMixin<RandomSharpness> {
+    /// @brief Sets the sharpness strength range (default: [0.0, 1.0]).
+    /// @throws improc::ParameterError if `min_s` < 0 or `min_s` > `max_s`.
     RandomSharpness& range(float min_s, float max_s) {
         if (min_s < 0.0f || min_s > max_s)
             throw ParameterError{"range", "must satisfy 0 <= min <= max", "RandomSharpness"};
         min_s_ = min_s; max_s_ = max_s; return *this;
     }
+    /// @brief Sets the application probability (default: 0.5).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomSharpness& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "RandomSharpness"};

--- a/include/improc/ml/augment/color.hpp
+++ b/include/improc/ml/augment/color.hpp
@@ -18,7 +18,12 @@ using improc::core::AnyFormat;
 using improc::core::BGRFormat;
 using improc::core::Image;
 
+/**
+ * @brief Multiplies all pixel values by a factor sampled uniformly from [low, high].
+ */
 struct RandomBrightness : detail::BindMixin<RandomBrightness> {
+    /// @brief Sets the brightness scale range (default: [0.8, 1.2]).
+    /// @throws improc::ParameterError if `low` <= 0 or `low` > `high`.
     RandomBrightness& range(float low, float high) {
         if (low <= 0.0f)
             throw ParameterError{"low", "must be > 0", "RandomBrightness"};
@@ -51,7 +56,13 @@ private:
     float high_ = 1.2f;
 };
 
+/**
+ * @brief Adjusts contrast via alpha blending with the channel mean:
+ * `dst = alpha * src + (1 - alpha) * mean`.
+ */
 struct RandomContrast : detail::BindMixin<RandomContrast> {
+    /// @brief Sets the contrast scale range (default: [0.8, 1.2]).
+    /// @throws improc::ParameterError if `low` <= 0 or `low` > `high`.
     RandomContrast& range(float low, float high) {
         if (low <= 0.0f)
             throw ParameterError{"low", "must be > 0", "RandomContrast"};
@@ -85,22 +96,43 @@ private:
     float high_ = 1.2f;
 };
 
+/**
+ * @brief Jointly randomises brightness, contrast, saturation, and hue of a BGR image.
+ *
+ * Only supports 8-bit `BGR` images. Hue is applied in HSV space.
+ *
+ * @code
+ * auto jitter = ColorJitter()
+ *     .brightness(0.8f, 1.2f)
+ *     .contrast(0.8f, 1.2f)
+ *     .saturation(0.8f, 1.2f)
+ *     .hue(-10.f, 10.f);
+ * @endcode
+ */
 struct ColorJitter : detail::BindMixin<ColorJitter> {
+    /// @brief Sets brightness multiplier range (default: [0.8, 1.2]).
+    /// @throws improc::ParameterError if `low` <= 0 or `low` > `high`.
     ColorJitter& brightness(float low, float high) {
         if (low <= 0.0f) throw ParameterError{"brightness.low", "must be > 0", "ColorJitter"};
         if (low > high)  throw ParameterError{"brightness.low", "must be <= high", "ColorJitter"};
         br_low_ = low; br_high_ = high; return *this;
     }
+    /// @brief Sets contrast scale range (default: [0.8, 1.2]).
+    /// @throws improc::ParameterError if `low` <= 0 or `low` > `high`.
     ColorJitter& contrast(float low, float high) {
         if (low <= 0.0f) throw ParameterError{"contrast.low", "must be > 0", "ColorJitter"};
         if (low > high)  throw ParameterError{"contrast.low", "must be <= high", "ColorJitter"};
         ct_low_ = low; ct_high_ = high; return *this;
     }
+    /// @brief Sets HSV saturation scale range (default: [0.8, 1.2]).
+    /// @throws improc::ParameterError if `low` <= 0 or `low` > `high`.
     ColorJitter& saturation(float low, float high) {
         if (low <= 0.0f) throw ParameterError{"saturation.low", "must be > 0", "ColorJitter"};
         if (low > high)  throw ParameterError{"saturation.low", "must be <= high", "ColorJitter"};
         sa_low_ = low; sa_high_ = high; return *this;
     }
+    /// @brief Sets hue shift range in degrees (default: [-10, 10]).
+    /// @throws improc::ParameterError if either bound is outside [-180, 180] or `low` > `high`.
     ColorJitter& hue(float low, float high) {
         if (std::abs(low) > 180.0f || std::abs(high) > 180.0f)
             throw ParameterError{"hue", "values must be in [-180, 180]", "ColorJitter"};
@@ -172,7 +204,13 @@ private:
     float hu_low_ = -10.f, hu_high_ = 10.0f;
 };
 
+/**
+ * @brief With probability `p`, converts a BGR image to grayscale (3-channel, equal channels).
+ * Non-BGR formats are returned unchanged.
+ */
 struct RandomGrayscale : detail::BindMixin<RandomGrayscale> {
+    /// @brief Sets the grayscale conversion probability (default: 0.1).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomGrayscale& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "RandomGrayscale"};
@@ -203,12 +241,20 @@ private:
     float p_ = 0.1f;
 };
 
+/**
+ * @brief With probability `p`, inverts pixel values at or above `threshold`.
+ * No-op on float images.
+ */
 struct RandomSolarize : detail::BindMixin<RandomSolarize> {
+    /// @brief Sets the solarization threshold in [0, 255] (default: 128).
+    /// @throws improc::ParameterError if `t` is outside [0, 255].
     RandomSolarize& threshold(int t) {
         if (t < 0 || t > 255)
             throw ParameterError{"threshold", "must be in [0, 255]", "RandomSolarize"};
         threshold_ = t; return *this;
     }
+    /// @brief Sets the application probability (default: 0.5).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomSolarize& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "RandomSolarize"};
@@ -243,12 +289,20 @@ private:
     float p_         = 0.5f;
 };
 
+/**
+ * @brief With probability `p`, reduces each channel to `bits` significant bits.
+ * No-op on float images.
+ */
 struct RandomPosterize : detail::BindMixin<RandomPosterize> {
+    /// @brief Sets the bit depth to retain per channel (default: 4). Must be in [1, 8].
+    /// @throws improc::ParameterError if `b` is outside [1, 8].
     RandomPosterize& bits(int b) {
         if (b < 1 || b > 8)
             throw ParameterError{"bits", "must be in [1, 8]", "RandomPosterize"};
         bits_ = b; return *this;
     }
+    /// @brief Sets the application probability (default: 0.5).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomPosterize& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "RandomPosterize"};
@@ -284,7 +338,14 @@ private:
     float p_    = 0.5f;
 };
 
+/**
+ * @brief With probability `p`, applies histogram equalisation.
+ * BGR: equalises the Y channel of YCrCb. Gray: direct `equalizeHist`.
+ * Other formats are returned unchanged.
+ */
 struct RandomEqualize : detail::BindMixin<RandomEqualize> {
+    /// @brief Sets the application probability (default: 0.5).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomEqualize& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "RandomEqualize"};

--- a/include/improc/ml/augment/compose.hpp
+++ b/include/improc/ml/augment/compose.hpp
@@ -15,10 +15,25 @@ namespace improc::ml {
 using improc::core::AnyFormat;
 using improc::core::Image;
 
+/**
+ * @brief Sequential pipeline of augmentation ops applied to `Image<Format>`.
+ *
+ * Each op is stored as `std::function<Image<Format>(Image<Format>, std::mt19937&)>`.
+ * Ops are applied in insertion order. Inherits `bind(rng)` from `BindMixin`.
+ *
+ * @code
+ * std::mt19937 rng(42);
+ * Compose<BGR> aug;
+ * aug.add([](Image<BGR> img, std::mt19937& r) { return RandomFlip{}(img, r); })
+ *    .add([](Image<BGR> img, std::mt19937& r) { return ColorJitter{}(img, r); });
+ * img = img | aug.bind(rng);
+ * @endcode
+ */
 template<AnyFormat Format>
 struct Compose : detail::BindMixin<Compose<Format>> {
     using AugFn = std::function<Image<Format>(Image<Format>, std::mt19937&)>;
 
+    /// @brief Appends an augmentation op to the pipeline.
     template<typename Aug>
         requires std::invocable<Aug&, Image<Format>, std::mt19937&>
     Compose& add(Aug aug) {
@@ -36,6 +51,11 @@ private:
     std::vector<AugFn> steps_;
 };
 
+/**
+ * @brief Applies a single augmentation op with probability `p`.
+ *
+ * Wraps any op that takes `(Image<Format>, std::mt19937&)`.
+ */
 template<AnyFormat Format>
 struct RandomApply : detail::BindMixin<RandomApply<Format>> {
     using AugFn = std::function<Image<Format>(Image<Format>, std::mt19937&)>;
@@ -52,6 +72,8 @@ private:
     }
 
 public:
+    /// @brief Constructs with an augmentation op and application probability.
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     template<typename Aug>
     RandomApply(Aug aug, float p) : p_(validate_p(p)), aug_(std::move(aug)) {}
 
@@ -62,10 +84,14 @@ public:
     }
 };
 
+/**
+ * @brief Uniformly samples one op from a registered pool and applies it.
+ */
 template<AnyFormat Format>
 struct OneOf : detail::BindMixin<OneOf<Format>> {
     using AugFn = std::function<Image<Format>(Image<Format>, std::mt19937&)>;
 
+    /// @brief Adds an op to the selection pool.
     template<typename Aug>
         requires std::invocable<Aug&, Image<Format>, std::mt19937&>
     OneOf& add(Aug aug) {

--- a/include/improc/ml/augment/detail.hpp
+++ b/include/improc/ml/augment/detail.hpp
@@ -5,11 +5,23 @@
 
 namespace improc::ml::detail {
 
+/**
+ * @brief CRTP mixin that adds `bind(rng)` to augmentation ops.
+ *
+ * Inherit from `BindMixin<Derived>` to get a `bind()` method that wraps
+ * `operator()(img, rng)` into a unary functor compatible with `operator|`.
+ *
+ * @code
+ * std::mt19937 rng(42);
+ * img = img | RandomFlip().bind(rng);
+ * @endcode
+ *
+ * @tparam Derived The concrete augmentation struct.
+ */
 template<typename Derived>
 struct BindMixin {
-    // Returns a unary functor (Image<Format> → Image<Format>) for use with operator|.
-    // The caller's rng must outlive the returned functor.
-    // Intended for immediate operator| use: img | aug.bind(rng). Do not store across rng's scope.
+    /// @brief Returns a unary functor `Image<F> → Image<F>` for use with `operator|`.
+    /// @warning The caller's `rng` must outlive the returned functor.
     [[nodiscard]] auto bind(std::mt19937& rng) const {
         return [derived = static_cast<const Derived&>(*this), &rng](auto img) {
             return derived(std::move(img), rng);

--- a/include/improc/ml/augment/erase.hpp
+++ b/include/improc/ml/augment/erase.hpp
@@ -15,22 +15,41 @@ namespace improc::ml {
 using improc::core::AnyFormat;
 using improc::core::Image;
 
+/**
+ * @brief With probability `p`, erases a randomly placed rectangle filled with `value`.
+ *
+ * Area and aspect ratio of the erased region are sampled from the given ranges.
+ * Up to 10 placement attempts are made; if all fail the image is returned unchanged.
+ *
+ * @code
+ * auto erase = RandomErasing().p(0.5f).scale(0.02f, 0.33f).value(0);
+ * img = img | erase.bind(rng);
+ * @endcode
+ */
 struct RandomErasing : detail::BindMixin<RandomErasing> {
+    /// @brief Sets the application probability (default: 0.5).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomErasing& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "RandomErasing"};
         p_ = prob; return *this;
     }
+    /// @brief Sets the erased area as a fraction of the total image area (default: [0.02, 0.33]).
+    /// @throws improc::ParameterError if `min_s` <= 0 or `max_s` > 1 or `min_s` > `max_s`.
     RandomErasing& scale(float min_s, float max_s) {
         if (min_s <= 0.0f || max_s > 1.0f || min_s > max_s)
             throw ParameterError{"scale", "must satisfy 0 < min <= max <= 1", "RandomErasing"};
         min_s_ = min_s; max_s_ = max_s; return *this;
     }
+    /// @brief Sets the aspect ratio range of the erased rectangle (default: [0.3, 3.3]).
+    /// @throws improc::ParameterError if `min_r` <= 0 or `min_r` > `max_r`.
     RandomErasing& ratio(float min_r, float max_r) {
         if (min_r <= 0.0f || min_r > max_r)
             throw ParameterError{"ratio", "must satisfy 0 < min <= max", "RandomErasing"};
         min_r_ = min_r; max_r_ = max_r; return *this;
     }
+    /// @brief Sets the fill value for 8-bit images in [0, 255] (default: 0). Float images use `value/255`.
+    /// @throws improc::ParameterError if `v` is outside [0, 255].
     RandomErasing& value(int v) {
         if (v < 0 || v > 255)
             throw ParameterError{"value", "must be in [0, 255]", "RandomErasing"};
@@ -73,17 +92,26 @@ private:
     int   value_ = 0;
 };
 
+/**
+ * @brief Randomly zeros out grid cells of size `unit_size × unit_size` with probability `ratio`.
+ */
 struct GridDropout : detail::BindMixin<GridDropout> {
+    /// @brief Sets the per-cell dropout probability (default: 0.5). Must be in (0, 1).
+    /// @throws improc::ParameterError if `r` is outside (0, 1).
     GridDropout& ratio(float r) {
         if (r <= 0.0f || r >= 1.0f)
             throw ParameterError{"ratio", "must be in (0, 1)", "GridDropout"};
         ratio_ = r; return *this;
     }
+    /// @brief Sets the grid cell size in pixels (default: 32).
+    /// @throws improc::ParameterError if `s` <= 0.
     GridDropout& unit_size(int s) {
         if (s <= 0)
             throw ParameterError{"unit_size", "must be positive", "GridDropout"};
         unit_size_ = s; return *this;
     }
+    /// @brief Sets the fill value in [0, 255] (default: 0). Float images use `value / 255.0`.
+    /// @throws improc::ParameterError if `v` is outside [0, 255].
     GridDropout& value(int v) {
         if (v < 0 || v > 255)
             throw ParameterError{"value", "must be in [0, 255]", "GridDropout"};

--- a/include/improc/ml/augment/geometric.hpp
+++ b/include/improc/ml/augment/geometric.hpp
@@ -59,13 +59,27 @@ inline bool keep_box(cv::Rect2f clipped, cv::Rect2f original, float threshold) {
 
 } // namespace detail
 
+/**
+ * @brief Randomly flips an image (and its bounding boxes / segmentation mask) along a spatial axis.
+ *
+ * @code
+ * std::mt19937 rng(42);
+ * auto flip = RandomFlip().p(0.5f).axis(core::Axis::Horizontal);
+ * img = img | flip.bind(rng);
+ * @endcode
+ */
 struct RandomFlip : detail::BindMixin<RandomFlip> {
+    /// @brief Sets the flip probability (default: 0.5).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomFlip& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", std::format("must be in [0, 1], got {}", prob), "RandomFlip"};
         p_ = prob; return *this;
     }
+    /// @brief Sets the flip axis (default: Horizontal).
     RandomFlip& axis(core::Axis a) { axis_ = a; return *this; }
+    /// @brief Sets the minimum retained area ratio for bounding boxes after flip (default: 0.1).
+    /// @throws improc::ParameterError if `r` is outside [0, 1].
     RandomFlip& min_area_ratio(float r) {
         if (r < 0.0f || r > 1.0f)
             throw ParameterError{"min_area_ratio", "must be in [0, 1]", "RandomFlip"};
@@ -139,17 +153,27 @@ private:
     float      min_area_ratio_  = 0.1f;
 };
 
+/**
+ * @brief Randomly rotates an image by an angle sampled uniformly from [min_deg, max_deg].
+ * Bounding boxes are transformed via corner-rotation + axis-aligned re-fitting.
+ */
 struct RandomRotate : detail::BindMixin<RandomRotate> {
+    /// @brief Sets the rotation range in degrees (default: [-15, 15]).
+    /// @throws improc::ParameterError if `min_deg` > `max_deg`.
     RandomRotate& range(float min_deg, float max_deg) {
         if (min_deg > max_deg)
             throw ParameterError{"min_deg", "must be <= max_deg", "RandomRotate"};
         min_deg_ = min_deg; max_deg_ = max_deg; return *this;
     }
+    /// @brief Sets the rotation scale factor (default: 1.0).
+    /// @throws improc::ParameterError if `s` <= 0.
     RandomRotate& scale(float s) {
         if (s <= 0.0f)
             throw ParameterError{"scale", "must be > 0", "RandomRotate"};
         scale_ = s; return *this;
     }
+    /// @brief Sets the minimum retained area ratio for bounding boxes (default: 0.1).
+    /// @throws improc::ParameterError if `r` is outside [0, 1].
     RandomRotate& min_area_ratio(float r) {
         if (r < 0.0f || r > 1.0f)
             throw ParameterError{"min_area_ratio", "must be in [0, 1]", "RandomRotate"};
@@ -226,15 +250,25 @@ private:
     float min_area_ratio_  =   0.1f;
 };
 
+/**
+ * @brief Randomly crops a fixed-size region from an image.
+ * Bounding boxes that fall outside the crop region by more than `min_area_ratio` are discarded.
+ */
 struct RandomCrop : detail::BindMixin<RandomCrop> {
+    /// @brief Sets the crop width in pixels. Must be called before `operator()`.
+    /// @throws improc::ParameterError if `w` <= 0.
     RandomCrop& width(int w) {
         if (w <= 0) throw ParameterError{"width", "must be positive", "RandomCrop"};
         width_ = w; return *this;
     }
+    /// @brief Sets the crop height in pixels. Must be called before `operator()`.
+    /// @throws improc::ParameterError if `h` <= 0.
     RandomCrop& height(int h) {
         if (h <= 0) throw ParameterError{"height", "must be positive", "RandomCrop"};
         height_ = h; return *this;
     }
+    /// @brief Sets the minimum retained area ratio for bounding boxes (default: 0.1).
+    /// @throws improc::ParameterError if `r` is outside [0, 1].
     RandomCrop& min_area_ratio(float r) {
         if (r < 0.0f || r > 1.0f)
             throw ParameterError{"min_area_ratio", "must be in [0, 1]", "RandomCrop"};
@@ -311,7 +345,13 @@ private:
     float min_area_ratio_  = 0.1f;
 };
 
+/**
+ * @brief Randomly resizes an image so its shorter side equals a value sampled from [min_side, max_side].
+ * Aspect ratio is preserved. Bounding box coordinates are scaled proportionally.
+ */
 struct RandomResize : detail::BindMixin<RandomResize> {
+    /// @brief Sets the shorter-side target range in pixels (default: [224, 256]).
+    /// @throws improc::ParameterError if `min_side` <= 0 or `min_side` > `max_side`.
     RandomResize& range(int min_side, int max_side) {
         if (min_side <= 0)
             throw ParameterError{"min_side", "must be > 0", "RandomResize"};
@@ -319,6 +359,8 @@ struct RandomResize : detail::BindMixin<RandomResize> {
             throw ParameterError{"min_side", "must be <= max_side", "RandomResize"};
         min_side_ = min_side; max_side_ = max_side; return *this;
     }
+    /// @brief Sets the minimum retained area ratio for bounding boxes (default: 0.1).
+    /// @throws improc::ParameterError if `r` is outside [0, 1].
     RandomResize& min_area_ratio(float r) {
         if (r < 0.0f || r > 1.0f)
             throw ParameterError{"min_area_ratio", "must be in [0, 1]", "RandomResize"};
@@ -395,7 +437,12 @@ private:
     float min_area_ratio_  = 0.1f;
 };
 
+/**
+ * @brief Randomly zooms into an image by cropping a fraction of [min_scale, max_scale] and upscaling back.
+ */
 struct RandomZoom : detail::BindMixin<RandomZoom> {
+    /// @brief Sets the crop scale range as a fraction of the image side (default: [0.7, 1.0]).
+    /// @throws improc::ParameterError if values are outside (0, 1].
     RandomZoom& range(float min_scale, float max_scale) {
         if (min_scale <= 0.0f || max_scale <= 0.0f || min_scale > 1.0f || max_scale > 1.0f)
             throw ParameterError{"min_scale/max_scale", "must be in (0, 1]", "RandomZoom"};
@@ -403,6 +450,8 @@ struct RandomZoom : detail::BindMixin<RandomZoom> {
             throw ParameterError{"min_scale", "must be <= max_scale", "RandomZoom"};
         min_scale_ = min_scale; max_scale_ = max_scale; return *this;
     }
+    /// @brief Sets the minimum retained area ratio for bounding boxes (default: 0.1).
+    /// @throws improc::ParameterError if `r` is outside [0, 1].
     RandomZoom& min_area_ratio(float r) {
         if (r < 0.0f || r > 1.0f)
             throw ParameterError{"min_area_ratio", "must be in [0, 1]", "RandomZoom"};
@@ -486,17 +535,26 @@ private:
     float min_area_ratio_  = 0.1f;
 };
 
+/**
+ * @brief Applies a random affine shear transformation along one axis.
+ */
 struct RandomShear : detail::BindMixin<RandomShear> {
+    /// @brief Sets the shear angle range in degrees (default: [-15, 15]).
+    /// @throws improc::ParameterError if `min_deg` > `max_deg`.
     RandomShear& range(float min_deg, float max_deg) {
         if (min_deg > max_deg)
             throw ParameterError{"min_deg", "must be <= max_deg", "RandomShear"};
         min_deg_ = min_deg; max_deg_ = max_deg; return *this;
     }
+    /// @brief Sets the shear axis — Horizontal or Vertical (default: Horizontal).
+    /// @throws improc::ParameterError if `Axis::Both` is passed.
     RandomShear& axis(core::Axis a) {
         if (a == core::Axis::Both)
             throw ParameterError{"axis", "Axis::Both is not supported; use Horizontal or Vertical", "RandomShear"};
         axis_ = a; return *this;
     }
+    /// @brief Sets the minimum retained area ratio for bounding boxes (default: 0.1).
+    /// @throws improc::ParameterError if `r` is outside [0, 1].
     RandomShear& min_area_ratio(float r) {
         if (r < 0.0f || r > 1.0f)
             throw ParameterError{"min_area_ratio", "must be in [0, 1]", "RandomShear"};
@@ -579,12 +637,20 @@ private:
     float      min_area_ratio_ =   0.1f;
 };
 
+/**
+ * @brief Applies a random perspective (projective) warp.
+ * Each corner of the image is perturbed by up to `distortion_scale * min(W,H) / 2` pixels.
+ */
 struct RandomPerspective : detail::BindMixin<RandomPerspective> {
+    /// @brief Sets the corner perturbation scale in [0, 1] (default: 0.5).
+    /// @throws improc::ParameterError if `s` is outside [0, 1].
     RandomPerspective& distortion_scale(float s) {
         if (s < 0.0f || s > 1.0f)
             throw ParameterError{"distortion_scale", "must be in [0, 1]", "RandomPerspective"};
         distortion_scale_ = s; return *this;
     }
+    /// @brief Sets the minimum retained area ratio for bounding boxes (default: 0.1).
+    /// @throws improc::ParameterError if `r` is outside [0, 1].
     RandomPerspective& min_area_ratio(float r) {
         if (r < 0.0f || r > 1.0f)
             throw ParameterError{"min_area_ratio", "must be in [0, 1]", "RandomPerspective"};

--- a/include/improc/ml/augment/mixup.hpp
+++ b/include/improc/ml/augment/mixup.hpp
@@ -27,18 +27,34 @@ inline float sample_beta(float alpha, std::mt19937& rng) {
 }
 } // namespace detail
 
+/**
+ * @brief Applies MixUp augmentation: blends two `LabeledImage<F>` samples by a Beta(alpha, alpha) weight.
+ *
+ * Reference: Zhang et al., "mixup: Beyond Empirical Risk Minimisation", ICLR 2018.
+ *
+ * @code
+ * std::mt19937 rng(42);
+ * auto mixed = MixUp().alpha(0.4f)(a, b, rng);
+ * @endcode
+ */
 struct MixUp {
+    /// @brief Sets the Beta distribution concentration parameter (default: 0.4).
+    /// @throws improc::ParameterError if `a` <= 0.
     MixUp& alpha(float a) {
         if (a <= 0.0f)
             throw ParameterError{"alpha", "must be > 0", "MixUp"};
         alpha_ = a; return *this;
     }
+    /// @brief Sets the application probability (default: 1.0).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     MixUp& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "MixUp"};
         p_ = prob; return *this;
     }
 
+    /// @brief Mixes `a` with `b` using a Beta-sampled weight.
+    /// @throws improc::ParameterError if images differ in size or label vectors differ in length.
     template<AnyFormat F>
     LabeledImage<F> operator()(LabeledImage<F> a,
                                 const LabeledImage<F>& b,
@@ -72,12 +88,22 @@ private:
     float p_     = 1.0f;
 };
 
+/**
+ * @brief Applies CutMix: pastes a rectangular patch from a secondary image into the primary,
+ * with soft labels proportional to the patch area.
+ *
+ * Reference: Yun et al., "CutMix: Training Strategy", ICCV 2019.
+ */
 struct CutMix {
+    /// @brief Sets the Beta distribution concentration parameter (default: 1.0).
+    /// @throws improc::ParameterError if `a` <= 0.
     CutMix& alpha(float a) {
         if (a <= 0.0f)
             throw ParameterError{"alpha", "must be > 0", "CutMix"};
         alpha_ = a; return *this;
     }
+    /// @brief Sets the application probability (default: 1.0).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     CutMix& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", "must be in [0, 1]", "CutMix"};
@@ -136,12 +162,17 @@ private:
     float p_     = 1.0f;
 };
 
+/**
+ * @brief Sequential pipeline of mix-style augmentation ops (MixUp, CutMix) applied to pairs of `LabeledImage<F>`.
+ */
 template<AnyFormat Format>
 struct MixCompose {
     using Op = std::function<LabeledImage<Format>(LabeledImage<Format>,
                                                    const LabeledImage<Format>&,
                                                    std::mt19937&)>;
 
+    /// @brief Appends a mix op to the pipeline.
+    /// @throws improc::ParameterError if `op` is null.
     MixCompose& add(Op op) {
         if (!op) throw ParameterError{"op", "must not be null", "MixCompose"};
         ops_.push_back(std::move(op));
@@ -156,8 +187,8 @@ struct MixCompose {
         return primary;
     }
 
-    // secondary, rng, and this MixCompose must outlive the returned functor.
-    // Intended for immediate operator| use: `li | pipe.bind(b, rng)`.
+    /// @brief Returns a unary functor `LabeledImage<F> → LabeledImage<F>` for use with `operator|`.
+    /// @warning `secondary`, `rng`, and this `MixCompose` must outlive the returned functor.
     [[nodiscard]] auto bind(const LabeledImage<Format>& secondary, std::mt19937& rng) const {
         return [this, &secondary, &rng](LabeledImage<Format> primary) {
             return (*this)(std::move(primary), secondary, rng);

--- a/include/improc/ml/augment/noise.hpp
+++ b/include/improc/ml/augment/noise.hpp
@@ -14,7 +14,13 @@ namespace improc::ml {
 using improc::core::AnyFormat;
 using improc::core::Image;
 
+/**
+ * @brief Adds Gaussian noise with zero mean and a standard deviation sampled from [std_low, std_high].
+ * Pixel values are clamped to the valid range after noise addition.
+ */
 struct RandomGaussianNoise : detail::BindMixin<RandomGaussianNoise> {
+    /// @brief Sets the standard deviation range (default: [5.0, 20.0]).
+    /// @throws improc::ParameterError if `low` < 0 or `low` > `high`.
     RandomGaussianNoise& std_dev(float low, float high) {
         if (low < 0.0f)
             throw ParameterError{"std_dev.low", "must be >= 0", "RandomGaussianNoise"};
@@ -22,6 +28,7 @@ struct RandomGaussianNoise : detail::BindMixin<RandomGaussianNoise> {
             throw ParameterError{"std_dev.low", "must be <= high", "RandomGaussianNoise"};
         std_low_ = low; std_high_ = high; return *this;
     }
+    /// @brief Sets the noise mean (default: 0.0).
     RandomGaussianNoise& mean(float m) { mean_ = m; return *this; }
 
     template<AnyFormat Format>
@@ -54,7 +61,13 @@ private:
     float mean_     =  0.0f;
 };
 
+/**
+ * @brief Randomly sets pixels to 0 (pepper) or max (salt) with probability `p` per pixel.
+ * Supports 8-bit and float32 images.
+ */
 struct RandomSaltAndPepper : detail::BindMixin<RandomSaltAndPepper> {
+    /// @brief Sets the per-pixel noise probability (default: 0.05).
+    /// @throws improc::ParameterError if `prob` is outside [0, 1].
     RandomSaltAndPepper& p(float prob) {
         if (prob < 0.0f || prob > 1.0f)
             throw ParameterError{"p", std::format("must be in [0, 1], got {}", prob), "RandomSaltAndPepper"};

--- a/include/improc/ml/augment/seg_compose.hpp
+++ b/include/improc/ml/augment/seg_compose.hpp
@@ -9,10 +9,18 @@
 
 namespace improc::ml {
 
+/**
+ * @brief Sequential pipeline of augmentation ops applied to `SegmentedImage<Format>` (image + class/instance masks).
+ *
+ * Each op receives and returns the full segmented image, ensuring masks stay aligned.
+ * Inherits `bind(rng)` from `BindMixin`.
+ */
 template<AnyFormat Format>
 struct SegCompose : detail::BindMixin<SegCompose<Format>> {
     using Op = std::function<SegmentedImage<Format>(SegmentedImage<Format>, std::mt19937&)>;
 
+    /// @brief Appends a segmented-image augmentation op.
+    /// @throws improc::ParameterError if `op` is null.
     SegCompose& add(Op op) {
         if (!op) throw ParameterError{"op", "must not be null", "SegCompose"};
         ops_.push_back(std::move(op));

--- a/include/improc/ml/eval/classification.hpp
+++ b/include/improc/ml/eval/classification.hpp
@@ -8,29 +8,63 @@
 
 namespace improc::ml {
 
+/// @brief Computes overall accuracy: correct / total.
+/// @return Value in [0, 1]. Returns 0 if predictions is empty.
 [[nodiscard]] float accuracy(std::span<const int> preds, std::span<const int> gts);
+
+/// @brief Computes precision for a specific class.
+/// @return Value in [0, 1].
 [[nodiscard]] float precision_score(std::span<const int> preds, std::span<const int> gts, int class_id);
+
+/// @brief Computes recall for a specific class.
+/// @return Value in [0, 1].
 [[nodiscard]] float recall_score(std::span<const int> preds, std::span<const int> gts, int class_id);
+
+/// @brief Computes F1 score for a specific class.
+/// @return Value in [0, 1].
 [[nodiscard]] float f1_score(std::span<const int> preds, std::span<const int> gts, int class_id);
 
+/**
+ * @brief Dense confusion matrix as a `num_classes × num_classes` OpenCV matrix.
+ *
+ * `mat(i, j)` is the count of samples with true class `i` predicted as class `j`.
+ */
 struct ConfusionMatrix {
-    cv::Mat_<int> mat;
-    int num_classes = 0;
+    cv::Mat_<int> mat;   ///< CV_32S confusion matrix (num_classes × num_classes).
+    int num_classes = 0; ///< Number of classes.
 };
 
+/**
+ * @brief Per-class and aggregate classification metrics computed from a confusion matrix.
+ */
 struct ClassMetrics {
-    float accuracy = 0.0f;
-    std::map<std::string, float> per_class_precision;
-    std::map<std::string, float> per_class_recall;
-    std::map<std::string, float> per_class_f1;
-    ConfusionMatrix confusion_matrix;
+    float accuracy = 0.0f;                            ///< Overall accuracy in [0, 1].
+    std::map<std::string, float> per_class_precision; ///< Precision per class name.
+    std::map<std::string, float> per_class_recall;    ///< Recall per class name.
+    std::map<std::string, float> per_class_f1;        ///< F1 score per class name.
+    ConfusionMatrix confusion_matrix;                 ///< Full confusion matrix.
 };
 
+/**
+ * @brief Stateful accumulator that aggregates predictions and computes `ClassMetrics`.
+ *
+ * @code
+ * ClassEval eval;
+ * eval.class_names({"cat", "dog", "bird"});
+ * eval.update(pred_class, gt_class);
+ * auto metrics = eval.compute();
+ * @endcode
+ */
 struct ClassEval {
+    /// @brief Sets the class names. Must be called before `update()`.
     ClassEval& class_names(std::vector<std::string> names);
 
+    /// @brief Appends a single prediction and ground-truth label.
     void update(int pred_class, int gt_class);
+    /// @brief Computes and returns the classification metrics from all accumulated data.
+    /// @return `ClassMetrics` aggregating all calls to `update()`.
     [[nodiscard]] ClassMetrics compute() const;
+    /// @brief Resets all prediction data. Class name mappings are preserved.
     void reset();
 
 private:

--- a/include/improc/ml/eval/detection.hpp
+++ b/include/improc/ml/eval/detection.hpp
@@ -11,30 +11,53 @@
 
 namespace improc::ml {
 
-// Intersection over Union of two bounding boxes.
-// Returns 0.0 when either box has zero area.
+/// @brief Computes the Intersection-over-Union of two axis-aligned bounding boxes.
+/// @param a First bounding box.
+/// @param b Second bounding box.
+/// @return Value in [0, 1]. Returns 0 if either box has zero area.
 [[nodiscard]] float iou(const BBox& a, const BBox& b);
 
-// Area under the precision-recall curve using 101-point COCO interpolation.
-// recalls and precisions must have the same length.
+/// @brief Computes Average Precision (AP) using the 101-point interpolation (COCO style).
+/// @param recalls    Recall values in ascending order.
+/// @param precisions Precision values corresponding to `recalls`.
+/// @return AP in [0, 1].
 [[nodiscard]] float average_precision(std::span<const float> recalls,
                                       std::span<const float> precisions);
 
+/**
+ * @brief mAP and per-class AP detection metrics at IoU thresholds 0.50 and 0.50:0.95.
+ */
 struct DetectionMetrics {
-    float mAP_50    = 0.0f;
-    float mAP_50_95 = 0.0f;
-    std::map<std::string, float> per_class_AP;
+    float mAP_50    = 0.0f; ///< Mean Average Precision at IoU ≥ 0.50.
+    float mAP_50_95 = 0.0f; ///< Mean AP averaged over IoU thresholds 0.50–0.95 (step 0.05).
+    std::map<std::string, float> per_class_AP; ///< AP@0.50 per class name.
 };
 
+/**
+ * @brief Stateful accumulator for object detection evaluation.
+ *
+ * Accumulates predictions and ground truths across frames, then computes
+ * mAP@0.50 and mAP@0.50:0.95 matching COCO evaluation conventions.
+ *
+ * @code
+ * DetectionEval eval;
+ * eval.update(predictions, ground_truths);
+ * auto metrics = eval.compute();
+ * @endcode
+ */
 struct DetectionEval {
+    /// @brief Appends a frame's predicted `Detection` list and ground-truth `BBox` list.
     void update(const std::vector<Detection>& preds,
                 const std::vector<BBox>&      gts);
+    /// @brief Computes and returns detection metrics from all accumulated data.
     [[nodiscard]] DetectionMetrics compute() const;
-    // Returns recall[] and precision[] per class at IoU=0.50.
-    // Recalls are non-decreasing. Returns empty map before any update() calls.
+    /// @brief Returns recall and precision curves per class at IoU=0.50.
+    ///
+    /// Recalls are non-decreasing. Returns empty map before any `update()` calls.
     [[nodiscard]]
     std::map<std::string, std::pair<std::vector<float>, std::vector<float>>>
     pr_curves() const;
+    /// @brief Resets all accumulated state.
     void reset();
 
 private:

--- a/include/improc/ml/eval/eval.hpp
+++ b/include/improc/ml/eval/eval.hpp
@@ -1,6 +1,11 @@
 // include/improc/ml/eval/eval.hpp
 #pragma once
 
+/** @file eval.hpp
+ *  @brief Convenience header — includes all `improc::ml` evaluation types
+ *         (classification, detection, segmentation).
+ */
+
 #include "improc/ml/eval/detection.hpp"
 #include "improc/ml/eval/segmentation.hpp"
 #include "improc/ml/eval/classification.hpp"

--- a/include/improc/ml/eval/segmentation.hpp
+++ b/include/improc/ml/eval/segmentation.hpp
@@ -11,21 +11,42 @@ namespace improc::ml {
 using improc::core::Gray;
 using improc::core::Image;
 
-// Pixel IoU for class_id over two single-channel masks.
-// Pixels where gt == 255 (void label) are ignored.
+/// @brief Computes pixel-level IoU for `class_id` over two single-channel label masks.
+/// @param pred      Predicted class mask (`Image<Gray>`).
+/// @param gt        Ground-truth class mask. Pixels equal to 255 (void label) are ignored.
+/// @param class_id  The class index to evaluate.
+/// @return IoU in [0, 1], or 0 if neither mask contains `class_id`.
 [[nodiscard]] float pixel_iou(const Image<Gray>& pred, const Image<Gray>& gt, int class_id);
 
-// Dice coefficient for class_id. Same void-pixel rule as pixel_iou.
+/// @brief Computes the Dice coefficient for `class_id` (same void-pixel rule as `pixel_iou`).
+/// @param pred      Predicted class mask (`Image<Gray>`).
+/// @param gt        Ground-truth class mask. Pixels equal to 255 (void label) are ignored.
+/// @param class_id  The class index to evaluate.
+/// @return Dice score in [0, 1], or 0 if neither mask contains `class_id`.
 [[nodiscard]] float dice(const Image<Gray>& pred, const Image<Gray>& gt, int class_id);
 
+/**
+ * @brief Per-class and mean IoU / Dice segmentation metrics.
+ */
 struct SegMetrics {
-    float mIoU      = 0.0f;
-    float mean_dice = 0.0f;
-    std::map<int, float> per_class_iou;
-    std::map<int, float> per_class_dice;
+    float mIoU      = 0.0f; ///< Mean IoU averaged over all classes present in ground truth.
+    float mean_dice = 0.0f; ///< Mean Dice score averaged over all classes present in ground truth.
+    std::map<int, float> per_class_iou;  ///< IoU per class index.
+    std::map<int, float> per_class_dice; ///< Dice per class index.
 };
 
+/**
+ * @brief Stateful accumulator for semantic segmentation evaluation.
+ *
+ * @code
+ * SegEval eval;
+ * eval.num_classes(21);
+ * eval.update(pred_mask, gt_mask);
+ * auto metrics = eval.compute();
+ * @endcode
+ */
 struct SegEval {
+    /// @brief Sets the number of classes. Resets all accumulated state.
     SegEval& num_classes(int n) {
         num_classes_ = n;
         tp_.assign(n, 0);
@@ -34,8 +55,11 @@ struct SegEval {
         return *this;
     }
 
+    /// @brief Appends one frame's predicted and ground-truth label masks.
     void update(const Image<Gray>& pred_mask, const Image<Gray>& gt_mask);
+    /// @brief Computes and returns segmentation metrics from all accumulated data.
     [[nodiscard]] SegMetrics compute() const;
+    /// @brief Resets all accumulated state.
     void reset();
 
 private:

--- a/include/improc/onnx/onnx.hpp
+++ b/include/improc/onnx/onnx.hpp
@@ -1,6 +1,13 @@
 // include/improc/onnx/onnx.hpp
 #pragma once
 
+/** @file onnx.hpp
+ *  @brief Convenience header — includes all `improc::onnx` types:
+ *         OnnxSession, OnnxClassifier, OnnxDetector.
+ *
+ *  Individual headers are fully documented; this umbrella exists for single-include convenience.
+ */
+
 #include "improc/onnx/onnx_session.hpp"
 #include "improc/onnx/onnx_classifier.hpp"
 #include "improc/onnx/onnx_detector.hpp"

--- a/include/improc/visualization/class_bar_chart.hpp
+++ b/include/improc/visualization/class_bar_chart.hpp
@@ -27,8 +27,19 @@ inline const cv::Scalar kCyan  {248, 189,  56};
 inline const cv::Scalar kGreen {153, 211,  52};
 } // namespace detail::cbc
 
+/**
+ * @brief Renders a per-class bar chart for Precision/Recall/F1 or AP metrics.
+ *
+ * Three constructors accept `ClassMetrics` (P/R/F1 bars), `DetectionMetrics` (AP bar),
+ * or a raw `map<string, array<float,3>>`.
+ *
+ * @code
+ * auto chart = ClassBarChart(metrics).width(800).height(400).title("Validation");
+ * auto img   = chart();
+ * @endcode
+ */
 struct ClassBarChart {
-    // From ClassMetrics: 3 bars per class (P/R/F1)
+    /// @brief Constructs from `ClassMetrics` — renders 3 bars per class (Precision, Recall, F1).
     explicit ClassBarChart(const improc::ml::ClassMetrics& m) {
         for (const auto& [cls, p] : m.per_class_precision) {
             float r = m.per_class_recall.count(cls) ? m.per_class_recall.at(cls) : 0.f;
@@ -37,22 +48,27 @@ struct ClassBarChart {
         }
     }
 
-    // From DetectionMetrics: 1 bar per class (AP only)
+    /// @brief Constructs from `DetectionMetrics` — renders 1 AP bar per class.
     explicit ClassBarChart(const improc::ml::DetectionMetrics& m) : single_mode_(true) {
         for (const auto& [cls, ap] : m.per_class_AP)
             data_[cls] = {ap, 0.f, 0.f};
     }
 
-    // Raw form: explicit {P, R, F1} per class
+    /// @brief Constructs from raw per-class values.
     explicit ClassBarChart(std::map<std::string, std::array<float,3>> vals) {
         for (const auto& [cls, arr] : vals)
             data_[cls] = {arr[0], arr[1], arr[2]};
     }
 
+    /// @brief Sets the canvas width in pixels (default: 640).
     ClassBarChart& width(int w)         { width_ = w;            return *this; }
+    /// @brief Sets the canvas height in pixels (default: 400).
     ClassBarChart& height(int h)        { height_ = h;           return *this; }
+    /// @brief Sets the chart title text (default: empty).
     ClassBarChart& title(std::string t) { title_ = std::move(t); return *this; }
 
+    /// @brief Renders and returns the chart as a BGR image.
+    /// @throws improc::ParameterError if width or height <= 0.
     Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "ClassBarChart"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "ClassBarChart"};

--- a/include/improc/visualization/confusion_matrix_plot.hpp
+++ b/include/improc/visualization/confusion_matrix_plot.hpp
@@ -24,8 +24,21 @@ inline const cv::Scalar kCmpAmber { 11, 158, 245};
 inline const cv::Scalar kCmpRed   { 68,  68, 239};
 } // namespace detail::cmp
 
+/**
+ * @brief Renders a heatmap-style confusion matrix with accuracy/F1 badge.
+ *
+ * Diagonal cells use a blue-to-orange gradient; off-diagonal cells use an
+ * amber-to-red gradient. A colour bar and Accuracy/Macro-F1 summary are included.
+ *
+ * @code
+ * auto plot = ConfusionMatrixPlot(metrics)
+ *     .width(500).height(500)
+ *     .class_names({"cat","dog","bird"});
+ * auto img = plot();
+ * @endcode
+ */
 struct ConfusionMatrixPlot {
-    // Struct form from ConfusionMatrix
+    /// @brief Constructs from a `ConfusionMatrix` struct.
     explicit ConfusionMatrixPlot(const improc::ml::ConfusionMatrix& cm) {
         if (!cm.mat.empty()) {
             int n = cm.mat.rows;
@@ -36,23 +49,29 @@ struct ConfusionMatrixPlot {
         }
     }
 
-    // Struct form from ClassMetrics (uses embedded confusion matrix)
+    /// @brief Constructs from `ClassMetrics` using its embedded confusion matrix.
     explicit ConfusionMatrixPlot(const improc::ml::ClassMetrics& m)
         : ConfusionMatrixPlot(m.confusion_matrix) {}
 
-    // Raw form: 2D vector + optional class names
+    /// @brief Constructs from a raw 2-D count vector and optional class names.
     explicit ConfusionMatrixPlot(std::vector<std::vector<int>> matrix,
                                  std::vector<std::string> names = {})
         : matrix_(std::move(matrix))
         , class_names_(std::move(names)) {}
 
+    /// @brief Sets the canvas width in pixels (default: 400).
     ConfusionMatrixPlot& width(int w)          { width_ = w;              return *this; }
+    /// @brief Sets the canvas height in pixels (default: 400).
     ConfusionMatrixPlot& height(int h)         { height_ = h;             return *this; }
+    /// @brief Sets the chart title text (default: empty).
     ConfusionMatrixPlot& title(std::string t)  { title_ = std::move(t);   return *this; }
+    /// @brief Sets class label strings for row and column headers.
     ConfusionMatrixPlot& class_names(std::vector<std::string> n) {
         class_names_ = std::move(n); return *this;
     }
 
+    /// @brief Renders and returns the confusion matrix plot as a BGR image.
+    /// @throws improc::ParameterError if width or height <= 0 or canvas is too small for the matrix.
     Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "ConfusionMatrixPlot"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "ConfusionMatrixPlot"};

--- a/include/improc/visualization/iou_histogram.hpp
+++ b/include/improc/visualization/iou_histogram.hpp
@@ -34,16 +34,36 @@ inline const std::array<cv::Scalar,4> kViolets{
 };
 } // namespace detail::iou
 
+/**
+ * @brief Renders a histogram of IoU scores with a threshold marker and stat badges.
+ *
+ * Bars below the threshold are amber-tinted; bars above use a violet gradient.
+ * Mean IoU and the percentage above threshold are shown as stat badges.
+ *
+ * @code
+ * auto hist = IoUHistogram(iou_scores)
+ *     .bins(20).threshold(0.5f).width(800).height(300);
+ * auto img = hist();
+ * @endcode
+ */
 struct IoUHistogram {
+    /// @brief Constructs from a vector of IoU scores in [0, 1].
     explicit IoUHistogram(std::vector<float> scores)
         : scores_(std::move(scores)) {}
 
+    /// @brief Sets the canvas width in pixels (default: 800).
     IoUHistogram& width(int w)         { width_ = w;            return *this; }
+    /// @brief Sets the canvas height in pixels (default: 300).
     IoUHistogram& height(int h)        { height_ = h;           return *this; }
+    /// @brief Sets the number of histogram bins (default: 20).
     IoUHistogram& bins(int b)          { bins_ = b;             return *this; }
+    /// @brief Sets the IoU threshold line position (default: 0.5).
     IoUHistogram& threshold(float t)   { threshold_ = t;        return *this; }
+    /// @brief Sets the chart title text (default: empty).
     IoUHistogram& title(std::string t) { title_ = std::move(t); return *this; }
 
+    /// @brief Renders and returns the histogram as a BGR image.
+    /// @throws improc::ParameterError if width, height, or bins <= 0, or threshold outside [0, 1].
     Image<BGR> operator()() const {
         if (width_ <= 0)
             throw improc::ParameterError{"width",     "must be positive",   "IoUHistogram"};

--- a/include/improc/visualization/ml_charts.hpp
+++ b/include/improc/visualization/ml_charts.hpp
@@ -1,6 +1,11 @@
 // include/improc/visualization/ml_charts.hpp
 #pragma once
 
+/** @file ml_charts.hpp
+ *  @brief Convenience header — includes all `improc::visualization` ML chart types
+ *         (ConfusionMatrixPlot, PRCurvePlot, ROCCurvePlot, ClassBarChart, IoUHistogram).
+ */
+
 #include "improc/visualization/confusion_matrix_plot.hpp"
 #include "improc/visualization/pr_curve_plot.hpp"
 #include "improc/visualization/roc_curve_plot.hpp"

--- a/include/improc/visualization/pr_curve_plot.hpp
+++ b/include/improc/visualization/pr_curve_plot.hpp
@@ -26,15 +26,27 @@ inline const std::vector<cv::Scalar> kColors{
 };
 } // namespace detail::pr
 
+/**
+ * @brief Renders Precision–Recall curves for one or more classes.
+ *
+ * Optionally displays an mAP badge at the bottom.
+ *
+ * @code
+ * auto plot = PRCurvePlot(eval.pr_curves())
+ *     .mAP_50(metrics.mAP_50)
+ *     .title("Validation PR");
+ * auto img = plot();
+ * @endcode
+ */
 struct PRCurvePlot {
     using CurveMap = std::map<std::string,
         std::pair<std::vector<float>, std::vector<float>>>;
 
-    // Struct form — direct from DetectionEval::pr_curves()
+    /// @brief Constructs from a class → (recall[], precision[]) map.
     explicit PRCurvePlot(CurveMap curves)
         : curves_(std::move(curves)) {}
 
-    // Raw form — separate recall and precision maps
+    /// @brief Constructs from separate recall and precision maps keyed by class name.
     PRCurvePlot(std::map<std::string, std::vector<float>> recalls,
                 std::map<std::string, std::vector<float>> precisions) {
         for (const auto& [cls, rec] : recalls) {
@@ -44,12 +56,19 @@ struct PRCurvePlot {
         }
     }
 
+    /// @brief Sets the canvas width in pixels (default: 640).
     PRCurvePlot& width(int w)           { width_ = w;            return *this; }
+    /// @brief Sets the canvas height in pixels (default: 480).
     PRCurvePlot& height(int h)          { height_ = h;           return *this; }
+    /// @brief Sets the chart title text (default: empty).
     PRCurvePlot& title(std::string t)   { title_ = std::move(t); return *this; }
+    /// @brief Sets the mAP@IoU value shown in the badge; negative = no badge (default: -1).
     PRCurvePlot& mAP_50(float v)        { mAP50_ = v;            return *this; }
+    /// @brief Sets the IoU threshold label shown alongside mAP (default: 0.50).
     PRCurvePlot& iou_threshold(float t) { iou_thr_ = t;          return *this; }
 
+    /// @brief Renders and returns the PR curve plot as a BGR image.
+    /// @throws improc::ParameterError if width or height <= 0.
     Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "PRCurvePlot"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "PRCurvePlot"};

--- a/include/improc/visualization/roc_curve_plot.hpp
+++ b/include/improc/visualization/roc_curve_plot.hpp
@@ -27,14 +27,24 @@ inline const std::vector<cv::Scalar> kColors{
 };
 } // namespace detail::roc
 
+/**
+ * @brief Renders ROC curves for one or more classes with AUC values in the legend.
+ *
+ * A dashed diagonal (random-classifier baseline) is drawn automatically.
+ *
+ * @code
+ * auto plot = ROCCurvePlot(fpr_map, tpr_map).title("ROC curves");
+ * auto img = plot();
+ * @endcode
+ */
 struct ROCCurvePlot {
     using RocMap = std::map<std::string,
         std::pair<std::vector<float>, std::vector<float>>>;
 
-    // Map form: class → (fpr[], tpr[])
+    /// @brief Constructs from a class → (fpr[], tpr[]) map.
     explicit ROCCurvePlot(RocMap curves) : curves_(std::move(curves)) {}
 
-    // Raw form: separate fpr and tpr maps
+    /// @brief Constructs from separate FPR and TPR maps keyed by class name.
     ROCCurvePlot(std::map<std::string, std::vector<float>> fprs,
                  std::map<std::string, std::vector<float>> tprs) {
         for (const auto& [cls, fpr] : fprs) {
@@ -43,10 +53,15 @@ struct ROCCurvePlot {
         }
     }
 
+    /// @brief Sets the canvas width in pixels (default: 640).
     ROCCurvePlot& width(int w)          { width_ = w;            return *this; }
+    /// @brief Sets the canvas height in pixels (default: 480).
     ROCCurvePlot& height(int h)         { height_ = h;           return *this; }
+    /// @brief Sets the chart title text (default: empty).
     ROCCurvePlot& title(std::string t)  { title_ = std::move(t); return *this; }
 
+    /// @brief Renders and returns the ROC curve plot as a BGR image.
+    /// @throws improc::ParameterError if width or height <= 0.
     Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "ROCCurvePlot"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "ROCCurvePlot"};

--- a/include/improc/visualization/visualization.hpp
+++ b/include/improc/visualization/visualization.hpp
@@ -1,6 +1,11 @@
 // include/improc/visualization/visualization.hpp
 #pragma once
 
+/** @file visualization.hpp
+ *  @brief Convenience header — includes all `improc::visualization` rendering types
+ *         (Histogram, LinePlot, Scatter, Show, Draw, DrawTracks, Montage).
+ */
+
 #include "improc/visualization/histogram.hpp"
 #include "improc/visualization/line_plot.hpp"
 #include "improc/visualization/scatter.hpp"


### PR DESCRIPTION
## Summary

- Add Doxygen documentation to all 51 previously undocumented public headers across every namespace (`improc::ml`, `improc::calib`, `improc::visualization`, `improc::io`, `improc::core`, `improc::onnx`)
- Zero logic changes — documentation only; all 1563 tests pass (5 pre-existing `VideoWriterTest` failures on macOS are unrelated codec issues present before this branch)
- Organised as 7 atomic commits by namespace for clean bisect history

## Commits

| Commit | Scope | Files |
|--------|-------|-------|
| `docs(ml/augment)` | `BindMixin`, `RandomFlip/Rotate/Crop/…`, `ColorJitter`, `MixUp`, `CutMix`, `BBoxCompose`, `SegCompose` | 10 |
| `docs(ml/eval)` | `ClassEval`, `DetectionEval`, `SegEval`, free metric functions | 4 |
| `docs(calib)` | 13 result types, `CalibrateCamera`, `FindFundamental/EssentialMat`, `SolvePnP`, `StereoCalibrate`, `ArucoPose`, `CharucoBoard` | 6 |
| `docs(visualization)` | `ClassBarChart`, `ConfusionMatrixPlot`, `IoUHistogram`, `PRCurvePlot`, `ROCCurvePlot` + umbrella headers | 7 |
| `docs(io)` | `AnyCameraSource`, `IPCameraCapture`, `OakDCapture` + alias/umbrella headers | 5 |
| `docs(core/ops)` | `FloodFill`, `GrabCut`, `CalcHist`, `HoughLinesP/Circles`, 6 image hash types, `Inpaint`, `MatchTemplate`, `Moments`, optical flow types, `PhaseCorrelate`, 9 photo ops, `PSNR/SSIM/GMSD/MSE`, `Stitch`, `Watershed` | 18 |
| `docs(onnx)` | `onnx.hpp` umbrella `@file` block | 1 |

## Test Plan

- [ ] CI passes on Ubuntu and macOS
- [ ] `VideoWriterTest` failures (5) are pre-existing codec issues — not introduced by this PR