### PR TITLE
pre-v1.0.0: v0.15.0–v0.18.0 API gap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [[Unreleased]](#unreleased)
+- [[0.15.0]](#0150--2026-06-02) — 2026-06-02 · Breaking changes: DrawContours/DrawKeypoints/DrawMatches moved to `improc::visualization`; `Dataset::shuffle_seed`; `[[nodiscard]]` ops; `ParameterError` exception hierarchy; remove empty cuda placeholder
 - [[0.12.0]](#0120--2026-05-30) — 2026-05-30 · Documentation Completion: 100% Doxygen coverage across all 51 public headers; Conan migration for onnxruntime and nlohmann_json
 - [[0.11.0]](#0110--2026-05-28) — 2026-05-28 · Documentation Coverage: 8 tutorials + 12 examples for motion, calib, stereo, ArUco, detectors, photo/creative, HDR, quality metrics, and perceptual hashing
 - [[0.10.0]](#0100--2026-05-27) — 2026-05-27 · Photo + Creative + Quality + Hashing: 8 photo/creative ops, panorama stitching, 4 quality metrics, 6 perceptual hash ops (all standard OpenCV, no contrib)
@@ -24,6 +25,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ---
 
 ## [Unreleased]
+
+---
+
+## [0.15.0] — 2026-06-02
+
+### Breaking Changes
+- `improc::core::DrawContours` moved to `improc::visualization::DrawContours` — update includes and `using`-declarations. Backward-compat alias in `improc::core` via `pipeline.hpp`.
+- `improc::core::DrawKeypoints` moved to `improc::visualization::DrawKeypoints`
+- `improc::core::DrawMatches` moved to `improc::visualization::DrawMatches`
+- `Dataset::set_shuffle_seed(seed)` renamed to `Dataset::shuffle_seed(seed)`
+- All result-returning `operator()` are now `[[nodiscard]]` — discarding return values is a compiler warning
+
+### Improvements
+- All `throw std::invalid_argument(...)` replaced with `throw improc::ParameterError{...}` throughout the library (`ParameterError` inherits `improc::Exception`; existing `catch(std::invalid_argument&)` blocks need updating to `catch(improc::ParameterError&)` or `catch(improc::Exception&)`)
+- Removed empty `include/improc/cuda/` placeholder directory
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [[Unreleased]](#unreleased)
+- [[0.18.0]](#0180--2026-06-02) — 2026-06-02 · Test improvements: renamed/moved test files, added `test_to_bgr.cpp` and `test_axis.cpp`
 - [[0.17.0]](#0170--2026-06-02) — 2026-06-02 · Fisheye camera ops: `FisheyeCalibrate`, `FisheyeUndistort`, `FisheyeUndistortPoints`, `FisheyeInitRectifyMap`, `FisheyeStereoCalibrate`, `FisheyeStereoRectify`
 - [[0.16.0]](#0160--2026-06-02) — 2026-06-02 · Typed wrappers: `HistogramData`, `ImageHash`, `FaceEmbedding`; `CountNonZero`/`ComponentMap` return `std::size_t`
 - [[0.15.0]](#0150--2026-06-02) — 2026-06-02 · Breaking changes: DrawContours/DrawKeypoints/DrawMatches moved to `improc::visualization`; `Dataset::shuffle_seed`; `[[nodiscard]]` ops; `ParameterError` exception hierarchy; remove empty cuda placeholder
@@ -27,6 +28,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ---
 
 ## [Unreleased]
+
+---
+
+## [0.18.0] — 2026-06-02
+
+### Test Improvements
+- Renamed `tests/core/ops/test_analysis_v080.cpp` → `tests/core/ops/test_analysis.cpp` (removed milestone label from filename)
+- Moved `tests/core/test_background_subtract.cpp` → `tests/core/ops/test_background_subtract.cpp` (consistent with source location)
+- Added `tests/core/ops/test_to_bgr.cpp` covering Gray→BGR, HSV→BGR, LAB→BGR, YCrCb→BGR conversions
+- Added `tests/core/ops/test_axis.cpp` covering `Axis` enum usability and `Flip` axis composition
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [[Unreleased]](#unreleased)
+- [[0.17.0]](#0170--2026-06-02) — 2026-06-02 · Fisheye camera ops: `FisheyeCalibrate`, `FisheyeUndistort`, `FisheyeUndistortPoints`, `FisheyeInitRectifyMap`, `FisheyeStereoCalibrate`, `FisheyeStereoRectify`
 - [[0.16.0]](#0160--2026-06-02) — 2026-06-02 · Typed wrappers: `HistogramData`, `ImageHash`, `FaceEmbedding`; `CountNonZero`/`ComponentMap` return `std::size_t`
 - [[0.15.0]](#0150--2026-06-02) — 2026-06-02 · Breaking changes: DrawContours/DrawKeypoints/DrawMatches moved to `improc::visualization`; `Dataset::shuffle_seed`; `[[nodiscard]]` ops; `ParameterError` exception hierarchy; remove empty cuda placeholder
 - [[0.12.0]](#0120--2026-05-30) — 2026-05-30 · Documentation Completion: 100% Doxygen coverage across all 51 public headers; Conan migration for onnxruntime and nlohmann_json
@@ -26,6 +27,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ---
 
 ## [Unreleased]
+
+---
+
+## [0.17.0] — 2026-06-02
+
+### New Features
+- `improc::calib::FisheyeCalibrate` — calibrates a fisheye camera via `cv::fisheye::calibrate`, returns `CalibrationResult`
+- `improc::calib::FisheyeUndistort` — removes fisheye distortion from images (templated on `AnyFormat`)
+- `improc::calib::FisheyeUndistortPoints` — undistorts 2-D image points for fisheye lenses
+- `improc::calib::FisheyeInitRectifyMap` — computes fisheye undistortion and rectification maps, returns `UndistortMapResult`
+- `improc::calib::FisheyeStereoCalibrate` — calibrates a fisheye stereo pair, returns `StereoCalibrationResult`
+- `improc::calib::FisheyeStereoRectify` — computes rectification transforms for a fisheye stereo pair, returns `StereoRectifyResult`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [[Unreleased]](#unreleased)
+- [[0.16.0]](#0160--2026-06-02) — 2026-06-02 · Typed wrappers: `HistogramData`, `ImageHash`, `FaceEmbedding`; `CountNonZero`/`ComponentMap` return `std::size_t`
 - [[0.15.0]](#0150--2026-06-02) — 2026-06-02 · Breaking changes: DrawContours/DrawKeypoints/DrawMatches moved to `improc::visualization`; `Dataset::shuffle_seed`; `[[nodiscard]]` ops; `ParameterError` exception hierarchy; remove empty cuda placeholder
 - [[0.12.0]](#0120--2026-05-30) — 2026-05-30 · Documentation Completion: 100% Doxygen coverage across all 51 public headers; Conan migration for onnxruntime and nlohmann_json
 - [[0.11.0]](#0110--2026-05-28) — 2026-05-28 · Documentation Coverage: 8 tutorials + 12 examples for motion, calib, stereo, ArUco, detectors, photo/creative, HDR, quality metrics, and perceptual hashing
@@ -25,6 +26,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ---
 
 ## [Unreleased]
+
+---
+
+## [0.16.0] — 2026-06-02
+
+### Breaking Changes
+- `CalcHist::operator()` now returns `HistogramData` instead of `cv::Mat`; update callers to use `.data` for the raw matrix
+- `CompareHist::operator()` now accepts `const HistogramData&` instead of `const cv::Mat&`
+- All 6 hash ops (`AverageHash`, `PHash`, `MarrHildrethHash`, `RadialVarianceHash`, `ColorMomentHash`, `BlockMeanHash`) return `ImageHash` instead of `cv::Mat`; `distance()` accepts `const ImageHash&`
+- `RecognizeFace::embed()` returns `FaceEmbedding` instead of `cv::Mat`; `match()` accepts `const FaceEmbedding&`
+- `CountNonZero::operator()` returns `std::size_t` instead of `int`
+- `ComponentMap::num_labels` and `count()` are now `std::size_t`
+
+### New Types
+- `improc::core::HistogramData` — typed wrapper for histogram data with bins/range metadata
+- `improc::core::ImageHash` — typed wrapper for perceptual hash matrices with `operator==` and `operator!=`
+- `improc::core::FaceEmbedding` — typed wrapper for face recognition embeddings with `cosine_similarity()`
 
 ---
 

--- a/docs/tutorials/dataset-loading.md
+++ b/docs/tutorials/dataset-loading.md
@@ -48,7 +48,7 @@ It loads all images, shuffles them, and splits into train/val/test sets.
 using namespace improc::ml;
 
 Dataset ds{};
-ds.set_shuffle_seed(42);
+ds.shuffle_seed(42);
 
 auto ok = ds.load_from_directory(
     "data/animals/",

--- a/include/improc/calib/ops/aruco.hpp
+++ b/include/improc/calib/ops/aruco.hpp
@@ -72,7 +72,7 @@ struct GenerateAruco {
     GenerateAruco& border_bits(int b) { border_bits_ = b; return *this; }
 
     /// @brief Renders marker `id` from `dict` at `side_pixels × side_pixels`.
-    /// @throws std::invalid_argument if `id` < 0 or `side_pixels` < 1.
+    /// @throws improc::ParameterError if `id` < 0 or `side_pixels` < 1.
     Image<Gray> operator()(const cv::aruco::Dictionary& dict,
                            int id,
                            int side_pixels) const;
@@ -125,7 +125,7 @@ struct CharucoBoard {
     CharucoBoard& marker_length(float m) { marker_length_ = m; return *this; }
 
     /// @brief Detects board corners (no subpixel refinement).
-    /// @throws std::invalid_argument if `board_size` not set, or lengths <= 0.
+    /// @throws improc::ParameterError if `board_size` not set, or lengths <= 0.
     CharucoResult operator()(Image<BGR> img, const cv::aruco::Dictionary& dict) const;
     /// @brief Detects board corners with subpixel refinement using camera intrinsics.
     CharucoResult operator()(Image<BGR> img,

--- a/include/improc/calib/ops/aruco.hpp
+++ b/include/improc/calib/ops/aruco.hpp
@@ -23,7 +23,7 @@ using improc::core::Gray;
  * @endcode
  */
 struct ArucoDict {
-    cv::aruco::Dictionary operator()(cv::aruco::PredefinedDictionaryType type) const;
+    [[nodiscard]] cv::aruco::Dictionary operator()(cv::aruco::PredefinedDictionaryType type) const;
 };
 
 // ── DetectAruco ───────────────────────────────────────────────────────────────
@@ -34,8 +34,8 @@ struct ArucoDict {
  * @return `ArucoResult` containing corners, IDs, and rejected candidates.
  */
 struct DetectAruco {
-    ArucoResult operator()(Image<BGR>  img, const cv::aruco::Dictionary& dict) const;
-    ArucoResult operator()(Image<Gray> img, const cv::aruco::Dictionary& dict) const;
+    [[nodiscard]] ArucoResult operator()(Image<BGR>  img, const cv::aruco::Dictionary& dict) const;
+    [[nodiscard]] ArucoResult operator()(Image<Gray> img, const cv::aruco::Dictionary& dict) const;
 };
 
 // ── DrawAruco ─────────────────────────────────────────────────────────────────
@@ -48,11 +48,11 @@ struct DrawAruco {
     DrawAruco& axis_length(float l) { axis_length_ = l; return *this; }
 
     // Overload 1: draws marker outlines + ID numbers only.
-    cv::Mat operator()(cv::Mat img, const ArucoResult& result) const;
+    [[nodiscard]] cv::Mat operator()(cv::Mat img, const ArucoResult& result) const;
 
     // Overload 2: draws marker outlines + IDs + coordinate axes per marker.
     // Uses cv::drawFrameAxes. Iterates poses and draws one axis frame per marker.
-    cv::Mat operator()(cv::Mat img,
+    [[nodiscard]] cv::Mat operator()(cv::Mat img,
                        const ArucoResult& result,
                        const std::vector<ArucoPoseResult>& poses,
                        const cv::Mat& K,
@@ -73,7 +73,7 @@ struct GenerateAruco {
 
     /// @brief Renders marker `id` from `dict` at `side_pixels × side_pixels`.
     /// @throws improc::ParameterError if `id` < 0 or `side_pixels` < 1.
-    Image<Gray> operator()(const cv::aruco::Dictionary& dict,
+    [[nodiscard]] Image<Gray> operator()(const cv::aruco::Dictionary& dict,
                            int id,
                            int side_pixels) const;
 
@@ -97,7 +97,7 @@ struct ArucoPose {
     /// @param dist         Distortion coefficients.
     /// @param marker_length Physical marker side length in world units.
     /// @return One `ArucoPoseResult` per detected marker, in the same order as `result`.
-    std::vector<ArucoPoseResult> operator()(const ArucoResult& result,
+    [[nodiscard]] std::vector<ArucoPoseResult> operator()(const ArucoResult& result,
                                             const cv::Mat& K,
                                             const cv::Mat& dist,
                                             float marker_length) const;
@@ -126,9 +126,9 @@ struct CharucoBoard {
 
     /// @brief Detects board corners (no subpixel refinement).
     /// @throws improc::ParameterError if `board_size` not set, or lengths <= 0.
-    CharucoResult operator()(Image<BGR> img, const cv::aruco::Dictionary& dict) const;
+    [[nodiscard]] CharucoResult operator()(Image<BGR> img, const cv::aruco::Dictionary& dict) const;
     /// @brief Detects board corners with subpixel refinement using camera intrinsics.
-    CharucoResult operator()(Image<BGR> img,
+    [[nodiscard]] CharucoResult operator()(Image<BGR> img,
                              const cv::aruco::Dictionary& dict,
                              const cv::Mat& K,
                              const cv::Mat& dist) const;

--- a/include/improc/calib/ops/calibrate.hpp
+++ b/include/improc/calib/ops/calibrate.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#include <stdexcept>
 #include <vector>
 #include <opencv2/core.hpp>
 #include "improc/calib/ops/calib_types.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::calib {
 
@@ -10,15 +10,13 @@ namespace improc::calib {
 /// @param board_size Inner corner count; `board_size.width × board_size.height` points are returned.
 /// @param square_size Physical side length of one square in any consistent unit.
 /// @return `board_size.width * board_size.height` points in row-major order.
-/// @throws std::invalid_argument if any dimension of `board_size` <= 0 or `square_size` <= 0.
+/// @throws improc::ParameterError if any dimension of `board_size` <= 0 or `square_size` <= 0.
 inline std::vector<cv::Point3f> make_chessboard_points(cv::Size board_size,
                                                         float square_size) {
     if (board_size.width <= 0 || board_size.height <= 0)
-        throw std::invalid_argument(
-            "make_chessboard_points: board_size dimensions must be positive");
+        throw improc::ParameterError{"board_size", "dimensions must be positive", "make_chessboard_points"};
     if (square_size <= 0.f)
-        throw std::invalid_argument(
-            "make_chessboard_points: square_size must be positive");
+        throw improc::ParameterError{"square_size", "must be positive", "make_chessboard_points"};
     std::vector<cv::Point3f> pts;
     pts.reserve(board_size.width * board_size.height);
     for (int r = 0; r < board_size.height; ++r)

--- a/include/improc/calib/ops/calibrate.hpp
+++ b/include/improc/calib/ops/calibrate.hpp
@@ -11,7 +11,7 @@ namespace improc::calib {
 /// @param square_size Physical side length of one square in any consistent unit.
 /// @return `board_size.width * board_size.height` points in row-major order.
 /// @throws improc::ParameterError if any dimension of `board_size` <= 0 or `square_size` <= 0.
-inline std::vector<cv::Point3f> make_chessboard_points(cv::Size board_size,
+[[nodiscard]] inline std::vector<cv::Point3f> make_chessboard_points(cv::Size board_size,
                                                         float square_size) {
     if (board_size.width <= 0 || board_size.height <= 0)
         throw improc::ParameterError{"board_size", "dimensions must be positive", "make_chessboard_points"};
@@ -40,7 +40,7 @@ struct CalibrateCamera {
 
     /// @brief Runs the calibration.
     /// @throws improc::ParameterError if sizes mismatch or fewer than 3 views are provided.
-    CalibrationResult operator()(const std::vector<std::vector<cv::Point3f>>& obj_pts,
+    [[nodiscard]] CalibrationResult operator()(const std::vector<std::vector<cv::Point3f>>& obj_pts,
                                  const std::vector<std::vector<cv::Point2f>>& img_pts,
                                  cv::Size image_size) const;
 

--- a/include/improc/calib/ops/calibrate.hpp
+++ b/include/improc/calib/ops/calibrate.hpp
@@ -39,7 +39,7 @@ struct CalibrateCamera {
     CalibrateCamera& flags(int f) { flags_ = f; return *this; }
 
     /// @brief Runs the calibration.
-    /// @throws std::invalid_argument if sizes mismatch or fewer than 3 views are provided.
+    /// @throws improc::ParameterError if sizes mismatch or fewer than 3 views are provided.
     CalibrationResult operator()(const std::vector<std::vector<cv::Point3f>>& obj_pts,
                                  const std::vector<std::vector<cv::Point2f>>& img_pts,
                                  cv::Size image_size) const;

--- a/include/improc/calib/ops/chessboard.hpp
+++ b/include/improc/calib/ops/chessboard.hpp
@@ -18,7 +18,7 @@ using improc::core::BGR;
  * number of inner corners per row and column (e.g., `{9, 6}` for a 10×7
  * square board). BGR input is auto-converted to Gray internally.
  *
- * @throws std::invalid_argument if board_size has not been set.
+ * @throws improc::ParameterError if board_size has not been set.
  *
  * @code
  * auto result = gray_img | FindChessboardCorners{}.board_size({9, 6});
@@ -49,7 +49,7 @@ private:
  * a separate refinement step. `board_size` must be set before invoking.
  * BGR input is auto-converted to Gray internally.
  *
- * @throws std::invalid_argument if board_size has not been set.
+ * @throws improc::ParameterError if board_size has not been set.
  *
  * @code
  * auto result = gray_img | FindChessboardCornersSB{}.board_size({9, 6});

--- a/include/improc/calib/ops/chessboard.hpp
+++ b/include/improc/calib/ops/chessboard.hpp
@@ -32,9 +32,9 @@ struct FindChessboardCorners {
     FindChessboardCorners& flags(int f)            { flags_ = f; return *this; }
 
     /// @brief Finds chessboard corners in a grayscale image.
-    FindChessboardResult operator()(Image<Gray> img) const;
+    [[nodiscard]] FindChessboardResult operator()(Image<Gray> img) const;
     /// @brief Finds chessboard corners in a BGR image (auto-converted to Gray).
-    FindChessboardResult operator()(Image<BGR>  img) const;
+    [[nodiscard]] FindChessboardResult operator()(Image<BGR>  img) const;
 
 private:
     cv::Size board_size_{};
@@ -63,9 +63,9 @@ struct FindChessboardCornersSB {
     FindChessboardCornersSB& flags(int f)            { flags_ = f; return *this; }
 
     /// @brief Finds chessboard corners in a grayscale image.
-    FindChessboardResult operator()(Image<Gray> img) const;
+    [[nodiscard]] FindChessboardResult operator()(Image<Gray> img) const;
     /// @brief Finds chessboard corners in a BGR image (auto-converted to Gray).
-    FindChessboardResult operator()(Image<BGR>  img) const;
+    [[nodiscard]] FindChessboardResult operator()(Image<BGR>  img) const;
 
 private:
     cv::Size board_size_{};
@@ -94,8 +94,8 @@ struct RefineCorners {
     RefineCorners& epsilon(double e) { epsilon_   = e;       return *this; }
 
     /// @brief Refines corners in a grayscale image. Returns refined corner positions.
-    std::vector<cv::Point2f> operator()(Image<Gray>               img,
-                                        std::vector<cv::Point2f>  corners) const;
+    [[nodiscard]] std::vector<cv::Point2f> operator()(Image<Gray>               img,
+                                                       std::vector<cv::Point2f>  corners) const;
 
 private:
     cv::Size win_size_  = {11, 11};

--- a/include/improc/calib/ops/epipolar.hpp
+++ b/include/improc/calib/ops/epipolar.hpp
@@ -23,7 +23,7 @@ struct FindFundamentalMat {
 
     /// @brief Estimates the fundamental matrix.
     /// @throws improc::ParameterError if `pts1.size() != pts2.size()` or fewer than 8 points.
-    FundamentalMatResult operator()(const std::vector<cv::Point2f>& pts1,
+    [[nodiscard]] FundamentalMatResult operator()(const std::vector<cv::Point2f>& pts1,
                                     const std::vector<cv::Point2f>& pts2) const;
 
 private:
@@ -48,7 +48,7 @@ struct FindEssentialMat {
     /// @brief Estimates the essential matrix.
     /// @param K 3×3 camera intrinsic matrix (same for both views).
     /// @throws improc::ParameterError if sizes mismatch or fewer than 5 points.
-    EssentialMatResult operator()(const std::vector<cv::Point2f>& pts1,
+    [[nodiscard]] EssentialMatResult operator()(const std::vector<cv::Point2f>& pts1,
                                   const std::vector<cv::Point2f>& pts2,
                                   const cv::Mat& K) const;
 
@@ -67,7 +67,7 @@ struct RecoverPose {
     /// @brief Recovers R and t.
     /// @param E Essential matrix (from `FindEssentialMat`).
     /// @param K Camera matrix (shared intrinsics assumed).
-    RecoverPoseResult operator()(const cv::Mat& E,
+    [[nodiscard]] RecoverPoseResult operator()(const cv::Mat& E,
                                  const std::vector<cv::Point2f>& pts1,
                                  const std::vector<cv::Point2f>& pts2,
                                  const cv::Mat& K) const;
@@ -83,7 +83,7 @@ struct TriangulatePoints {
     /// @param P1 3×4 projection matrix of the first camera.
     /// @param P2 3×4 projection matrix of the second camera.
     /// @return 4×N homogeneous point cloud (CV_32F); divide by row 3 for Euclidean coordinates.
-    cv::Mat operator()(const cv::Mat& P1, const cv::Mat& P2,
+    [[nodiscard]] cv::Mat operator()(const cv::Mat& P1, const cv::Mat& P2,
                        const std::vector<cv::Point2f>& pts1,
                        const std::vector<cv::Point2f>& pts2) const;
 };

--- a/include/improc/calib/ops/epipolar.hpp
+++ b/include/improc/calib/ops/epipolar.hpp
@@ -22,7 +22,7 @@ struct FindFundamentalMat {
     FindFundamentalMat& confidence(double c)       { confidence_       = c; return *this; }
 
     /// @brief Estimates the fundamental matrix.
-    /// @throws std::invalid_argument if `pts1.size() != pts2.size()` or fewer than 8 points.
+    /// @throws improc::ParameterError if `pts1.size() != pts2.size()` or fewer than 8 points.
     FundamentalMatResult operator()(const std::vector<cv::Point2f>& pts1,
                                     const std::vector<cv::Point2f>& pts2) const;
 
@@ -47,7 +47,7 @@ struct FindEssentialMat {
 
     /// @brief Estimates the essential matrix.
     /// @param K 3×3 camera intrinsic matrix (same for both views).
-    /// @throws std::invalid_argument if sizes mismatch or fewer than 5 points.
+    /// @throws improc::ParameterError if sizes mismatch or fewer than 5 points.
     EssentialMatResult operator()(const std::vector<cv::Point2f>& pts1,
                                   const std::vector<cv::Point2f>& pts2,
                                   const cv::Mat& K) const;

--- a/include/improc/calib/ops/fisheye.hpp
+++ b/include/improc/calib/ops/fisheye.hpp
@@ -1,0 +1,193 @@
+// include/improc/calib/ops/fisheye.hpp
+#pragma once
+#include <vector>
+#include <opencv2/core.hpp>
+#include <opencv2/calib3d.hpp>
+#include "improc/core/image.hpp"
+#include "improc/core/concepts.hpp"
+#include "improc/calib/ops/calib_types.hpp"
+
+namespace improc::calib {
+
+using improc::core::Image;
+using improc::core::AnyFormat;
+
+// ── FisheyeCalibrate ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Calibrates a fisheye camera from multi-view point correspondences.
+ *
+ * @code
+ * CalibrationResult r = FisheyeCalibrate{}(obj_pts, img_pts, image_size);
+ * @endcode
+ */
+struct FisheyeCalibrate {
+    /// @brief Sets OpenCV fisheye calibration flags.
+    FisheyeCalibrate& flags(int f) { flags_ = f; return *this; }
+    /// @brief Sets termination criteria for the iterative optimisation.
+    FisheyeCalibrate& criteria(cv::TermCriteria c) { criteria_ = c; return *this; }
+
+    [[nodiscard]] CalibrationResult operator()(
+        const std::vector<std::vector<cv::Point3f>>& object_pts,
+        const std::vector<std::vector<cv::Point2f>>& image_pts,
+        cv::Size image_size) const;
+
+private:
+    int flags_ = cv::fisheye::CALIB_RECOMPUTE_EXTRINSIC |
+                 cv::fisheye::CALIB_CHECK_COND |
+                 cv::fisheye::CALIB_FIX_SKEW;
+    cv::TermCriteria criteria_{cv::TermCriteria::COUNT + cv::TermCriteria::EPS, 100, 1e-6};
+};
+
+// ── FisheyeUndistort ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Undistorts an image captured with a fisheye lens.
+ *
+ * @code
+ * Image<BGR> out = FisheyeUndistort{}.K(K).dist(D)(img);
+ * @endcode
+ */
+struct FisheyeUndistort {
+    /// @brief Sets the camera intrinsic matrix.
+    FisheyeUndistort& K(cv::Mat k)       { K_    = std::move(k); return *this; }
+    /// @brief Sets the fisheye distortion coefficients (4×1 or 1×4).
+    FisheyeUndistort& dist(cv::Mat d)    { dist_ = std::move(d); return *this; }
+    /// @brief Sets the new (output) camera matrix; defaults to K if not set.
+    FisheyeUndistort& new_K(cv::Mat nk)  { new_K_= std::move(nk); return *this; }
+
+    template<AnyFormat F>
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
+        cv::Mat dst;
+        cv::fisheye::undistortImage(img.mat(), dst, K_, dist_,
+                                    new_K_.empty() ? K_ : new_K_);
+        return Image<F>(std::move(dst));
+    }
+
+private:
+    cv::Mat K_, dist_, new_K_;
+};
+
+// ── FisheyeUndistortPoints ────────────────────────────────────────────────────
+
+/**
+ * @brief Undistorts 2-D image points from a fisheye lens.
+ *
+ * @code
+ * auto out = FisheyeUndistortPoints{}.K(K).dist(D)(pts);
+ * @endcode
+ */
+struct FisheyeUndistortPoints {
+    /// @brief Sets the camera intrinsic matrix.
+    FisheyeUndistortPoints& K(cv::Mat k)    { K_    = std::move(k); return *this; }
+    /// @brief Sets the fisheye distortion coefficients.
+    FisheyeUndistortPoints& dist(cv::Mat d) { dist_ = std::move(d); return *this; }
+    /// @brief Optional rectification matrix R.
+    FisheyeUndistortPoints& R(cv::Mat r)    { R_    = std::move(r); return *this; }
+    /// @brief Optional new projection matrix P.
+    FisheyeUndistortPoints& P(cv::Mat p)    { P_    = std::move(p); return *this; }
+
+    [[nodiscard]] std::vector<cv::Point2f> operator()(
+        const std::vector<cv::Point2f>& pts) const;
+
+private:
+    cv::Mat K_, dist_, R_, P_;
+};
+
+// ── FisheyeInitRectifyMap ─────────────────────────────────────────────────────
+
+/**
+ * @brief Computes the undistortion and rectification maps for a fisheye lens.
+ *
+ * Pass the resulting maps to `cv::remap` (or `improc::core::Remap`).
+ *
+ * @code
+ * UndistortMapResult maps = FisheyeInitRectifyMap{}.K(K).dist(D)(size);
+ * @endcode
+ */
+struct FisheyeInitRectifyMap {
+    /// @brief Sets the camera intrinsic matrix.
+    FisheyeInitRectifyMap& K(cv::Mat k)      { K_     = std::move(k); return *this; }
+    /// @brief Sets the fisheye distortion coefficients.
+    FisheyeInitRectifyMap& dist(cv::Mat d)   { dist_  = std::move(d); return *this; }
+    /// @brief Optional rectification matrix (defaults to identity).
+    FisheyeInitRectifyMap& R(cv::Mat r)      { R_     = std::move(r); return *this; }
+    /// @brief Optional new projection matrix (defaults to K).
+    FisheyeInitRectifyMap& new_K(cv::Mat nk) { new_K_ = std::move(nk); return *this; }
+
+    [[nodiscard]] UndistortMapResult operator()(cv::Size image_size) const;
+
+private:
+    cv::Mat K_, dist_, R_, new_K_;
+};
+
+// ── FisheyeStereoCalibrate ────────────────────────────────────────────────────
+
+/**
+ * @brief Calibrates a stereo fisheye rig from multi-view point correspondences.
+ *
+ * @code
+ * StereoCalibrationResult r = FisheyeStereoCalibrate{}
+ *     .K1(K1).dist1(D1).K2(K2).dist2(D2)
+ *     (obj_pts, left_pts, right_pts, image_size);
+ * @endcode
+ */
+struct FisheyeStereoCalibrate {
+    /// @brief Sets initial left camera matrix.
+    FisheyeStereoCalibrate& K1(cv::Mat k)    { K1_    = std::move(k); return *this; }
+    /// @brief Sets initial left distortion coefficients.
+    FisheyeStereoCalibrate& dist1(cv::Mat d) { dist1_ = std::move(d); return *this; }
+    /// @brief Sets initial right camera matrix.
+    FisheyeStereoCalibrate& K2(cv::Mat k)    { K2_    = std::move(k); return *this; }
+    /// @brief Sets initial right distortion coefficients.
+    FisheyeStereoCalibrate& dist2(cv::Mat d) { dist2_ = std::move(d); return *this; }
+    /// @brief Sets OpenCV fisheye stereo calibration flags.
+    FisheyeStereoCalibrate& flags(int f)     { flags_ = f; return *this; }
+
+    [[nodiscard]] StereoCalibrationResult operator()(
+        const std::vector<std::vector<cv::Point3f>>& object_pts,
+        const std::vector<std::vector<cv::Point2f>>& left_pts,
+        const std::vector<std::vector<cv::Point2f>>& right_pts,
+        cv::Size image_size) const;
+
+private:
+    cv::Mat K1_, dist1_, K2_, dist2_;
+    int flags_ = cv::fisheye::CALIB_RECOMPUTE_EXTRINSIC |
+                 cv::fisheye::CALIB_CHECK_COND |
+                 cv::fisheye::CALIB_FIX_SKEW;
+};
+
+// ── FisheyeStereoRectify ──────────────────────────────────────────────────────
+
+/**
+ * @brief Computes stereo rectification for a fisheye stereo rig.
+ *
+ * @code
+ * StereoRectifyResult r = FisheyeStereoRectify{}
+ *     .image_size({640,480})
+ *     (K1, D1, K2, D2, R, T);
+ * @endcode
+ */
+struct FisheyeStereoRectify {
+    /// @brief Sets the image size used for rectification.
+    FisheyeStereoRectify& image_size(cv::Size s) { image_size_ = s; return *this; }
+    /// @brief Sets rectification flags (default: cv::CALIB_ZERO_DISPARITY).
+    FisheyeStereoRectify& flags(int f)           { flags_ = f; return *this; }
+    /// @brief Sets the balance parameter in [0, 1] (default: 0.0).
+    FisheyeStereoRectify& balance(double b)      { balance_ = b; return *this; }
+    /// @brief Sets the FOV scale factor (default: 1.0).
+    FisheyeStereoRectify& fov_scale(double f)    { fov_scale_ = f; return *this; }
+
+    [[nodiscard]] StereoRectifyResult operator()(
+        const cv::Mat& K1, const cv::Mat& D1,
+        const cv::Mat& K2, const cv::Mat& D2,
+        const cv::Mat& R,  const cv::Mat& T) const;
+
+private:
+    cv::Size image_size_{640, 480};
+    int      flags_     = cv::CALIB_ZERO_DISPARITY;
+    double   balance_   = 0.0;
+    double   fov_scale_ = 1.0;
+};
+
+} // namespace improc::calib

--- a/include/improc/calib/ops/project.hpp
+++ b/include/improc/calib/ops/project.hpp
@@ -29,7 +29,7 @@ struct SolvePnP {
     SolvePnP& method(int m) { method_ = m; return *this; }
 
     /// @brief Estimates the pose.
-    /// @throws std::invalid_argument if sizes mismatch or fewer than 4 points.
+    /// @throws improc::ParameterError if sizes mismatch or fewer than 4 points.
     PnPResult operator()(const std::vector<cv::Point3f>& obj_pts,
                          const std::vector<cv::Point2f>& img_pts,
                          const cv::Mat& K,

--- a/include/improc/calib/ops/project.hpp
+++ b/include/improc/calib/ops/project.hpp
@@ -14,7 +14,7 @@ namespace improc::calib {
 struct ProjectPoints {
     /// @brief Projects `obj_pts` using the given pose and camera parameters.
     /// @return Projected 2-D points in pixel coordinates.
-    std::vector<cv::Point2f> operator()(const std::vector<cv::Point3f>& obj_pts,
+    [[nodiscard]] std::vector<cv::Point2f> operator()(const std::vector<cv::Point3f>& obj_pts,
                                         const cv::Mat& rvec,
                                         const cv::Mat& tvec,
                                         const cv::Mat& K,
@@ -30,7 +30,7 @@ struct SolvePnP {
 
     /// @brief Estimates the pose.
     /// @throws improc::ParameterError if sizes mismatch or fewer than 4 points.
-    PnPResult operator()(const std::vector<cv::Point3f>& obj_pts,
+    [[nodiscard]] PnPResult operator()(const std::vector<cv::Point3f>& obj_pts,
                          const std::vector<cv::Point2f>& img_pts,
                          const cv::Mat& K,
                          const cv::Mat& dist) const;
@@ -53,7 +53,7 @@ struct SolvePnPRansac {
     SolvePnPRansac& iterations(int n)           { iterations_         = n; return *this; }
 
     /// @brief Estimates the pose with RANSAC.
-    PnPRansacResult operator()(const std::vector<cv::Point3f>& obj_pts,
+    [[nodiscard]] PnPRansacResult operator()(const std::vector<cv::Point3f>& obj_pts,
                                const std::vector<cv::Point2f>& img_pts,
                                const cv::Mat& K,
                                const cv::Mat& dist) const;

--- a/include/improc/calib/ops/stereo.hpp
+++ b/include/improc/calib/ops/stereo.hpp
@@ -38,7 +38,7 @@ struct StereoCalibrate {
     StereoCalibrate& flags(int f)     { flags_ = f;             return *this; }
 
     /// @brief Runs stereo calibration.
-    /// @throws std::invalid_argument if point set sizes mismatch, fewer than 3 views, or image_size is non-positive.
+    /// @throws improc::ParameterError if point set sizes mismatch, fewer than 3 views, or image_size is non-positive.
     StereoCalibrationResult operator()(
         const std::vector<std::vector<cv::Point3f>>& obj_pts,
         const std::vector<std::vector<cv::Point2f>>& img_pts1,
@@ -62,7 +62,7 @@ struct StereoRectify {
     StereoRectify& new_image_size(cv::Size s) { new_image_size_ = s; return *this; }
 
     /// @brief Computes stereo rectification.
-    /// @throws std::invalid_argument if any of the input matrices is empty.
+    /// @throws improc::ParameterError if any of the input matrices is empty.
     StereoRectifyResult operator()(const cv::Mat& K1, const cv::Mat& dist1,
                                    const cv::Mat& K2, const cv::Mat& dist2,
                                    const cv::Mat& R,  const cv::Mat& T,
@@ -86,7 +86,7 @@ struct StereoBM {
     StereoBM& block_size(int s)      { block_size_      = s; return *this; }
 
     /// @brief Computes the disparity map.
-    /// @throws std::invalid_argument if `left` and `right` have different sizes.
+    /// @throws improc::ParameterError if `left` and `right` have different sizes.
     cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
 
 private:
@@ -115,7 +115,7 @@ struct StereoSGBM {
     StereoSGBM& mode(int m)            { mode_            = m; return *this; }
 
     /// @brief Computes the disparity map.
-    /// @throws std::invalid_argument if `left` and `right` have different sizes.
+    /// @throws improc::ParameterError if `left` and `right` have different sizes.
     cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
 
 private:

--- a/include/improc/calib/ops/stereo.hpp
+++ b/include/improc/calib/ops/stereo.hpp
@@ -39,7 +39,7 @@ struct StereoCalibrate {
 
     /// @brief Runs stereo calibration.
     /// @throws improc::ParameterError if point set sizes mismatch, fewer than 3 views, or image_size is non-positive.
-    StereoCalibrationResult operator()(
+    [[nodiscard]] StereoCalibrationResult operator()(
         const std::vector<std::vector<cv::Point3f>>& obj_pts,
         const std::vector<std::vector<cv::Point2f>>& img_pts1,
         const std::vector<std::vector<cv::Point2f>>& img_pts2,
@@ -63,7 +63,7 @@ struct StereoRectify {
 
     /// @brief Computes stereo rectification.
     /// @throws improc::ParameterError if any of the input matrices is empty.
-    StereoRectifyResult operator()(const cv::Mat& K1, const cv::Mat& dist1,
+    [[nodiscard]] StereoRectifyResult operator()(const cv::Mat& K1, const cv::Mat& dist1,
                                    const cv::Mat& K2, const cv::Mat& dist2,
                                    const cv::Mat& R,  const cv::Mat& T,
                                    cv::Size image_size) const;
@@ -87,7 +87,7 @@ struct StereoBM {
 
     /// @brief Computes the disparity map.
     /// @throws improc::ParameterError if `left` and `right` have different sizes.
-    cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
+    [[nodiscard]] cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
 
 private:
     int num_disparities_ = 16;
@@ -116,7 +116,7 @@ struct StereoSGBM {
 
     /// @brief Computes the disparity map.
     /// @throws improc::ParameterError if `left` and `right` have different sizes.
-    cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
+    [[nodiscard]] cv::Mat operator()(Image<Gray> left, Image<Gray> right) const;
 
 private:
     int min_disparity_   = 0;
@@ -140,7 +140,7 @@ struct ReprojectTo3D {
     /// @param disparity CV_16S or CV_32F disparity map.
     /// @param Q         4×4 disparity-to-depth matrix from `StereoRectify`.
     /// @return CV_32FC3 point cloud; same size as `disparity`.
-    cv::Mat operator()(const cv::Mat& disparity, const cv::Mat& Q) const;
+    [[nodiscard]] cv::Mat operator()(const cv::Mat& disparity, const cv::Mat& Q) const;
 
 private:
     bool handle_missing_ = false;

--- a/include/improc/calib/ops/undistort.hpp
+++ b/include/improc/calib/ops/undistort.hpp
@@ -1,11 +1,11 @@
 // include/improc/calib/ops/undistort.hpp
 #pragma once
-#include <stdexcept>
 #include <opencv2/core.hpp>
 #include <opencv2/calib3d.hpp>  // template body calls cv::undistort inline
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
 #include "improc/calib/ops/calib_types.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::calib {
 
@@ -17,7 +17,7 @@ using improc::core::AnyFormat;
  *
  * Wraps `cv::undistort`. Both K and dist must be set before invoking.
  *
- * @throws std::invalid_argument if K or dist have not been set.
+ * @throws improc::ParameterError if K or dist have not been set.
  *
  * @code
  * auto undist = img | Undistort{}.K(camera_matrix).dist(dist_coeffs);
@@ -32,9 +32,9 @@ struct Undistort {
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (K_.empty())
-            throw std::invalid_argument("Undistort: K must be set");
+            throw improc::ParameterError{"K", "must be set before calling operator()", "Undistort"};
         if (dist_.empty())
-            throw std::invalid_argument("Undistort: dist must be set");
+            throw improc::ParameterError{"dist", "must be set before calling operator()", "Undistort"};
         cv::Mat dst;
         cv::undistort(img.mat(), dst, K_, dist_);
         return Image<F>(std::move(dst));
@@ -51,7 +51,7 @@ private:
  * Wraps `cv::initUndistortRectifyMap`. Both K and dist must be set before invoking.
  * Optionally accepts a new camera matrix and rotation matrix for stereo rectification.
  *
- * @throws std::invalid_argument if K or dist have not been set.
+ * @throws improc::ParameterError if K or dist have not been set.
  *
  * @code
  * auto maps = UndistortMap{}.K(camera_matrix).dist(dist_coeffs)(image_size);

--- a/include/improc/calib/ops/undistort.hpp
+++ b/include/improc/calib/ops/undistort.hpp
@@ -30,7 +30,7 @@ struct Undistort {
     Undistort& dist(cv::Mat d) { dist_ = std::move(d); return *this; }
 
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (K_.empty())
             throw improc::ParameterError{"K", "must be set before calling operator()", "Undistort"};
         if (dist_.empty())
@@ -69,7 +69,7 @@ struct UndistortMap {
     UndistortMap& R(cv::Mat r)       { R_     = std::move(r); return *this; }
 
     /// @brief Computes the undistortion maps for the given image size.
-    UndistortMapResult operator()(cv::Size image_size) const;
+    [[nodiscard]] UndistortMapResult operator()(cv::Size image_size) const;
 
 private:
     cv::Mat K_;

--- a/include/improc/calib/pipeline.hpp
+++ b/include/improc/calib/pipeline.hpp
@@ -20,3 +20,4 @@
 #include "improc/calib/ops/stereo.hpp"
 #include "improc/calib/ops/epipolar.hpp"
 #include "improc/calib/ops/aruco.hpp"
+#include "improc/calib/ops/fisheye.hpp"

--- a/include/improc/core/ops/adaptive_threshold.hpp
+++ b/include/improc/core/ops/adaptive_threshold.hpp
@@ -61,7 +61,7 @@ struct AdaptiveThreshold {
     AdaptiveThreshold& C(double v) { C_ = v; return *this; }
 
     template<GrayFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         const int cv_method = (method_ == AdaptiveMethod::Gaussian)
             ? cv::ADAPTIVE_THRESH_GAUSSIAN_C
             : cv::ADAPTIVE_THRESH_MEAN_C;

--- a/include/improc/core/ops/alpha_blend.hpp
+++ b/include/improc/core/ops/alpha_blend.hpp
@@ -26,7 +26,7 @@ namespace improc::core {
 struct AlphaBlend {
     explicit AlphaBlend(Image<BGRA> overlay) : overlay_(std::move(overlay)) {}
 
-    Image<BGR> operator()(Image<BGR> img) const {
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const {
         if (img.rows() != overlay_.rows() || img.cols() != overlay_.cols())
             throw ParameterError{"overlay", "size must match background", "AlphaBlend"};
 

--- a/include/improc/core/ops/analysis.hpp
+++ b/include/improc/core/ops/analysis.hpp
@@ -1,9 +1,9 @@
 // include/improc/core/ops/analysis.hpp
 #pragma once
-#include <stdexcept>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -85,10 +85,10 @@ struct Reduce {
     /// @brief Sets the reduction operation (default: Sum).
     Reduce& op(ReduceOp o) { op_  = o; return *this; }
     /// @brief Sets the reduction dimension: 0 = reduce rows → single row; 1 = reduce cols → single col.
-    /// @throws std::invalid_argument if dim is not 0 or 1.
+    /// @throws improc::ParameterError if dim is not 0 or 1.
     Reduce& dim(int d) {
         if (d != 0 && d != 1)
-            throw std::invalid_argument("Reduce: dim must be 0 (reduce rows) or 1 (reduce cols)");
+            throw improc::ParameterError{"dim", "must be 0 (reduce rows) or 1 (reduce cols)", "Reduce"};
         dim_ = d;
         return *this;
     }

--- a/include/improc/core/ops/analysis.hpp
+++ b/include/improc/core/ops/analysis.hpp
@@ -23,7 +23,7 @@ struct IntegralImage {
     IntegralImage& with_sq_sum(bool b) { with_sq_sum_ = b; return *this; }
 
     /// @brief Computes and returns the integral image.
-    IntegralResult operator()(const Image<Gray>& img) const;
+    [[nodiscard]] IntegralResult operator()(const Image<Gray>& img) const;
 
 private:
     bool with_sq_sum_ = false;
@@ -42,9 +42,9 @@ struct MinMaxLocResult {
  */
 struct MinMaxLoc {
     /// @brief Finds min/max in a `Gray` image.
-    MinMaxLocResult operator()(const Image<Gray>& img) const;
+    [[nodiscard]] MinMaxLocResult operator()(const Image<Gray>& img) const;
     /// @brief Finds min/max in an arbitrary `cv::Mat`.
-    MinMaxLocResult operator()(const cv::Mat& mat) const;
+    [[nodiscard]] MinMaxLocResult operator()(const cv::Mat& mat) const;
 };
 
 /**
@@ -60,7 +60,7 @@ struct MeanStdDevResult {
  */
 struct MeanStdDev {
     template<AnyFormat F>
-    MeanStdDevResult operator()(const Image<F>& img) const {
+    [[nodiscard]] MeanStdDevResult operator()(const Image<F>& img) const {
         MeanStdDevResult r;
         cv::meanStdDev(img.mat(), r.mean, r.stddev);
         return r;
@@ -72,7 +72,7 @@ struct MeanStdDev {
  */
 struct CountNonZero {
     /// @return Number of non-zero pixels.
-    int operator()(const Image<Gray>& img) const;
+    [[nodiscard]] int operator()(const Image<Gray>& img) const;
 };
 
 /// @brief Reduction operation used by `Reduce`.
@@ -94,7 +94,7 @@ struct Reduce {
     }
 
     /// @return Single-row or single-column cv::Mat.
-    cv::Mat operator()(const Image<Gray>& img) const;
+    [[nodiscard]] cv::Mat operator()(const Image<Gray>& img) const;
 
 private:
     ReduceOp op_  = ReduceOp::Sum;

--- a/include/improc/core/ops/analysis.hpp
+++ b/include/improc/core/ops/analysis.hpp
@@ -1,5 +1,6 @@
 // include/improc/core/ops/analysis.hpp
 #pragma once
+#include <cstddef>
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
@@ -72,7 +73,7 @@ struct MeanStdDev {
  */
 struct CountNonZero {
     /// @return Number of non-zero pixels.
-    [[nodiscard]] int operator()(const Image<Gray>& img) const;
+    [[nodiscard]] std::size_t operator()(const Image<Gray>& img) const;
 };
 
 /// @brief Reduction operation used by `Reduce`.

--- a/include/improc/core/ops/apply_mask.hpp
+++ b/include/improc/core/ops/apply_mask.hpp
@@ -33,7 +33,7 @@ struct ApplyMask {
 
     /// @brief Applies the mask to img, zeroing pixels where mask == 0.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!mask_)
             throw ParameterError{"mask", "must be set before calling operator()", "ApplyMask"};
         if (mask_->rows() != img.rows() || mask_->cols() != img.cols())

--- a/include/improc/core/ops/arithmetic.hpp
+++ b/include/improc/core/ops/arithmetic.hpp
@@ -20,7 +20,7 @@ struct AbsDiff {
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw improc::ParameterError{"AbsDiff", "images must have the same size and type"};
+            throw improc::ParameterError{"other", "must have the same size and type as lhs", "AbsDiff"};
         cv::Mat result;
         cv::absdiff(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -42,7 +42,7 @@ struct BitwiseAnd {
     template<IntegerFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw improc::ParameterError{"BitwiseAnd", "images must have the same size and type"};
+            throw improc::ParameterError{"other", "must have the same size and type as lhs", "BitwiseAnd"};
         cv::Mat result;
         cv::bitwise_and(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -64,7 +64,7 @@ struct BitwiseOr {
     template<IntegerFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw improc::ParameterError{"BitwiseOr", "images must have the same size and type"};
+            throw improc::ParameterError{"other", "must have the same size and type as lhs", "BitwiseOr"};
         cv::Mat result;
         cv::bitwise_or(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -148,7 +148,7 @@ struct Add {
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw improc::ParameterError{"Add", "images must have the same size and type"};
+            throw improc::ParameterError{"other", "must have the same size and type as lhs", "Add"};
         cv::Mat result;
         cv::add(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -169,7 +169,7 @@ struct Subtract {
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw improc::ParameterError{"Subtract", "images must have the same size and type"};
+            throw improc::ParameterError{"other", "must have the same size and type as lhs", "Subtract"};
         cv::Mat result;
         cv::subtract(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -192,7 +192,7 @@ struct Multiply {
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw improc::ParameterError{"Multiply", "images must have the same size and type"};
+            throw improc::ParameterError{"other", "must have the same size and type as lhs", "Multiply"};
         cv::Mat result;
         cv::multiply(img.mat(), other_, result, scale_);
         return Image<F>(std::move(result));
@@ -216,7 +216,7 @@ struct Divide {
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw improc::ParameterError{"Divide", "images must have the same size and type"};
+            throw improc::ParameterError{"other", "must have the same size and type as lhs", "Divide"};
         cv::Mat result;
         cv::divide(img.mat(), other_, result, scale_);
         return Image<F>(std::move(result));

--- a/include/improc/core/ops/arithmetic.hpp
+++ b/include/improc/core/ops/arithmetic.hpp
@@ -18,7 +18,7 @@ struct AbsDiff {
 
     /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
             throw improc::ParameterError{"other", "must have the same size and type as lhs", "AbsDiff"};
         cv::Mat result;
@@ -40,7 +40,7 @@ struct BitwiseAnd {
 
     /// @throws improc::ParameterError if sizes or types differ.
     template<IntegerFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
             throw improc::ParameterError{"other", "must have the same size and type as lhs", "BitwiseAnd"};
         cv::Mat result;
@@ -62,7 +62,7 @@ struct BitwiseOr {
 
     /// @throws improc::ParameterError if sizes or types differ.
     template<IntegerFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
             throw improc::ParameterError{"other", "must have the same size and type as lhs", "BitwiseOr"};
         cv::Mat result;
@@ -101,7 +101,7 @@ struct Convolve {
     Convolve& border(int t)       { border_ = t; return *this; }
 
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         cv::Mat result;
         cv::filter2D(img.mat(), result, -1, kernel_, anchor_, delta_, border_);
         return Image<F>(std::move(result));
@@ -126,7 +126,7 @@ struct ConvertScaleAbs {
     ConvertScaleAbs& beta(double b)  { beta_  = b; return *this; }
 
     /// @return Grayscale Image<Gray> (CV_8UC1).
-    Image<Gray> operator()(const cv::Mat& src) const {
+    [[nodiscard]] Image<Gray> operator()(const cv::Mat& src) const {
         cv::Mat result;
         cv::convertScaleAbs(src, result, alpha_, beta_);
         return Image<Gray>(std::move(result));
@@ -146,7 +146,7 @@ struct Add {
 
     /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
             throw improc::ParameterError{"other", "must have the same size and type as lhs", "Add"};
         cv::Mat result;
@@ -167,7 +167,7 @@ struct Subtract {
 
     /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
             throw improc::ParameterError{"other", "must have the same size and type as lhs", "Subtract"};
         cv::Mat result;
@@ -190,7 +190,7 @@ struct Multiply {
 
     /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
             throw improc::ParameterError{"other", "must have the same size and type as lhs", "Multiply"};
         cv::Mat result;
@@ -214,7 +214,7 @@ struct Divide {
 
     /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
             throw improc::ParameterError{"other", "must have the same size and type as lhs", "Divide"};
         cv::Mat result;

--- a/include/improc/core/ops/arithmetic.hpp
+++ b/include/improc/core/ops/arithmetic.hpp
@@ -1,11 +1,11 @@
 // include/improc/core/ops/arithmetic.hpp
 #pragma once
-#include <stdexcept>
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
 #include "improc/core/ops/invert.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -16,11 +16,11 @@ struct AbsDiff {
     /// @brief Constructs with the subtrahend matrix.
     explicit AbsDiff(cv::Mat other) : other_(std::move(other)) {}
 
-    /// @throws std::invalid_argument if sizes or types differ.
+    /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw std::invalid_argument("AbsDiff: images must have the same size and type");
+            throw improc::ParameterError{"AbsDiff", "images must have the same size and type"};
         cv::Mat result;
         cv::absdiff(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -38,11 +38,11 @@ struct BitwiseAnd {
     /// @brief Constructs with the mask matrix.
     explicit BitwiseAnd(cv::Mat other) : other_(std::move(other)) {}
 
-    /// @throws std::invalid_argument if sizes or types differ.
+    /// @throws improc::ParameterError if sizes or types differ.
     template<IntegerFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw std::invalid_argument("BitwiseAnd: images must have the same size and type");
+            throw improc::ParameterError{"BitwiseAnd", "images must have the same size and type"};
         cv::Mat result;
         cv::bitwise_and(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -60,11 +60,11 @@ struct BitwiseOr {
     /// @brief Constructs with the mask matrix.
     explicit BitwiseOr(cv::Mat other) : other_(std::move(other)) {}
 
-    /// @throws std::invalid_argument if sizes or types differ.
+    /// @throws improc::ParameterError if sizes or types differ.
     template<IntegerFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw std::invalid_argument("BitwiseOr: images must have the same size and type");
+            throw improc::ParameterError{"BitwiseOr", "images must have the same size and type"};
         cv::Mat result;
         cv::bitwise_or(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -87,10 +87,10 @@ using BitwiseNot = Invert;
  */
 struct Convolve {
     /// @brief Constructs with the convolution kernel.
-    /// @throws std::invalid_argument if kernel is empty.
+    /// @throws improc::ParameterError if kernel is empty.
     explicit Convolve(cv::Mat kernel) : kernel_(std::move(kernel)) {
         if (kernel_.empty())
-            throw std::invalid_argument("Convolve: kernel must not be empty");
+            throw improc::ParameterError{"kernel", "must not be empty", "Convolve"};
     }
 
     /// @brief Sets the anchor point (default: {-1,-1} = kernel centre).
@@ -144,11 +144,11 @@ struct Add {
     /// @brief Constructs with the addend matrix.
     explicit Add(cv::Mat other) : other_(std::move(other)) {}
 
-    /// @throws std::invalid_argument if sizes or types differ.
+    /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw std::invalid_argument("Add: images must have the same size and type");
+            throw improc::ParameterError{"Add", "images must have the same size and type"};
         cv::Mat result;
         cv::add(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -165,11 +165,11 @@ struct Subtract {
     /// @brief Constructs with the subtrahend matrix.
     explicit Subtract(cv::Mat other) : other_(std::move(other)) {}
 
-    /// @throws std::invalid_argument if sizes or types differ.
+    /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw std::invalid_argument("Subtract: images must have the same size and type");
+            throw improc::ParameterError{"Subtract", "images must have the same size and type"};
         cv::Mat result;
         cv::subtract(img.mat(), other_, result);
         return Image<F>(std::move(result));
@@ -188,11 +188,11 @@ struct Multiply {
     /// @brief Sets an optional scale factor applied after multiplication (default: 1.0).
     Multiply& scale(double s) { scale_ = s; return *this; }
 
-    /// @throws std::invalid_argument if sizes or types differ.
+    /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw std::invalid_argument("Multiply: images must have the same size and type");
+            throw improc::ParameterError{"Multiply", "images must have the same size and type"};
         cv::Mat result;
         cv::multiply(img.mat(), other_, result, scale_);
         return Image<F>(std::move(result));
@@ -212,11 +212,11 @@ struct Divide {
     /// @brief Sets an optional scale factor applied after division (default: 1.0).
     Divide& scale(double s) { scale_ = s; return *this; }
 
-    /// @throws std::invalid_argument if sizes or types differ.
+    /// @throws improc::ParameterError if sizes or types differ.
     template<AnyFormat F>
     Image<F> operator()(Image<F> img) const {
         if (img.mat().size() != other_.size() || img.mat().type() != other_.type())
-            throw std::invalid_argument("Divide: images must have the same size and type");
+            throw improc::ParameterError{"Divide", "images must have the same size and type"};
         cv::Mat result;
         cv::divide(img.mat(), other_, result, scale_);
         return Image<F>(std::move(result));

--- a/include/improc/core/ops/background_subtract.hpp
+++ b/include/improc/core/ops/background_subtract.hpp
@@ -38,7 +38,7 @@ struct BackgroundSubtractMOG2 {
     BackgroundSubtractMOG2& detect_shadows(bool s) { detect_shadows_ = s;  return *this; }
 
     /// @brief Applies the subtractor; updates internal model. Non-const.
-    Image<Gray> operator()(const Image<BGR>& img);
+    [[nodiscard]] Image<Gray> operator()(const Image<BGR>& img);
 
 private:
     int    history_        = 500;
@@ -71,7 +71,7 @@ struct BackgroundSubtractKNN {
     BackgroundSubtractKNN& detect_shadows(bool s) { detect_shadows_ = s;  return *this; }
 
     /// @brief Applies the subtractor; updates internal model. Non-const.
-    Image<Gray> operator()(const Image<BGR>& img);
+    [[nodiscard]] Image<Gray> operator()(const Image<BGR>& img);
 
 private:
     int    history_        = 500;

--- a/include/improc/core/ops/bilateral_filter.hpp
+++ b/include/improc/core/ops/bilateral_filter.hpp
@@ -43,9 +43,9 @@ struct BilateralFilter {
     }
 
     /// @brief Applies bilateral filter to img.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Applies bilateral filter to img.
-    Image<BGR>  operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<BGR>  operator()(Image<BGR>  img) const;
 
 private:
     int    diameter_    = 9;

--- a/include/improc/core/ops/blur.hpp
+++ b/include/improc/core/ops/blur.hpp
@@ -40,7 +40,7 @@ struct GaussianBlur {
 
     /// @brief Applies Gaussian blur to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat dst;
         cv::GaussianBlur(img.mat(), dst, cv::Size(kernel_size_, kernel_size_), sigma_);
         return Image<Format>(std::move(dst));
@@ -75,7 +75,7 @@ struct MedianBlur {
 
     /// @brief Applies median blur to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat dst;
         cv::medianBlur(img.mat(), dst, kernel_size_);
         return Image<Format>(std::move(dst));
@@ -116,7 +116,7 @@ struct BoxFilter {
 
     /// @brief Applies box filter to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat result;
         cv::boxFilter(img.mat(), result, -1,
                       cv::Size(ksize_, ksize_), cv::Point(-1, -1),

--- a/include/improc/core/ops/brightness.hpp
+++ b/include/improc/core/ops/brightness.hpp
@@ -31,7 +31,7 @@ struct Brightness {
     Brightness& delta(double d) { delta_ = d; return *this; }
 
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         cv::Mat dst;
         img.mat().convertTo(dst, -1, 1.0, delta_);
         return Image<F>(std::move(dst));

--- a/include/improc/core/ops/center_crop.hpp
+++ b/include/improc/core/ops/center_crop.hpp
@@ -38,7 +38,7 @@ struct CenterCrop {
 
     /// @brief Applies the centered crop to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!width_ || !height_)
             throw ParameterError{"width/height", "both must be set", "CenterCrop"};
         const int w = *width_, h = *height_;

--- a/include/improc/core/ops/channels.hpp
+++ b/include/improc/core/ops/channels.hpp
@@ -13,10 +13,10 @@ namespace improc::core {
 struct SplitChannels {
     /// @brief Splits BGR into B, G, R channels.
     /// @return Array of three single-channel Image<Gray> in B, G, R order.
-    std::array<Image<Gray>, 3> operator()(const Image<BGR>&  img) const;
+    [[nodiscard]] std::array<Image<Gray>, 3> operator()(const Image<BGR>&  img) const;
     /// @brief Splits BGRA into B, G, R, A channels.
     /// @return Array of four single-channel Image<Gray> in B, G, R, A order.
-    std::array<Image<Gray>, 4> operator()(const Image<BGRA>& img) const;
+    [[nodiscard]] std::array<Image<Gray>, 4> operator()(const Image<BGRA>& img) const;
 };
 
 /**
@@ -24,10 +24,10 @@ struct SplitChannels {
  */
 struct MergeChannels {
     /// @brief Merges three single-channel images into a BGR image.
-    Image<BGR>  operator()(const Image<Gray>& b, const Image<Gray>& g,
+    [[nodiscard]] Image<BGR>  operator()(const Image<Gray>& b, const Image<Gray>& g,
                             const Image<Gray>& r) const;
     /// @brief Merges four single-channel images into a BGRA image.
-    Image<BGRA> operator()(const Image<Gray>& b, const Image<Gray>& g,
+    [[nodiscard]] Image<BGRA> operator()(const Image<Gray>& b, const Image<Gray>& g,
                             const Image<Gray>& r, const Image<Gray>& a) const;
 };
 

--- a/include/improc/core/ops/clahe.hpp
+++ b/include/improc/core/ops/clahe.hpp
@@ -41,9 +41,9 @@ struct CLAHE {
     }
 
     /// @brief Applies CLAHE to img. May propagate cv::Exception on OpenCV failure.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Applies CLAHE to img. May propagate cv::Exception on OpenCV failure.
-    Image<BGR>  operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<BGR>  operator()(Image<BGR>  img) const;
 
 private:
     double clip_limit_ = 40.0;

--- a/include/improc/core/ops/connected_components.hpp
+++ b/include/improc/core/ops/connected_components.hpp
@@ -1,5 +1,6 @@
 // include/improc/core/ops/connected_components.hpp
 #pragma once
+#include <cstddef>
 #include <stdexcept>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
@@ -22,10 +23,10 @@ struct ComponentMap {
     cv::Mat labels;        ///< CV_32S label matrix, same size as source
     cv::Mat stats;         ///< (num_labels × 5) int stats matrix (CC_STAT_* columns)
     cv::Mat centroids;     ///< (num_labels × 2) double centroid matrix
-    int     num_labels{0}; ///< total label count including background (label 0)
+    std::size_t num_labels{0}; ///< total label count including background (label 0)
 
     /// @brief Alias for `num_labels`.
-    int count() const { return num_labels; }
+    std::size_t count() const { return num_labels; }
 
     /// @brief Pixel area of label `label` (CC_STAT_AREA). Throws `std::out_of_range` if invalid.
     int area(int label) const;

--- a/include/improc/core/ops/connected_components.hpp
+++ b/include/improc/core/ops/connected_components.hpp
@@ -60,7 +60,7 @@ struct ConnectedComponents {
 
     ConnectedComponents& connectivity(Connectivity c) { conn_ = c; return *this; }
 
-    ComponentMap operator()(Image<Gray> img) const;
+    [[nodiscard]] ComponentMap operator()(Image<Gray> img) const;
 
 private:
     Connectivity conn_ = Connectivity::Eight;

--- a/include/improc/core/ops/contours.hpp
+++ b/include/improc/core/ops/contours.hpp
@@ -58,43 +58,6 @@ private:
     Method method_ = Method::Simple;
 };
 
-/**
- * @brief Pipeline op: draws contours from a `ContourSet` onto a BGR image clone.
- *
- * Wraps `cv::drawContours`. Pass `index(-1)` to draw all (default).
- * Pass `thickness(-1)` to fill contours.
- * The source image is never mutated.
- *
- * @throws improc::ParameterError if `thickness` is not positive and not -1.
- *
- * @code
- * Image<BGR> annotated = bgr | DrawContours{cs}.color({0, 255, 0});
- * Image<BGR> filled    = bgr | DrawContours{cs}.thickness(-1);
- * @endcode
- */
-struct DrawContours {
-    explicit DrawContours(ContourSet cs) : cs_(std::move(cs)) {}
-
-    DrawContours& index(int i) { index_ = i; return *this; }
-
-    DrawContours& color(cv::Scalar c) { color_ = c; return *this; }
-
-    DrawContours& thickness(int t) {
-        if (t <= 0 && t != -1)
-            throw ParameterError{"thickness", "must be positive or -1 (fill)", "DrawContours"};
-        thickness_ = t;
-        return *this;
-    }
-
-    Image<BGR> operator()(Image<BGR> img) const;
-
-private:
-    ContourSet cs_;
-    int        index_{-1};
-    cv::Scalar color_{0, 255, 0};
-    int        thickness_{1};
-};
-
 struct ConvexHull {
     std::vector<cv::Point> operator()(const std::vector<cv::Point>& contour) const;
 };

--- a/include/improc/core/ops/contours.hpp
+++ b/include/improc/core/ops/contours.hpp
@@ -51,7 +51,7 @@ struct FindContours {
     FindContours& mode(Mode m)     { mode_   = m; return *this; }
     FindContours& method(Method m) { method_ = m; return *this; }
 
-    ContourSet operator()(Image<Gray> img) const;
+    [[nodiscard]] ContourSet operator()(Image<Gray> img) const;
 
 private:
     Mode   mode_   = Mode::External;
@@ -59,14 +59,14 @@ private:
 };
 
 struct ConvexHull {
-    std::vector<cv::Point> operator()(const std::vector<cv::Point>& contour) const;
+    [[nodiscard]] std::vector<cv::Point> operator()(const std::vector<cv::Point>& contour) const;
 };
 
 struct ApproxPolyDP {
     ApproxPolyDP& epsilon(double e) { epsilon_ = e; return *this; }
     ApproxPolyDP& closed(bool c)    { closed_  = c; return *this; }
 
-    std::vector<cv::Point> operator()(const std::vector<cv::Point>& contour) const;
+    [[nodiscard]] std::vector<cv::Point> operator()(const std::vector<cv::Point>& contour) const;
 
 private:
     double epsilon_ = 3.0;
@@ -74,11 +74,11 @@ private:
 };
 
 struct MinAreaRect {
-    cv::RotatedRect operator()(const std::vector<cv::Point>& contour) const;
+    [[nodiscard]] cv::RotatedRect operator()(const std::vector<cv::Point>& contour) const;
 };
 
 struct BoundingRect {
-    cv::Rect operator()(const std::vector<cv::Point>& contour) const;
+    [[nodiscard]] cv::Rect operator()(const std::vector<cv::Point>& contour) const;
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/contrast.hpp
+++ b/include/improc/core/ops/contrast.hpp
@@ -32,7 +32,7 @@ struct Contrast {
     }
 
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         cv::Mat dst;
         img.mat().convertTo(dst, -1, factor_, 0.0);
         return Image<F>(std::move(dst));

--- a/include/improc/core/ops/crop.hpp
+++ b/include/improc/core/ops/crop.hpp
@@ -42,7 +42,7 @@ struct Crop {
 
     /// @brief Crops img to the configured ROI.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!x_ || !y_ || !width_ || !height_)
             throw ParameterError{"x/y/width/height", "all four must be set", "Crop"};
         cv::Rect roi(*x_, *y_, *width_, *height_);

--- a/include/improc/core/ops/detectors.hpp
+++ b/include/improc/core/ops/detectors.hpp
@@ -17,7 +17,7 @@ namespace improc::core {
 struct DetectFAST {
     DetectFAST& threshold(int t)             { threshold_ = t;   return *this; }
     DetectFAST& non_max_suppression(bool nms) { nms_       = nms; return *this; }
-    KeypointSet operator()(Image<Gray> img) const;
+    [[nodiscard]] KeypointSet operator()(Image<Gray> img) const;
 private:
     int  threshold_ = 10;
     bool nms_       = true;
@@ -30,7 +30,7 @@ private:
 /// @endcode
 struct DetectBlob {
     DetectBlob& params(cv::SimpleBlobDetector::Params p) { params_ = p; return *this; }
-    KeypointSet operator()(Image<Gray> img) const;
+    [[nodiscard]] KeypointSet operator()(Image<Gray> img) const;
 private:
     cv::SimpleBlobDetector::Params params_;
 };
@@ -44,7 +44,7 @@ struct DetectMSER {
     DetectMSER& delta(int d)    { delta_    = d; return *this; }
     DetectMSER& min_area(int a) { min_area_ = a; return *this; }
     DetectMSER& max_area(int a) { max_area_ = a; return *this; }
-    MSERResult  operator()(Image<Gray> img) const;
+    [[nodiscard]] MSERResult  operator()(Image<Gray> img) const;
 private:
     int delta_    = 5;
     int min_area_ = 60;
@@ -59,7 +59,7 @@ private:
 struct DetectLines {
     DetectLines& scale(double s)       { scale_       = s; return *this; }
     DetectLines& sigma_scale(double s) { sigma_scale_ = s; return *this; }
-    LineSet      operator()(Image<Gray> img) const;
+    [[nodiscard]] LineSet      operator()(Image<Gray> img) const;
 private:
     double scale_       = 0.8;
     double sigma_scale_ = 0.6;
@@ -70,7 +70,7 @@ private:
 /// QRResult qr = bgr | DetectQR{};
 /// @endcode
 struct DetectQR {
-    QRResult operator()(Image<BGR> img) const;
+    [[nodiscard]] QRResult operator()(Image<BGR> img) const;
 };
 
 /// @brief Pipeline op: detects and decodes barcodes in `Image<BGR>` (no model file needed). Returns `BarcodeResult`.
@@ -78,7 +78,7 @@ struct DetectQR {
 /// BarcodeResult bc = bgr | DetectBarcode{};
 /// @endcode
 struct DetectBarcode {
-    BarcodeResult operator()(Image<BGR> img) const;
+    [[nodiscard]] BarcodeResult operator()(Image<BGR> img) const;
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/distance_transform.hpp
+++ b/include/improc/core/ops/distance_transform.hpp
@@ -23,7 +23,7 @@ struct DistanceTransform {
     DistanceTransform& dist_type(DistType t) { dist_type_ = t; return *this; }
     DistanceTransform& mask_size(MaskSize m) { mask_size_ = m; return *this; }
 
-    Image<Float32> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Float32> operator()(Image<Gray> img) const;
 
 private:
     DistType dist_type_ = DistType::L2;

--- a/include/improc/core/ops/draw_matches.hpp
+++ b/include/improc/core/ops/draw_matches.hpp
@@ -1,56 +1,11 @@
 // include/improc/core/ops/draw_matches.hpp
+// DrawKeypoints and DrawMatches have moved to improc::visualization.
+// This header is kept for backward compatibility.
 #pragma once
-#include <utility>
-#include <opencv2/features2d.hpp>
-#include "improc/core/ops/matching.hpp"
-
+#include "improc/visualization/draw_matches.hpp"
 namespace improc::core {
-
-/**
- * @brief Pipeline op: draws keypoints onto an image.
- *
- * Accepts Image<Gray> or Image<BGR>; always returns Image<BGR>.
- * Uses cv::DrawMatchesFlags::DRAW_RICH_KEYPOINTS (oriented, scaled circles).
- * An empty KeypointSet produces a valid BGR image with no annotations.
- *
- * @code
- * Image<BGR> vis = gray | DrawKeypoints{kps};
- * @endcode
- */
-struct DrawKeypoints {
-    explicit DrawKeypoints(KeypointSet kps) : kps_(std::move(kps)) {}
-
-    Image<BGR> operator()(Image<Gray> img) const;
-    Image<BGR> operator()(Image<BGR>  img) const;
-
-private:
-    KeypointSet kps_;
-};
-
-/**
- * @brief Callable: draws matches between two BGR images side-by-side.
- *
- * Output width: img1.cols + img2.cols. Height: max(img1.rows, img2.rows).
- * An empty MatchSet produces a side-by-side image with no connecting lines.
- *
- * @code
- * Image<BGR> vis = DrawMatches{img1, kps1, img2, kps2, matches}();
- * @endcode
- */
-struct DrawMatches {
-    DrawMatches(Image<BGR> img1, KeypointSet kps1,
-                Image<BGR> img2, KeypointSet kps2,
-                MatchSet   ms)
-        : img1_(std::move(img1)), kps1_(std::move(kps1)),
-          img2_(std::move(img2)), kps2_(std::move(kps2)),
-          ms_(std::move(ms)) {}
-
-    Image<BGR> operator()() const;
-
-private:
-    Image<BGR>  img1_, img2_;
-    KeypointSet kps1_, kps2_;
-    MatchSet    ms_;
-};
-
+    // Deprecated: use improc::visualization::DrawKeypoints instead.
+    using improc::visualization::DrawKeypoints;
+    // Deprecated: use improc::visualization::DrawMatches instead.
+    using improc::visualization::DrawMatches;
 } // namespace improc::core

--- a/include/improc/core/ops/drawing.hpp
+++ b/include/improc/core/ops/drawing.hpp
@@ -40,7 +40,7 @@ struct DrawText {
         return *this;
     }
 
-    Image<BGR> operator()(Image<BGR> img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const;
 
 private:
     std::string text_;
@@ -73,7 +73,7 @@ struct DrawLine {
         return *this;
     }
 
-    Image<BGR> operator()(Image<BGR> img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const;
 
 private:
     cv::Point  p1_, p2_;
@@ -110,7 +110,7 @@ struct DrawCircle {
         return *this;
     }
 
-    Image<BGR> operator()(Image<BGR> img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const;
 
 private:
     cv::Point  center_;
@@ -143,7 +143,7 @@ struct DrawRectangle {
         return *this;
     }
 
-    Image<BGR> operator()(Image<BGR> img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const;
 
 private:
     cv::Rect   rect_;

--- a/include/improc/core/ops/edge.hpp
+++ b/include/improc/core/ops/edge.hpp
@@ -26,7 +26,7 @@ struct SobelEdge {
     /// @brief Sets Sobel kernel size. Must be 1, 3, 5, or 7.
     SobelEdge& ksize(int k) {
         if (k != 1 && k != 3 && k != 5 && k != 7)
-            throw ParameterError{"ksize", "must be 1, 3, 5, or 7", "SobelEdge"};
+            throw improc::ParameterError{"ksize", "must be 1, 3, 5, or 7", "SobelEdge"};
         ksize_ = k;
         return *this;
     }
@@ -57,21 +57,21 @@ struct CannyEdge {
     /// @brief Sets lower hysteresis threshold. Must be >= 0.
     CannyEdge& threshold1(double t) {
         if (t < 0.0)
-            throw ParameterError{"threshold1", "must be >= 0", "CannyEdge"};
+            throw improc::ParameterError{"threshold1", "must be >= 0", "CannyEdge"};
         threshold1_ = t;
         return *this;
     }
     /// @brief Sets upper hysteresis threshold. Must be >= 0.
     CannyEdge& threshold2(double t) {
         if (t < 0.0)
-            throw ParameterError{"threshold2", "must be >= 0", "CannyEdge"};
+            throw improc::ParameterError{"threshold2", "must be >= 0", "CannyEdge"};
         threshold2_ = t;
         return *this;
     }
     /// @brief Sets Sobel aperture size. Must be 3, 5, or 7.
     CannyEdge& aperture_size(int s) {
         if (s != 3 && s != 5 && s != 7)
-            throw ParameterError{"aperture_size", "must be 3, 5, or 7", "CannyEdge"};
+            throw improc::ParameterError{"aperture_size", "must be 3, 5, or 7", "CannyEdge"};
         aperture_size_ = s;
         return *this;
     }
@@ -106,7 +106,7 @@ struct LaplacianEdge {
     /// @brief Laplacian kernel size. Default 1. Must be odd and positive.
     LaplacianEdge& ksize(int v) {
         if (v <= 0 || v % 2 == 0)
-            throw ParameterError{"ksize",
+            throw improc::ParameterError{"ksize",
                 std::format("must be odd and positive, got {}", v), "LaplacianEdge"};
         ksize_ = v;
         return *this;
@@ -114,7 +114,7 @@ struct LaplacianEdge {
     /// @brief Scale factor applied to computed Laplacian values. Default 1.0. Must be > 0.
     LaplacianEdge& scale(double v) {
         if (v <= 0.0)
-            throw ParameterError{"scale", "must be positive", "LaplacianEdge"};
+            throw improc::ParameterError{"scale", "must be positive", "LaplacianEdge"};
         scale_ = v;
         return *this;
     }
@@ -155,21 +155,21 @@ struct HarrisCorner {
     /// @brief Neighbourhood size for covariance matrix. Default 2. Must be > 0.
     HarrisCorner& block_size(int v) {
         if (v <= 0)
-            throw ParameterError{"block_size", "must be positive", "HarrisCorner"};
+            throw improc::ParameterError{"block_size", "must be positive", "HarrisCorner"};
         block_size_ = v;
         return *this;
     }
     /// @brief Sobel kernel size. Must be 3, 5, or 7. Default 3.
     HarrisCorner& ksize(int v) {
         if (v != 3 && v != 5 && v != 7)
-            throw ParameterError{"ksize", "must be 3, 5, or 7", "HarrisCorner"};
+            throw improc::ParameterError{"ksize", "must be 3, 5, or 7", "HarrisCorner"};
         ksize_ = v;
         return *this;
     }
     /// @brief Harris sensitivity parameter. Must be in (0, 1). Default 0.04.
     HarrisCorner& k(double v) {
         if (v <= 0.0 || v >= 1.0)
-            throw ParameterError{"k", "must be in (0, 1)", "HarrisCorner"};
+            throw improc::ParameterError{"k", "must be in (0, 1)", "HarrisCorner"};
         k_ = v;
         return *this;
     }
@@ -193,7 +193,7 @@ struct SobelResult {
 struct SobelGradient {
     SobelGradient& ksize(int k) {
         if (k != 1 && k != 3 && k != 5 && k != 7)
-            throw ParameterError{"ksize", "must be 1, 3, 5, or 7", "SobelGradient"};
+            throw improc::ParameterError{"ksize", "must be 1, 3, 5, or 7", "SobelGradient"};
         ksize_ = k;
         return *this;
     }

--- a/include/improc/core/ops/edge.hpp
+++ b/include/improc/core/ops/edge.hpp
@@ -32,9 +32,9 @@ struct SobelEdge {
     }
 
     /// @brief Detects edges in img using the Sobel operator.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Detects edges in img using the Sobel operator.
-    Image<Gray> operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<BGR>  img) const;
 
 private:
     int ksize_ = 3;
@@ -77,9 +77,9 @@ struct CannyEdge {
     }
 
     /// @brief Detects edges in img using the Canny algorithm.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Detects edges in img using the Canny algorithm.
-    Image<Gray> operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<BGR>  img) const;
 
 private:
     double threshold1_    = 100.0;
@@ -125,9 +125,9 @@ struct LaplacianEdge {
     }
 
     /// @brief Detects edges in img using the Laplacian operator.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Detects edges in img using the Laplacian operator (auto-converts BGR→Gray).
-    Image<Gray> operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<BGR>  img) const;
 
 private:
     int    ksize_ = 1;
@@ -175,9 +175,9 @@ struct HarrisCorner {
     }
 
     /// @brief Returns normalized corner response map for a gray image.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Returns normalized corner response map (auto-converts BGR→Gray).
-    Image<Gray> operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<BGR>  img) const;
 
 private:
     int    block_size_ = 2;
@@ -200,7 +200,7 @@ struct SobelGradient {
     SobelGradient& scale(double s) { scale_ = s; return *this; }
     SobelGradient& delta(double d) { delta_ = d; return *this; }
 
-    SobelResult operator()(const Image<Gray>& img) const;
+    [[nodiscard]] SobelResult operator()(const Image<Gray>& img) const;
 
 private:
     int    ksize_ = 3;
@@ -217,7 +217,7 @@ struct ScharrGradient {
     ScharrGradient& scale(double s) { scale_ = s; return *this; }
     ScharrGradient& delta(double d) { delta_ = d; return *this; }
 
-    ScharrResult operator()(const Image<Gray>& img) const;
+    [[nodiscard]] ScharrResult operator()(const Image<Gray>& img) const;
 
 private:
     double scale_ = 1.0;

--- a/include/improc/core/ops/edge.hpp
+++ b/include/improc/core/ops/edge.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <format>
-#include <stdexcept>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/exceptions.hpp"
@@ -194,7 +193,7 @@ struct SobelResult {
 struct SobelGradient {
     SobelGradient& ksize(int k) {
         if (k != 1 && k != 3 && k != 5 && k != 7)
-            throw std::invalid_argument("SobelGradient: ksize must be 1, 3, 5, or 7");
+            throw ParameterError{"ksize", "must be 1, 3, 5, or 7", "SobelGradient"};
         ksize_ = k;
         return *this;
     }

--- a/include/improc/core/ops/face.hpp
+++ b/include/improc/core/ops/face.hpp
@@ -5,6 +5,7 @@
 #include <opencv2/objdetect.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/ops/detector_types.hpp"
+#include "improc/core/types/face_embedding.hpp"
 #include "improc/exceptions.hpp"
 
 namespace improc::core {
@@ -42,7 +43,7 @@ private:
 };
 
 /// @brief Stateful SFace face recogniser. Requires `.model(path)` before calling embed().
-/// embed() returns (1, 128) CV_32F embedding; non-const (lazy init).
+/// embed() returns a FaceEmbedding wrapping a (1, 128) CV_32F descriptor; non-const (lazy init).
 /// match() is static — cosine similarity [-1, 1]; no model needed.
 /// @code
 /// RecognizeFace op;
@@ -54,9 +55,9 @@ class RecognizeFace {
 public:
     RecognizeFace& model(std::string path) { model_path_ = std::move(path); return *this; }
 
-    [[nodiscard]] cv::Mat      embed(Image<BGR> face_chip);           // non-const; returns (1, 128) CV_32F
-    static float match(const cv::Mat& emb_a,
-                       const cv::Mat& emb_b);           // static: cosine similarity, no model needed
+    [[nodiscard]] FaceEmbedding embed(Image<BGR> face_chip);           // non-const; returns FaceEmbedding with (1, 128) CV_32F descriptor
+    [[nodiscard]] static float match(const FaceEmbedding& emb_a,
+                                     const FaceEmbedding& emb_b);      // static: cosine similarity, no model needed
 
 private:
     void ensure_initialized();

--- a/include/improc/core/ops/face.hpp
+++ b/include/improc/core/ops/face.hpp
@@ -27,7 +27,7 @@ public:
     DetectFaceYN& nms_threshold(float t)   { nms_threshold_    = t;               return *this; }
     DetectFaceYN& top_k(int k)             { top_k_            = k;               return *this; }
 
-    std::vector<FaceDetection> operator()(Image<BGR> img);  // non-const: lazy init
+    [[nodiscard]] std::vector<FaceDetection> operator()(Image<BGR> img);  // non-const: lazy init
 
 private:
     void ensure_initialized(cv::Size frame_size);
@@ -54,7 +54,7 @@ class RecognizeFace {
 public:
     RecognizeFace& model(std::string path) { model_path_ = std::move(path); return *this; }
 
-    cv::Mat      embed(Image<BGR> face_chip);           // non-const; returns (1, 128) CV_32F
+    [[nodiscard]] cv::Mat      embed(Image<BGR> face_chip);           // non-const; returns (1, 128) CV_32F
     static float match(const cv::Mat& emb_a,
                        const cv::Mat& emb_b);           // static: cosine similarity, no model needed
 

--- a/include/improc/core/ops/feature_detection.hpp
+++ b/include/improc/core/ops/feature_detection.hpp
@@ -43,7 +43,7 @@ struct DetectORB {
     DetectORB& scale_factor(float f) { scale_factor_ = f; return *this; }
     DetectORB& n_levels(int n)       { n_levels_     = n; return *this; }
 
-    KeypointSet operator()(Image<Gray> img) const;
+    [[nodiscard]] KeypointSet operator()(Image<Gray> img) const;
 
 private:
     int   max_features_{500};
@@ -74,7 +74,7 @@ struct DetectSIFT {
     DetectSIFT& max_features(int n)    { max_features_    = n; return *this; }
     DetectSIFT& n_octave_layers(int n) { n_octave_layers_ = n; return *this; }
 
-    KeypointSet operator()(Image<Gray> img) const;
+    [[nodiscard]] KeypointSet operator()(Image<Gray> img) const;
 
 private:
     int max_features_{0};    ///< 0 = no limit
@@ -94,7 +94,7 @@ private:
 struct DetectAKAZE {
     DetectAKAZE& threshold(float t) { threshold_ = t; return *this; }
 
-    KeypointSet operator()(Image<Gray> img) const;
+    [[nodiscard]] KeypointSet operator()(Image<Gray> img) const;
 
 private:
     float threshold_{0.001f};
@@ -128,8 +128,8 @@ struct DescriptorSet {
 /// @brief Pipeline op: computes ORB descriptors for a given `KeypointSet`.
 struct DescribeORB {
     explicit DescribeORB(KeypointSet kps) : kps_(std::move(kps)) {}
-    DescriptorSet operator()(Image<Gray> img) const;
-    DescriptorSet operator()(Image<BGR>  img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<Gray> img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<BGR>  img) const;
 private:
     KeypointSet kps_;
 };
@@ -143,8 +143,8 @@ private:
  */
 struct DescribeSIFT {
     explicit DescribeSIFT(KeypointSet kps) : kps_(std::move(kps)) {}
-    DescriptorSet operator()(Image<Gray> img) const;
-    DescriptorSet operator()(Image<BGR>  img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<Gray> img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<BGR>  img) const;
 private:
     KeypointSet kps_;
 };
@@ -152,8 +152,8 @@ private:
 /// @brief Pipeline op: computes AKAZE descriptors for a given `KeypointSet`.
 struct DescribeAKAZE {
     explicit DescribeAKAZE(KeypointSet kps) : kps_(std::move(kps)) {}
-    DescriptorSet operator()(Image<Gray> img) const;
-    DescriptorSet operator()(Image<BGR>  img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<Gray> img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<BGR>  img) const;
 private:
     KeypointSet kps_;
 };
@@ -174,7 +174,7 @@ struct GoodFeaturesToTrack {
     }
     GoodFeaturesToTrack& use_harris(bool b) { use_harris_ = b; return *this; }
 
-    std::vector<cv::Point2f> operator()(const Image<Gray>& img) const;
+    [[nodiscard]] std::vector<cv::Point2f> operator()(const Image<Gray>& img) const;
 
 private:
     int    max_corners_   = 100;

--- a/include/improc/core/ops/flip.hpp
+++ b/include/improc/core/ops/flip.hpp
@@ -24,7 +24,7 @@ struct Flip {
 
     /// @brief Flips img along the configured axis.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         int flip_code;
         switch (axis_) {
             case Axis::Horizontal: flip_code =  1; break;

--- a/include/improc/core/ops/flood_fill.hpp
+++ b/include/improc/core/ops/flood_fill.hpp
@@ -21,9 +21,9 @@ struct FloodFill {
     FloodFill& up_diff(cv::Scalar hi) { up_diff_ = hi; return *this; }
 
     /// @brief Fills a connected region in a BGR image.
-    Image<BGR>  operator()(const Image<BGR>&  img, cv::Point seed, cv::Scalar new_color) const;
+    [[nodiscard]] Image<BGR>  operator()(const Image<BGR>&  img, cv::Point seed, cv::Scalar new_color) const;
     /// @brief Fills a connected region in a Gray image.
-    Image<Gray> operator()(const Image<Gray>& img, cv::Point seed, uchar      new_val)   const;
+    [[nodiscard]] Image<Gray> operator()(const Image<Gray>& img, cv::Point seed, uchar      new_val)   const;
 
 private:
     cv::Scalar lo_diff_{0, 0, 0};

--- a/include/improc/core/ops/gamma.hpp
+++ b/include/improc/core/ops/gamma.hpp
@@ -32,7 +32,7 @@ struct GammaCorrection {
 
     /// @brief Applies gamma correction to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         const int depth = img.mat().depth();
         cv::Mat dst;
 

--- a/include/improc/core/ops/grabcut.hpp
+++ b/include/improc/core/ops/grabcut.hpp
@@ -20,7 +20,7 @@ struct GrabCut {
     /// @brief Runs GrabCut and returns a binary foreground mask.
     /// @param roi Rectangle containing the foreground object.
     /// @return Image<Gray> where 255 = foreground, 0 = background.
-    Image<Gray> operator()(const Image<BGR>& img, cv::Rect roi) const;
+    [[nodiscard]] Image<Gray> operator()(const Image<BGR>& img, cv::Rect roi) const;
 
 private:
     int iterations_{5};

--- a/include/improc/core/ops/hist.hpp
+++ b/include/improc/core/ops/hist.hpp
@@ -3,13 +3,15 @@
 
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
+#include "improc/core/types/histogram_data.hpp"
 
 namespace improc::core {
 
 /**
  * @brief Computes a 1-D histogram for a grayscale or BGR image.
  *
- * For BGR images, per-channel histograms are concatenated along columns.
+ * For Gray images the result contains a (bins × 1) CV_32F matrix.
+ * For BGR images the result contains a (bins × 3) CV_32F matrix (columns = B, G, R).
  */
 struct CalcHist {
     /// @brief Sets the number of histogram bins (default: 256).
@@ -18,9 +20,9 @@ struct CalcHist {
     CalcHist& range(float lo, float hi);
 
     /// @brief Computes a 1-D histogram for a grayscale image.
-    [[nodiscard]] cv::Mat operator()(const Image<Gray>& img) const;
-    /// @brief Computes per-channel histograms for a BGR image, concatenated along columns.
-    [[nodiscard]] cv::Mat operator()(const Image<BGR>& img) const;
+    [[nodiscard]] HistogramData operator()(const Image<Gray>& img) const;
+    /// @brief Computes per-channel histograms for a BGR image, stored as columns of the result matrix.
+    [[nodiscard]] HistogramData operator()(const Image<BGR>& img) const;
 
 private:
     int bins_ = 256;
@@ -36,7 +38,7 @@ struct CompareHist {
     CompareHist& method(int m);
 
     /// @return Scalar result whose meaning depends on the chosen method.
-    [[nodiscard]] double operator()(const cv::Mat& h1, const cv::Mat& h2) const;
+    [[nodiscard]] double operator()(const HistogramData& h1, const HistogramData& h2) const;
 
 private:
     int method_ = cv::HISTCMP_CORREL;

--- a/include/improc/core/ops/hist.hpp
+++ b/include/improc/core/ops/hist.hpp
@@ -18,9 +18,9 @@ struct CalcHist {
     CalcHist& range(float lo, float hi);
 
     /// @brief Computes a 1-D histogram for a grayscale image.
-    cv::Mat operator()(const Image<Gray>& img) const;
+    [[nodiscard]] cv::Mat operator()(const Image<Gray>& img) const;
     /// @brief Computes per-channel histograms for a BGR image, concatenated along columns.
-    cv::Mat operator()(const Image<BGR>& img) const;
+    [[nodiscard]] cv::Mat operator()(const Image<BGR>& img) const;
 
 private:
     int bins_ = 256;
@@ -36,7 +36,7 @@ struct CompareHist {
     CompareHist& method(int m);
 
     /// @return Scalar result whose meaning depends on the chosen method.
-    double operator()(const cv::Mat& h1, const cv::Mat& h2) const;
+    [[nodiscard]] double operator()(const cv::Mat& h1, const cv::Mat& h2) const;
 
 private:
     int method_ = cv::HISTCMP_CORREL;

--- a/include/improc/core/ops/hist_eq.hpp
+++ b/include/improc/core/ops/hist_eq.hpp
@@ -22,9 +22,9 @@ namespace improc::core {
  */
 struct HistogramEqualization {
     /// @brief Equalizes the histogram of a single-channel gray image.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Equalizes the luminance (Y) channel of a BGR image.
-    Image<BGR>  operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<BGR>  operator()(Image<BGR>  img) const;
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/homography.hpp
+++ b/include/improc/core/ops/homography.hpp
@@ -72,7 +72,7 @@ struct WarpPerspective {
 
     /// @brief Warps img using the configured homography.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!H_)
             throw ParameterError{"homography", "must be set before calling operator()", "WarpPerspective"};
         int w = width_.value_or(img.cols());

--- a/include/improc/core/ops/hough.hpp
+++ b/include/improc/core/ops/hough.hpp
@@ -27,7 +27,7 @@ struct HoughLinesP {
     HoughLinesP& max_line_gap(double g);
 
     /// @return Detected line segments as cv::Vec4i (x1, y1, x2, y2).
-    std::vector<cv::Vec4i> operator()(const Image<Gray>& img) const;
+    [[nodiscard]] std::vector<cv::Vec4i> operator()(const Image<Gray>& img) const;
 
 private:
     double rho_             = 1.0;
@@ -57,7 +57,7 @@ struct HoughCircles {
     HoughCircles& max_radius(int r);
 
     /// @return Detected circles as cv::Vec3f (cx, cy, radius).
-    std::vector<cv::Vec3f> operator()(const Image<Gray>& img) const;
+    [[nodiscard]] std::vector<cv::Vec3f> operator()(const Image<Gray>& img) const;
 
 private:
     double min_dist_   = 20.0;

--- a/include/improc/core/ops/img_hash.hpp
+++ b/include/improc/core/ops/img_hash.hpp
@@ -15,7 +15,7 @@ namespace improc::core {
  */
 struct AverageHash {
     /// @return 1×8 CV_8U hash matrix (64 bits).
-    cv::Mat operator()(const Image<BGR>&) const;
+    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two AverageHash digests.
     static double distance(const cv::Mat& a, const cv::Mat& b);
 };
@@ -25,7 +25,7 @@ struct AverageHash {
  */
 struct PHash {
     /// @return 1×8 CV_8U hash matrix (64 bits, DCT-based).
-    cv::Mat operator()(const Image<BGR>&) const;
+    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two PHash digests.
     static double distance(const cv::Mat& a, const cv::Mat& b);
 };
@@ -35,7 +35,7 @@ struct PHash {
  */
 struct MarrHildrethHash {
     /// @return 1×72 CV_8U hash matrix (576 bits, LoG zero-crossing).
-    cv::Mat operator()(const Image<BGR>&) const;
+    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two MarrHildrethHash digests.
     static double distance(const cv::Mat& a, const cv::Mat& b);
 };
@@ -45,7 +45,7 @@ struct MarrHildrethHash {
  */
 struct RadialVarianceHash {
     /// @return 1×40 CV_64F hash matrix (radial variances).
-    cv::Mat operator()(const Image<BGR>&) const;
+    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
     /// @brief Computes the L2 distance between two RadialVarianceHash digests.
     static double distance(const cv::Mat& a, const cv::Mat& b);
 };
@@ -55,7 +55,7 @@ struct RadialVarianceHash {
  */
 struct ColorMomentHash {
     /// @return 1×42 CV_64F hash matrix (color moments).
-    cv::Mat operator()(const Image<BGR>&) const;
+    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
     /// @brief Computes the L2 distance between two ColorMomentHash digests.
     static double distance(const cv::Mat& a, const cv::Mat& b);
 };
@@ -65,7 +65,7 @@ struct ColorMomentHash {
  */
 struct BlockMeanHash {
     /// @return 1×32 CV_8U hash matrix (256 bits, block means).
-    cv::Mat operator()(const Image<BGR>&) const;
+    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two BlockMeanHash digests.
     static double distance(const cv::Mat& a, const cv::Mat& b);
 };

--- a/include/improc/core/ops/img_hash.hpp
+++ b/include/improc/core/ops/img_hash.hpp
@@ -1,12 +1,13 @@
 /** @file img_hash.hpp
  *  @brief Perceptual image hash algorithms for similarity comparison.
  *
- *  All hash ops expose `operator()(Image<BGR>) → cv::Mat` and a static `distance()`.
- *  Hamming-based hashes return CV_8U; L2-based hashes return CV_64F.
+ *  All hash ops expose `operator()(Image<BGR>) → ImageHash` and a static `distance()`.
+ *  Hamming-based hashes store CV_8U internally; L2-based hashes store CV_64F internally.
  */
 #pragma once
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
+#include "improc/core/types/image_hash.hpp"
 
 namespace improc::core {
 
@@ -14,60 +15,60 @@ namespace improc::core {
  * @brief Average Hash — fast 64-bit perceptual hash based on mean pixel value.
  */
 struct AverageHash {
-    /// @return 1×8 CV_8U hash matrix (64 bits).
-    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
+    /// @return ImageHash wrapping a 1×8 CV_8U hash matrix (64 bits).
+    [[nodiscard]] ImageHash operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two AverageHash digests.
-    static double distance(const cv::Mat& a, const cv::Mat& b);
+    static double distance(const ImageHash& a, const ImageHash& b);
 };
 
 /**
  * @brief Perceptual Hash (pHash) — 64-bit DCT-based hash robust to minor image changes.
  */
 struct PHash {
-    /// @return 1×8 CV_8U hash matrix (64 bits, DCT-based).
-    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
+    /// @return ImageHash wrapping a 1×8 CV_8U hash matrix (64 bits, DCT-based).
+    [[nodiscard]] ImageHash operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two PHash digests.
-    static double distance(const cv::Mat& a, const cv::Mat& b);
+    static double distance(const ImageHash& a, const ImageHash& b);
 };
 
 /**
  * @brief Marr-Hildreth Hash — 576-bit hash based on LoG zero-crossings.
  */
 struct MarrHildrethHash {
-    /// @return 1×72 CV_8U hash matrix (576 bits, LoG zero-crossing).
-    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
+    /// @return ImageHash wrapping a 1×72 CV_8U hash matrix (576 bits, LoG zero-crossing).
+    [[nodiscard]] ImageHash operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two MarrHildrethHash digests.
-    static double distance(const cv::Mat& a, const cv::Mat& b);
+    static double distance(const ImageHash& a, const ImageHash& b);
 };
 
 /**
  * @brief Radial Variance Hash — L2-based hash using radial variance projections.
  */
 struct RadialVarianceHash {
-    /// @return 1×40 CV_64F hash matrix (radial variances).
-    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
+    /// @return ImageHash wrapping a 1×40 CV_64F hash matrix (radial variances).
+    [[nodiscard]] ImageHash operator()(const Image<BGR>&) const;
     /// @brief Computes the L2 distance between two RadialVarianceHash digests.
-    static double distance(const cv::Mat& a, const cv::Mat& b);
+    static double distance(const ImageHash& a, const ImageHash& b);
 };
 
 /**
  * @brief Color Moment Hash — L2-based hash encoding colour distribution moments.
  */
 struct ColorMomentHash {
-    /// @return 1×42 CV_64F hash matrix (color moments).
-    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
+    /// @return ImageHash wrapping a 1×42 CV_64F hash matrix (color moments).
+    [[nodiscard]] ImageHash operator()(const Image<BGR>&) const;
     /// @brief Computes the L2 distance between two ColorMomentHash digests.
-    static double distance(const cv::Mat& a, const cv::Mat& b);
+    static double distance(const ImageHash& a, const ImageHash& b);
 };
 
 /**
  * @brief Block Mean Hash — 256-bit hash based on mean values of image blocks.
  */
 struct BlockMeanHash {
-    /// @return 1×32 CV_8U hash matrix (256 bits, block means).
-    [[nodiscard]] cv::Mat operator()(const Image<BGR>&) const;
+    /// @return ImageHash wrapping a 1×32 CV_8U hash matrix (256 bits, block means).
+    [[nodiscard]] ImageHash operator()(const Image<BGR>&) const;
     /// @brief Computes the Hamming distance between two BlockMeanHash digests.
-    static double distance(const cv::Mat& a, const cv::Mat& b);
+    static double distance(const ImageHash& a, const ImageHash& b);
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/in_range.hpp
+++ b/include/improc/core/ops/in_range.hpp
@@ -36,7 +36,7 @@ struct InRange {
 
     /// @brief Applies the range check and returns a binary Gray mask.
     template<AnyFormat Format>
-    Image<Gray> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Gray> operator()(Image<Format> img) const {
         if (!lower_)
             throw ParameterError{"lower", "must be set before calling operator()", "InRange"};
         if (!upper_)

--- a/include/improc/core/ops/inpaint.hpp
+++ b/include/improc/core/ops/inpaint.hpp
@@ -26,7 +26,7 @@ struct Inpaint {
     Inpaint& method(InpaintMethod m);
 
     /// @brief Inpaints regions where mask is non-zero.
-    Image<BGR> operator()(const Image<BGR>& img, const Image<Gray>& mask) const;
+    [[nodiscard]] Image<BGR> operator()(const Image<BGR>& img, const Image<Gray>& mask) const;
 
 private:
     double radius_ = 3.0;

--- a/include/improc/core/ops/invert.hpp
+++ b/include/improc/core/ops/invert.hpp
@@ -22,7 +22,7 @@ namespace improc::core {
  */
 struct Invert {
     template<IntegerFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat dst;
         cv::bitwise_not(img.mat(), dst);
         return Image<Format>(std::move(dst));

--- a/include/improc/core/ops/letter_box.hpp
+++ b/include/improc/core/ops/letter_box.hpp
@@ -47,7 +47,7 @@ struct LetterBox {
 
     /// @brief Applies the letterbox transform to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!width_ || !height_)
             throw ParameterError{"width/height", "both must be set", "LetterBox"};
         const int tw = *width_, th = *height_;

--- a/include/improc/core/ops/lut.hpp
+++ b/include/improc/core/ops/lut.hpp
@@ -4,6 +4,7 @@
 #include <opencv2/core.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -20,9 +21,9 @@ namespace improc::core {
 struct LUT {
     explicit LUT(cv::Mat table) : table_(std::move(table)) {
         if (table_.total() != 256)
-            throw std::invalid_argument("LUT table must have exactly 256 entries");
+            throw improc::ParameterError{"table", "must have exactly 256 entries", "LUT"};
         if (table_.depth() != CV_8U)
-            throw std::invalid_argument("LUT table must be CV_8U");
+            throw improc::ParameterError{"table", "must be CV_8U", "LUT"};
     }
 
     template<AnyFormat F>

--- a/include/improc/core/ops/lut.hpp
+++ b/include/improc/core/ops/lut.hpp
@@ -27,7 +27,7 @@ struct LUT {
     }
 
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         cv::Mat result;
         cv::LUT(img.mat(), table_, result);
         return Image<F>(std::move(result));

--- a/include/improc/core/ops/match_template.hpp
+++ b/include/improc/core/ops/match_template.hpp
@@ -19,7 +19,7 @@ struct MatchTemplate {
     MatchTemplate& method(int m);
 
     /// @return {best_match_top_left, match_score}.
-    std::pair<cv::Point, double> operator()(const Image<BGR>& img,
+    [[nodiscard]] std::pair<cv::Point, double> operator()(const Image<BGR>& img,
                                              const Image<BGR>& templ) const;
 
 private:

--- a/include/improc/core/ops/matching.hpp
+++ b/include/improc/core/ops/matching.hpp
@@ -51,7 +51,7 @@ struct MatchBF {
         return *this;
     }
 
-    MatchSet operator()() const;
+    [[nodiscard]] MatchSet operator()() const;
 
 private:
     DescriptorSet lhs_;
@@ -85,7 +85,7 @@ struct MatchFlann {
         return *this;
     }
 
-    MatchSet operator()() const;
+    [[nodiscard]] MatchSet operator()() const;
 
 private:
     DescriptorSet lhs_;

--- a/include/improc/core/ops/moments.hpp
+++ b/include/improc/core/ops/moments.hpp
@@ -14,7 +14,7 @@ struct Moments {
     bool binary = false; ///< If true, treats the image as binary before moment computation.
 
     /// @return cv::Moments containing spatial, central, and normalised central moments.
-    cv::Moments operator()(const Image<Gray>& img) const {
+    [[nodiscard]] cv::Moments operator()(const Image<Gray>& img) const {
         return cv::moments(img.mat(), binary);
     }
 };

--- a/include/improc/core/ops/morphology.hpp
+++ b/include/improc/core/ops/morphology.hpp
@@ -55,7 +55,7 @@ struct Dilate {
 
     /// @brief Applies morphological dilation to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat kernel = cv::getStructuringElement(
             detail::morph_shape_to_cv(shape_),
             cv::Size(kernel_size_, kernel_size_));
@@ -98,7 +98,7 @@ struct Erode {
 
     /// @brief Applies morphological erosion to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat kernel = cv::getStructuringElement(
             detail::morph_shape_to_cv(shape_),
             cv::Size(kernel_size_, kernel_size_));
@@ -144,7 +144,7 @@ struct MorphOpen {
 
     /// @brief Applies morphological opening (erode then dilate) to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat kernel = cv::getStructuringElement(
             detail::morph_shape_to_cv(shape_),
             cv::Size(kernel_size_, kernel_size_));
@@ -191,7 +191,7 @@ struct MorphClose {
 
     /// @brief Applies morphological closing (dilate then erode) to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat kernel = cv::getStructuringElement(
             detail::morph_shape_to_cv(shape_),
             cv::Size(kernel_size_, kernel_size_));
@@ -229,7 +229,7 @@ struct MorphGradient {
 
     /// @brief Applies morphological gradient (dilate − erode) to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat kernel = cv::getStructuringElement(
             detail::morph_shape_to_cv(shape_),
             cv::Size(kernel_size_, kernel_size_));
@@ -265,7 +265,7 @@ struct TopHat {
 
     /// @brief Applies top-hat transform (src − MorphOpen) to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat kernel = cv::getStructuringElement(
             detail::morph_shape_to_cv(shape_),
             cv::Size(kernel_size_, kernel_size_));
@@ -301,7 +301,7 @@ struct BlackHat {
 
     /// @brief Applies black-hat transform (MorphClose − src) to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat kernel = cv::getStructuringElement(
             detail::morph_shape_to_cv(shape_),
             cv::Size(kernel_size_, kernel_size_));

--- a/include/improc/core/ops/nlmeans.hpp
+++ b/include/improc/core/ops/nlmeans.hpp
@@ -60,9 +60,9 @@ struct NLMeansDenoising {
     }
 
     /// @brief Denoises a single-channel gray image.
-    Image<Gray> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<Gray> operator()(Image<Gray> img) const;
     /// @brief Denoises a BGR color image.
-    Image<BGR>  operator()(Image<BGR>  img) const;
+    [[nodiscard]] Image<BGR>  operator()(Image<BGR>  img) const;
 
 private:
     float h_                    = 3.0f;

--- a/include/improc/core/ops/normalize.hpp
+++ b/include/improc/core/ops/normalize.hpp
@@ -18,9 +18,9 @@ namespace improc::core {
  */
 struct Normalize {
     /// @brief Applies min-max normalization to img, scaling values to [0, 1].
-    Image<Float32>   operator()(Image<Float32>   img) const;
+    [[nodiscard]] Image<Float32>   operator()(Image<Float32>   img) const;
     /// @brief Applies min-max normalization to img, scaling values to [0, 1].
-    Image<Float32C3> operator()(Image<Float32C3> img) const;
+    [[nodiscard]] Image<Float32C3> operator()(Image<Float32C3> img) const;
 };
 
 /**
@@ -42,9 +42,9 @@ struct NormalizeTo {
      */
     explicit NormalizeTo(float min, float max);
     /// @brief Scales pixel values of img to [min_val, max_val].
-    Image<Float32>   operator()(Image<Float32>   img) const;
+    [[nodiscard]] Image<Float32>   operator()(Image<Float32>   img) const;
     /// @brief Scales pixel values of img to [min_val, max_val].
-    Image<Float32C3> operator()(Image<Float32C3> img) const;
+    [[nodiscard]] Image<Float32C3> operator()(Image<Float32C3> img) const;
 private:
     float min_, max_;
 };
@@ -67,9 +67,9 @@ struct Standardize {
      */
     explicit Standardize(float mean, float std_dev);
     /// @brief Standardizes img by subtracting mean and dividing by std_dev.
-    Image<Float32>   operator()(Image<Float32>   img) const;
+    [[nodiscard]] Image<Float32>   operator()(Image<Float32>   img) const;
     /// @brief Standardizes img by subtracting mean and dividing by std_dev.
-    Image<Float32C3> operator()(Image<Float32C3> img) const;
+    [[nodiscard]] Image<Float32C3> operator()(Image<Float32C3> img) const;
 private:
     float mean_, std_dev_;
 };

--- a/include/improc/core/ops/optical_flow.hpp
+++ b/include/improc/core/ops/optical_flow.hpp
@@ -28,7 +28,7 @@ struct SparseLKFlow {
     /// @brief Sets the convergence epsilon for the iterative search (default: 0.01).
     SparseLKFlow& epsilon(double e)     { epsilon_   = e; return *this; }
 
-    SparseLKFlowResult operator()(const Image<Gray>& prev,
+    [[nodiscard]] SparseLKFlowResult operator()(const Image<Gray>& prev,
                                   const Image<Gray>& next,
                                   const std::vector<cv::Point2f>& prev_pts) const;
 
@@ -59,7 +59,7 @@ struct DenseFarnebackFlow {
     DenseFarnebackFlow& poly_sigma(double s) { poly_sigma_ = s; return *this; }
 
     /// @return Image<Flow> (CV_32FC2) displacement field.
-    Image<Flow> operator()(const Image<Gray>& prev, const Image<Gray>& next) const;
+    [[nodiscard]] Image<Flow> operator()(const Image<Gray>& prev, const Image<Gray>& next) const;
 
 private:
     double pyr_scale_  = 0.5;
@@ -85,7 +85,7 @@ struct DenseDISFlow {
     DenseDISFlow& preset(Preset p) { preset_ = p; return *this; }
 
     /// @return Image<Flow> (CV_32FC2) displacement field.
-    Image<Flow> operator()(const Image<Gray>& prev, const Image<Gray>& next) const;
+    [[nodiscard]] Image<Flow> operator()(const Image<Gray>& prev, const Image<Gray>& next) const;
 
 private:
     Preset preset_ = Preset::Medium;

--- a/include/improc/core/ops/pad.hpp
+++ b/include/improc/core/ops/pad.hpp
@@ -69,7 +69,7 @@ struct Pad {
 
     /// @brief Applies the configured border padding to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (top_ == 0 && bottom_ == 0 && left_ == 0 && right_ == 0)
             throw ParameterError{"top/bottom/left/right", "at least one side must be > 0", "Pad"};
         cv::Mat dst;
@@ -109,7 +109,7 @@ struct PadToSquare {
 
     /// @brief Pads img along the short axis to produce a square.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         const int h = img.rows();
         const int w = img.cols();
         if (h == w) return img.clone();

--- a/include/improc/core/ops/phase_correlate.hpp
+++ b/include/improc/core/ops/phase_correlate.hpp
@@ -24,7 +24,7 @@ struct PhaseCorrelateResult {
  */
 struct PhaseCorrelate {
     /// @return PhaseCorrelateResult with the sub-pixel shift and peak response strength.
-    PhaseCorrelateResult operator()(const Image<Float32>& prev,
+    [[nodiscard]] PhaseCorrelateResult operator()(const Image<Float32>& prev,
                                     const Image<Float32>& next) const;
 };
 

--- a/include/improc/core/ops/photo.hpp
+++ b/include/improc/core/ops/photo.hpp
@@ -27,7 +27,7 @@ struct SeamlessClone {
     /// @brief Sets the blending mode (default: Mode::Normal).
     SeamlessClone& mode(Mode m) { mode_ = m; return *this; }
     /// @brief Clones the masked region of src into dst centred at center.
-    Image<BGR> operator()(const Image<BGR>& src,
+    [[nodiscard]] Image<BGR> operator()(const Image<BGR>& src,
                           const Image<BGR>& dst,
                           const Image<Gray>& mask,
                           cv::Point center) const;
@@ -51,7 +51,7 @@ struct EdgePreservingFilter {
     /// @brief Sets the filter type (default: Filter::Recursive).
     EdgePreservingFilter& filter(Filter f) { filter_  = f; return *this; }
     /// @return Smoothed BGR image with preserved edges.
-    Image<BGR> operator()(const Image<BGR>&) const;
+    [[nodiscard]] Image<BGR> operator()(const Image<BGR>&) const;
 private:
     float  sigma_s_ = 60.f;
     float  sigma_r_ = 0.4f;
@@ -67,7 +67,7 @@ struct DetailEnhance {
     /// @brief Sets the colour standard deviation (default: 0.15).
     DetailEnhance& sigma_r(float r) { sigma_r_ = r; return *this; }
     /// @return Detail-enhanced BGR image.
-    Image<BGR> operator()(const Image<BGR>&) const;
+    [[nodiscard]] Image<BGR> operator()(const Image<BGR>&) const;
 private:
     float sigma_s_ = 10.f;
     float sigma_r_ = 0.15f;
@@ -82,7 +82,7 @@ struct Stylize {
     /// @brief Sets the colour standard deviation (default: 0.45).
     Stylize& sigma_r(float r) { sigma_r_ = r; return *this; }
     /// @return Stylised BGR image.
-    Image<BGR> operator()(const Image<BGR>&) const;
+    [[nodiscard]] Image<BGR> operator()(const Image<BGR>&) const;
 private:
     float sigma_s_ = 60.f;
     float sigma_r_ = 0.45f;
@@ -99,7 +99,7 @@ struct PencilSketch {
     /// @brief Sets the shading intensity for the colour sketch (default: 0.05).
     PencilSketch& shade_factor(float f) { shade_factor_ = f; return *this; }
     /// @return PencilSketchResult containing grayscale and colour sketch images.
-    PencilSketchResult operator()(const Image<BGR>&) const;
+    [[nodiscard]] PencilSketchResult operator()(const Image<BGR>&) const;
 private:
     float sigma_s_      = 60.f;
     float sigma_r_      = 0.07f;
@@ -115,7 +115,7 @@ struct NLMeansDenoisingMulti {
     /// @brief Sets the number of surrounding frames in the temporal window (default: 3).
     NLMeansDenoisingMulti& temporal_window_size(int w) { tws_ = w; return *this; }
     /// @return Denoised BGR image of the middle frame.
-    Image<BGR> operator()(const std::vector<Image<BGR>>&) const;
+    [[nodiscard]] Image<BGR> operator()(const std::vector<Image<BGR>>&) const;
 private:
     float h_   = 3.f;
     int   tws_ = 3;
@@ -136,7 +136,7 @@ struct MergeHDR {
     /// @brief Sets the merge algorithm (default: Method::Mertens).
     MergeHDR& method(Method m) { method_ = m; return *this; }
     /// @return Image<Float32C3> HDR image.
-    Image<Float32C3> operator()(const std::vector<Image<BGR>>& images,
+    [[nodiscard]] Image<Float32C3> operator()(const std::vector<Image<BGR>>& images,
                                 const std::vector<float>& times = {}) const;
 private:
     Method method_ = Method::Mertens;
@@ -158,7 +158,7 @@ struct ToneMap {
     /// @brief Sets the tone-mapping algorithm (default: Algorithm::Reinhard).
     ToneMap& algorithm(Algorithm a) { algo_ = a; return *this; }
     /// @return Tone-mapped BGR image (CV_8UC3).
-    Image<BGR> operator()(const Image<Float32C3>&) const;
+    [[nodiscard]] Image<BGR> operator()(const Image<Float32C3>&) const;
 private:
     float     gamma_ = 1.f;
     Algorithm algo_  = Algorithm::Reinhard;

--- a/include/improc/core/ops/pyramid.hpp
+++ b/include/improc/core/ops/pyramid.hpp
@@ -19,7 +19,7 @@ namespace improc::core {
  */
 struct PyrDown {
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat dst;
         cv::pyrDown(img.mat(), dst);
         return Image<Format>(std::move(dst));
@@ -38,7 +38,7 @@ struct PyrDown {
  */
 struct PyrUp {
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat dst;
         cv::pyrUp(img.mat(), dst);
         return Image<Format>(std::move(dst));

--- a/include/improc/core/ops/quality.hpp
+++ b/include/improc/core/ops/quality.hpp
@@ -19,8 +19,8 @@ namespace improc::core {
  * @return INFINITY when images are identical (MSE == 0).
  */
 struct PSNR {
-    double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
-    double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
+    [[nodiscard]] double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
+    [[nodiscard]] double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };
 
 /**
@@ -29,24 +29,24 @@ struct PSNR {
  * @return 1.0 for identical images.
  */
 struct SSIM {
-    double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
-    double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
+    [[nodiscard]] double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
+    [[nodiscard]] double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };
 
 /**
  * @brief Gradient Magnitude Similarity Deviation — lower is better; 0 for identical images.
  */
 struct GMSD {
-    double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
-    double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
+    [[nodiscard]] double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
+    [[nodiscard]] double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };
 
 /**
  * @brief Mean Squared Error — lower is better; 0 for identical images.
  */
 struct MSE {
-    double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
-    double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
+    [[nodiscard]] double operator()(const Image<BGR>&  ref, const Image<BGR>&  cmp) const;
+    [[nodiscard]] double operator()(const Image<Gray>& ref, const Image<Gray>& cmp) const;
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/remap.hpp
+++ b/include/improc/core/ops/remap.hpp
@@ -35,7 +35,7 @@ struct Remap {
     Remap& interpolation(int flags) { interpolation_ = flags; return *this; }
 
     template<AnyFormat F>
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         cv::Mat result;
         cv::remap(img.mat(), result, map1_, map2_, interpolation_);
         return Image<F>(std::move(result));

--- a/include/improc/core/ops/remap.hpp
+++ b/include/improc/core/ops/remap.hpp
@@ -1,9 +1,9 @@
 // include/improc/core/ops/remap.hpp
 #pragma once
-#include <stdexcept>
 #include <opencv2/imgproc.hpp>
 #include "improc/core/image.hpp"
 #include "improc/core/concepts.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -14,7 +14,7 @@ namespace improc::core {
  * map2 holds the y-coordinates (row index). Both must be CV_32FC1 and
  * have identical sizes.
  *
- * @throws std::invalid_argument if either map is empty or their sizes differ.
+ * @throws improc::ParameterError if either map is empty or their sizes differ.
  *
  * @code
  * cv::Mat map1, map2;
@@ -26,9 +26,9 @@ struct Remap {
     Remap(cv::Mat map1, cv::Mat map2)
         : map1_(std::move(map1)), map2_(std::move(map2)) {
         if (map1_.empty() || map2_.empty())
-            throw std::invalid_argument("Remap: maps must not be empty");
+            throw improc::ParameterError{"maps", "must not be empty", "Remap"};
         if (map1_.size() != map2_.size())
-            throw std::invalid_argument("Remap: map1 and map2 must have the same size");
+            throw improc::ParameterError{"maps", "map1 and map2 must have the same size", "Remap"};
     }
 
     /// @brief Sets the interpolation method (default: cv::INTER_LINEAR).

--- a/include/improc/core/ops/resize.hpp
+++ b/include/improc/core/ops/resize.hpp
@@ -40,7 +40,7 @@ struct Resize {
 
     /// @brief Resizes img to the configured dimensions.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!width_ && !height_) {
             throw ParameterError{"width/height", "at least one must be set", "Resize"};
         }

--- a/include/improc/core/ops/rotate.hpp
+++ b/include/improc/core/ops/rotate.hpp
@@ -34,7 +34,7 @@ struct Rotate {
 
     /// @brief Rotates img around its center by the configured angle.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!angle_)
             throw ParameterError{"angle", "must be set before calling operator()", "Rotate"};
         cv::Point2f center(img.cols() / 2.0f, img.rows() / 2.0f);

--- a/include/improc/core/ops/stitching.hpp
+++ b/include/improc/core/ops/stitching.hpp
@@ -31,7 +31,7 @@ struct Stitch {
     /// @brief Sets the stitching mode (default: Mode::Panorama).
     Stitch& mode(Mode m) { mode_ = m; return *this; }
     /// @return StitchResult; ok is false if feature matching or blending fails.
-    StitchResult operator()(const std::vector<Image<BGR>>&) const;
+    [[nodiscard]] StitchResult operator()(const std::vector<Image<BGR>>&) const;
 private:
     Mode mode_ = Mode::Panorama;
 };

--- a/include/improc/core/ops/threshold.hpp
+++ b/include/improc/core/ops/threshold.hpp
@@ -57,7 +57,7 @@ struct Threshold {
 
     /// @brief Applies thresholding to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat dst;
         try {
             cv::threshold(img.mat(), dst, value_, max_value_, detail::to_cv_type(mode_));

--- a/include/improc/core/ops/to_bgr.hpp
+++ b/include/improc/core/ops/to_bgr.hpp
@@ -17,10 +17,10 @@ namespace improc::core {
  * @endcode
  */
 struct ToBGR {
-    Image<BGR> operator()(Image<Gray> img) const;
-    Image<BGR> operator()(Image<HSV>  img) const;
-    Image<BGR> operator()(Image<LAB>   img) const { return convert<BGR, LAB>  (std::move(img)); }
-    Image<BGR> operator()(Image<YCrCb> img) const { return convert<BGR, YCrCb>(std::move(img)); }
+    [[nodiscard]] Image<BGR> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<HSV>  img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<LAB>   img) const { return convert<BGR, LAB>  (std::move(img)); }
+    [[nodiscard]] Image<BGR> operator()(Image<YCrCb> img) const { return convert<BGR, YCrCb>(std::move(img)); }
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/to_hsv.hpp
+++ b/include/improc/core/ops/to_hsv.hpp
@@ -13,7 +13,7 @@ namespace improc::core {
  * @endcode
  */
 struct ToHSV {
-    Image<HSV> operator()(Image<BGR> img) const;
+    [[nodiscard]] Image<HSV> operator()(Image<BGR> img) const;
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/to_lab.hpp
+++ b/include/improc/core/ops/to_lab.hpp
@@ -17,7 +17,7 @@ namespace improc::core {
  * @endcode
  */
 struct ToLAB {
-    Image<LAB> operator()(Image<BGR> img) const;
+    [[nodiscard]] Image<LAB> operator()(Image<BGR> img) const;
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/to_ycrcb.hpp
+++ b/include/improc/core/ops/to_ycrcb.hpp
@@ -18,7 +18,7 @@ namespace improc::core {
  * @endcode
  */
 struct ToYCrCb {
-    Image<YCrCb> operator()(Image<BGR> img) const;
+    [[nodiscard]] Image<YCrCb> operator()(Image<BGR> img) const;
 };
 
 } // namespace improc::core

--- a/include/improc/core/ops/tracking.hpp
+++ b/include/improc/core/ops/tracking.hpp
@@ -40,7 +40,7 @@ struct CamShift {
     CamShift& max_iter(int n)    { max_iter_ = n; return *this; }
 
     /// @brief Runs one frame of CamShift on `back_proj`, updating `window` in place.
-    CamShiftResult operator()(const Image<Gray>& back_proj, cv::Rect& window) const;
+    [[nodiscard]] CamShiftResult operator()(const Image<Gray>& back_proj, cv::Rect& window) const;
 
 private:
     double epsilon_  = 1.0;
@@ -70,7 +70,7 @@ struct MeanShift {
 
     /// @brief Runs one frame of Mean-Shift on `back_proj`, updating `window` in place.
     /// @return Number of iterations performed.
-    int operator()(const Image<Gray>& back_proj, cv::Rect& window) const;
+    [[nodiscard]] int operator()(const Image<Gray>& back_proj, cv::Rect& window) const;
 
 private:
     double epsilon_  = 1.0;

--- a/include/improc/core/ops/unsharp_mask.hpp
+++ b/include/improc/core/ops/unsharp_mask.hpp
@@ -38,7 +38,7 @@ struct UnsharpMask {
 
     /// @brief Applies unsharp mask sharpening to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         cv::Mat blurred;
         cv::GaussianBlur(img.mat(), blurred, cv::Size(0, 0), sigma_);
         cv::Mat dst;

--- a/include/improc/core/ops/warp_affine.hpp
+++ b/include/improc/core/ops/warp_affine.hpp
@@ -51,7 +51,7 @@ struct WarpAffine {
 
     /// @brief Applies the affine transform to img.
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img) const {
         if (!M_)
             throw ParameterError{"matrix", "must be set before calling operator()", "WarpAffine"};
         int w = width_.value_or(img.cols());

--- a/include/improc/core/ops/weighted_blend.hpp
+++ b/include/improc/core/ops/weighted_blend.hpp
@@ -33,7 +33,7 @@ struct WeightedBlend {
         return *this;
     }
 
-    Image<F> operator()(Image<F> img) const {
+    [[nodiscard]] Image<F> operator()(Image<F> img) const {
         if (img.rows() != other_.rows() || img.cols() != other_.cols())
             throw ParameterError{"other", "size must match source image", "WeightedBlend"};
         cv::Mat dst;

--- a/include/improc/core/pipeline.hpp
+++ b/include/improc/core/pipeline.hpp
@@ -99,6 +99,7 @@
 
 // Types
 #include "improc/core/types/histogram_data.hpp"
+#include "improc/core/types/image_hash.hpp"
 
 // Analysis ops (multi-arg or non-image output — not composable via operator|)
 #include "improc/core/ops/analysis.hpp"

--- a/include/improc/core/pipeline.hpp
+++ b/include/improc/core/pipeline.hpp
@@ -97,6 +97,9 @@
 #include "improc/core/ops/arithmetic.hpp"
 #include "improc/core/ops/channels.hpp"
 
+// Types
+#include "improc/core/types/histogram_data.hpp"
+
 // Analysis ops (multi-arg or non-image output — not composable via operator|)
 #include "improc/core/ops/analysis.hpp"
 #include "improc/core/ops/optical_flow.hpp"

--- a/include/improc/core/pipeline.hpp
+++ b/include/improc/core/pipeline.hpp
@@ -100,6 +100,7 @@
 // Types
 #include "improc/core/types/histogram_data.hpp"
 #include "improc/core/types/image_hash.hpp"
+#include "improc/core/types/face_embedding.hpp"
 
 // Analysis ops (multi-arg or non-image output — not composable via operator|)
 #include "improc/core/ops/analysis.hpp"

--- a/include/improc/core/pipeline.hpp
+++ b/include/improc/core/pipeline.hpp
@@ -7,11 +7,11 @@
  * Standardize, ApplyMask, WarpAffine, WarpPerspective, ToGray, ToFloat32,
  * ToFloat32C3, ToHSV, ToLAB, ToYCrCb, ToBGR, Brightness, Contrast, WeightedBlend, AlphaBlend,
  * PyrDown, PyrUp, DrawText, DrawLine, DrawCircle, DrawRectangle,
- * FindContours, DrawContours, ConnectedComponents, DistanceTransform,
+ * FindContours, ConnectedComponents, DistanceTransform,
  * DetectORB, DetectSIFT, DetectAKAZE,
  * DescribeORB, DescribeSIFT, DescribeAKAZE,
  * MatchSet, MatchBF, MatchFlann,
- * DrawKeypoints, DrawMatches,
+ * DrawKeypoints, DrawMatches, (both now in improc::visualization, backward-compat aliases in improc::core)
  * BackgroundSubtractMOG2, BackgroundSubtractKNN, LUT,
  * CalcHist, CompareHist, HoughLinesP, HoughCircles, MatchTemplate,
  * Moments, Inpaint, Watershed, GrabCut,
@@ -70,6 +70,8 @@
 #include "improc/core/ops/pyramid.hpp"
 #include "improc/core/ops/drawing.hpp"
 #include "improc/core/ops/contours.hpp"
+// DrawContours moved to improc::visualization; backward-compat alias in improc::core.
+#include "improc/visualization/draw_contours.hpp"
 #include "improc/core/ops/connected_components.hpp"
 #include "improc/core/ops/distance_transform.hpp"
 #include "improc/core/ops/feature_detection.hpp"
@@ -114,6 +116,10 @@
 #include "improc/core/ops/img_hash.hpp"
 
 namespace improc::core {
+
+// Backward-compat alias: DrawContours moved to improc::visualization.
+// Deprecated: include "improc/visualization/draw_contours.hpp" and use improc::visualization::DrawContours.
+using improc::visualization::DrawContours;
 
 /**
  * @brief Generic pipeline dispatch operator.

--- a/include/improc/core/types/face_embedding.hpp
+++ b/include/improc/core/types/face_embedding.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <opencv2/core.hpp>
+
+namespace improc::core {
+
+/**
+ * @brief Typed wrapper for a face recognition embedding vector.
+ *
+ * Produced by RecognizeFace::embed(). The descriptor is typically
+ * a (1 × 128) CV_32F row vector from SFace.
+ *
+ * Use cosine_similarity() to compare two embeddings.
+ * Values range from -1 (opposite) to 1 (identical).
+ */
+struct FaceEmbedding {
+    cv::Mat descriptor;
+
+    bool empty() const { return descriptor.empty(); }
+
+    float cosine_similarity(const FaceEmbedding& other) const {
+        if (descriptor.empty() || other.descriptor.empty()) return 0.0f;
+        cv::Mat n1, n2;
+        cv::normalize(descriptor, n1);
+        cv::normalize(other.descriptor, n2);
+        return static_cast<float>(n1.dot(n2));
+    }
+};
+
+} // namespace improc::core

--- a/include/improc/core/types/histogram_data.hpp
+++ b/include/improc/core/types/histogram_data.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <opencv2/core.hpp>
+
+namespace improc::core {
+
+/**
+ * @brief Result of CalcHist: a 1-D histogram with its configuration metadata.
+ *
+ * For Gray images: data is (bins × 1) CV_32F, channels = 1.
+ * For BGR images: data is (bins × 3) CV_32F (columns = B, G, R), channels = 3.
+ */
+struct HistogramData {
+    cv::Mat data;
+    int     bins      = 256;
+    float   range_min = 0.0f;
+    float   range_max = 256.0f;
+    int     channels  = 1;
+
+    bool empty() const { return data.empty(); }
+};
+
+} // namespace improc::core

--- a/include/improc/core/types/image_hash.hpp
+++ b/include/improc/core/types/image_hash.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <opencv2/core.hpp>
+
+namespace improc::core {
+
+/**
+ * @brief Typed wrapper around a perceptual hash matrix.
+ *
+ * All improc hash ops return this type. Use the static distance() method
+ * on the originating hash struct to compare two hashes.
+ */
+struct ImageHash {
+    cv::Mat value;
+
+    bool empty() const { return value.empty(); }
+
+    bool operator==(const ImageHash& o) const {
+        if (value.size() != o.value.size() || value.type() != o.value.type()) return false;
+        return cv::norm(value, o.value, cv::NORM_L1) == 0.0;
+    }
+    bool operator!=(const ImageHash& o) const { return !(*this == o); }
+};
+
+} // namespace improc::core

--- a/include/improc/ml/augment/bbox_compose.hpp
+++ b/include/improc/ml/augment/bbox_compose.hpp
@@ -27,7 +27,7 @@ struct BBoxCompose : detail::BindMixin<BBoxCompose<Format>> {
         return *this;
     }
 
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         for (const auto& op : ops_)
             ann = op(std::move(ann), rng);
         return ann;

--- a/include/improc/ml/augment/blur.hpp
+++ b/include/improc/ml/augment/blur.hpp
@@ -51,7 +51,7 @@ struct RandomBlur : detail::BindMixin<RandomBlur> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         constexpr bool is_float = improc::core::FormatTraits<Format>::is_float;
         if constexpr (is_float) {
             bool has_bilateral = std::find(types_.begin(), types_.end(), Type::Bilateral) != types_.end();
@@ -82,7 +82,7 @@ struct RandomBlur : detail::BindMixin<RandomBlur> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -114,7 +114,7 @@ struct RandomSharpness : detail::BindMixin<RandomSharpness> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         std::uniform_real_distribution<float> s_d(min_s_, max_s_);
@@ -138,7 +138,7 @@ struct RandomSharpness : detail::BindMixin<RandomSharpness> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }

--- a/include/improc/ml/augment/color.hpp
+++ b/include/improc/ml/augment/color.hpp
@@ -33,7 +33,7 @@ struct RandomBrightness : detail::BindMixin<RandomBrightness> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(low_, high_);
         float factor = d(rng);
         cv::Mat src_f, dst;
@@ -46,7 +46,7 @@ struct RandomBrightness : detail::BindMixin<RandomBrightness> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -72,7 +72,7 @@ struct RandomContrast : detail::BindMixin<RandomContrast> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(low_, high_);
         float alpha = d(rng);
         cv::Scalar mean = cv::mean(img.mat());
@@ -86,7 +86,7 @@ struct RandomContrast : detail::BindMixin<RandomContrast> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -142,7 +142,7 @@ struct ColorJitter : detail::BindMixin<ColorJitter> {
     }
 
     template<BGRFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::uniform_real_distribution<float> br_d(br_low_, br_high_);
         std::uniform_real_distribution<float> ct_d(ct_low_, ct_high_);
         std::uniform_real_distribution<float> sa_d(sa_low_, sa_high_);
@@ -192,7 +192,7 @@ struct ColorJitter : detail::BindMixin<ColorJitter> {
     }
 
     template<BGRFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -218,7 +218,7 @@ struct RandomGrayscale : detail::BindMixin<RandomGrayscale> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         if constexpr (std::is_same_v<Format, improc::core::BGR>) {
@@ -232,7 +232,7 @@ struct RandomGrayscale : detail::BindMixin<RandomGrayscale> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -262,7 +262,7 @@ struct RandomSolarize : detail::BindMixin<RandomSolarize> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         if constexpr (improc::core::FormatTraits<Format>::is_float) {
@@ -279,7 +279,7 @@ struct RandomSolarize : detail::BindMixin<RandomSolarize> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -310,7 +310,7 @@ struct RandomPosterize : detail::BindMixin<RandomPosterize> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         if constexpr (improc::core::FormatTraits<Format>::is_float) {
@@ -328,7 +328,7 @@ struct RandomPosterize : detail::BindMixin<RandomPosterize> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -353,7 +353,7 @@ struct RandomEqualize : detail::BindMixin<RandomEqualize> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         if constexpr (std::is_same_v<Format, improc::core::BGR>) {
@@ -376,7 +376,7 @@ struct RandomEqualize : detail::BindMixin<RandomEqualize> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }

--- a/include/improc/ml/augment/compose.hpp
+++ b/include/improc/ml/augment/compose.hpp
@@ -41,7 +41,7 @@ struct Compose : detail::BindMixin<Compose<Format>> {
         return *this;
     }
 
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         for (const auto& step : steps_)
             img = step(std::move(img), rng);
         return img;
@@ -77,7 +77,7 @@ public:
     template<typename Aug>
     RandomApply(Aug aug, float p) : p_(validate_p(p)), aug_(std::move(aug)) {}
 
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         return aug_(std::move(img), rng);
@@ -99,7 +99,7 @@ struct OneOf : detail::BindMixin<OneOf<Format>> {
         return *this;
     }
 
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         if (options_.empty())
             throw AugmentError{"OneOf: operator() called with no augmentations added"};
         std::uniform_int_distribution<std::size_t> d(0, options_.size() - 1);

--- a/include/improc/ml/augment/erase.hpp
+++ b/include/improc/ml/augment/erase.hpp
@@ -57,7 +57,7 @@ struct RandomErasing : detail::BindMixin<RandomErasing> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         int W = img.cols(), H = img.rows();
@@ -119,7 +119,7 @@ struct GridDropout : detail::BindMixin<GridDropout> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         cv::Mat dst = img.mat().clone();
         std::bernoulli_distribution d(ratio_);
         int W = img.cols(), H = img.rows();

--- a/include/improc/ml/augment/geometric.hpp
+++ b/include/improc/ml/augment/geometric.hpp
@@ -87,7 +87,7 @@ struct RandomFlip : detail::BindMixin<RandomFlip> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return img;
         int flip_code;
@@ -103,7 +103,7 @@ struct RandomFlip : detail::BindMixin<RandomFlip> {
     }
 
     template<AnyFormat Format>
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return ann;
         int W = ann.image.cols(), H = ann.image.rows();
@@ -127,7 +127,7 @@ struct RandomFlip : detail::BindMixin<RandomFlip> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         std::bernoulli_distribution d(p_);
         if (!d(rng)) return seg;
         int flip_code;
@@ -181,7 +181,7 @@ struct RandomRotate : detail::BindMixin<RandomRotate> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(min_deg_, max_deg_);
         float angle = d(rng);
         cv::Point2f center(img.cols() / 2.0f, img.rows() / 2.0f);
@@ -196,7 +196,7 @@ struct RandomRotate : detail::BindMixin<RandomRotate> {
     }
 
     template<AnyFormat Format>
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(min_deg_, max_deg_);
         float angle = d(rng);
         int W = ann.image.cols(), H = ann.image.rows();
@@ -225,7 +225,7 @@ struct RandomRotate : detail::BindMixin<RandomRotate> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(min_deg_, max_deg_);
         float angle = d(rng);
         cv::Point2f center(seg.image.cols() / 2.0f, seg.image.rows() / 2.0f);
@@ -276,7 +276,7 @@ struct RandomCrop : detail::BindMixin<RandomCrop> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         if (width_ <= 0 || height_ <= 0)
             throw ParameterError{"width/height", "both must be set", "RandomCrop"};
         if (width_ > img.cols() || height_ > img.rows())
@@ -293,7 +293,7 @@ struct RandomCrop : detail::BindMixin<RandomCrop> {
     }
 
     template<AnyFormat Format>
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         if (width_ <= 0 || height_ <= 0)
             throw ParameterError{"width/height", "both must be set", "RandomCrop"};
         if (width_ > ann.image.cols() || height_ > ann.image.rows())
@@ -320,7 +320,7 @@ struct RandomCrop : detail::BindMixin<RandomCrop> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         if (width_ <= 0 || height_ <= 0)
             throw ParameterError{"width/height", "both must be set", "RandomCrop"};
         if (width_ > seg.image.cols() || height_ > seg.image.rows())
@@ -368,7 +368,7 @@ struct RandomResize : detail::BindMixin<RandomResize> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::uniform_int_distribution<int> d(min_side_, max_side_);
         int target = d(rng);
         const int h = img.rows();
@@ -387,7 +387,7 @@ struct RandomResize : detail::BindMixin<RandomResize> {
     }
 
     template<AnyFormat Format>
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         std::uniform_int_distribution<int> d(min_side_, max_side_);
         int target = d(rng);
         const int h = ann.image.rows(), w = ann.image.cols();
@@ -410,7 +410,7 @@ struct RandomResize : detail::BindMixin<RandomResize> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         std::uniform_int_distribution<int> d(min_side_, max_side_);
         int target = d(rng);
         const int h = seg.image.rows(), w = seg.image.cols();
@@ -459,7 +459,7 @@ struct RandomZoom : detail::BindMixin<RandomZoom> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         int W = img.cols(), H = img.rows();
         std::uniform_real_distribution<float> d(min_scale_, max_scale_);
         float scale = d(rng);
@@ -475,7 +475,7 @@ struct RandomZoom : detail::BindMixin<RandomZoom> {
     }
 
     template<AnyFormat Format>
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         int W = ann.image.cols(), H = ann.image.rows();
         std::uniform_real_distribution<float> d(min_scale_, max_scale_);
         float scale = d(rng);
@@ -509,7 +509,7 @@ struct RandomZoom : detail::BindMixin<RandomZoom> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         int W = seg.image.cols(), H = seg.image.rows();
         std::uniform_real_distribution<float> d(min_scale_, max_scale_);
         float scale = d(rng);
@@ -562,7 +562,7 @@ struct RandomShear : detail::BindMixin<RandomShear> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(min_deg_, max_deg_);
         float angle_rad = d(rng) * std::numbers::pi_v<float> / 180.0f;
         float shear = std::tan(angle_rad);
@@ -579,7 +579,7 @@ struct RandomShear : detail::BindMixin<RandomShear> {
     }
 
     template<AnyFormat Format>
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(min_deg_, max_deg_);
         float angle_rad = d(rng) * std::numbers::pi_v<float> / 180.0f;
         float shear = std::tan(angle_rad);
@@ -609,7 +609,7 @@ struct RandomShear : detail::BindMixin<RandomShear> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(min_deg_, max_deg_);
         float angle_rad = d(rng) * std::numbers::pi_v<float> / 180.0f;
         float shear = std::tan(angle_rad);
@@ -658,7 +658,7 @@ struct RandomPerspective : detail::BindMixin<RandomPerspective> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         int W = img.cols(), H = img.rows();
         float half_range = distortion_scale_ * std::min(W, H) / 2.0f;
         std::uniform_real_distribution<float> d(-half_range, half_range);
@@ -679,7 +679,7 @@ struct RandomPerspective : detail::BindMixin<RandomPerspective> {
     }
 
     template<AnyFormat Format>
-    AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
+    [[nodiscard]] AnnotatedImage<Format> operator()(AnnotatedImage<Format> ann, std::mt19937& rng) const {
         int W = ann.image.cols(), H = ann.image.rows();
         float half_range = distortion_scale_ * std::min(W, H) / 2.0f;
         std::uniform_real_distribution<float> d(-half_range, half_range);
@@ -713,7 +713,7 @@ struct RandomPerspective : detail::BindMixin<RandomPerspective> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         int W = seg.image.cols(), H = seg.image.rows();
         float half_range = distortion_scale_ * std::min(W, H) / 2.0f;
         std::uniform_real_distribution<float> d(-half_range, half_range);

--- a/include/improc/ml/augment/mixup.hpp
+++ b/include/improc/ml/augment/mixup.hpp
@@ -56,7 +56,7 @@ struct MixUp {
     /// @brief Mixes `a` with `b` using a Beta-sampled weight.
     /// @throws improc::ParameterError if images differ in size or label vectors differ in length.
     template<AnyFormat F>
-    LabeledImage<F> operator()(LabeledImage<F> a,
+    [[nodiscard]] LabeledImage<F> operator()(LabeledImage<F> a,
                                 const LabeledImage<F>& b,
                                 std::mt19937& rng) const {
         if (a.image.mat().size() != b.image.mat().size())
@@ -111,7 +111,7 @@ struct CutMix {
     }
 
     template<AnyFormat F>
-    LabeledImage<F> operator()(LabeledImage<F> a,
+    [[nodiscard]] LabeledImage<F> operator()(LabeledImage<F> a,
                                 const LabeledImage<F>& b,
                                 std::mt19937& rng) const {
         if (a.image.mat().size() != b.image.mat().size())
@@ -179,7 +179,7 @@ struct MixCompose {
         return *this;
     }
 
-    LabeledImage<Format> operator()(LabeledImage<Format> primary,
+    [[nodiscard]] LabeledImage<Format> operator()(LabeledImage<Format> primary,
                                     const LabeledImage<Format>& secondary,
                                     std::mt19937& rng) const {
         for (const auto& op : ops_)

--- a/include/improc/ml/augment/noise.hpp
+++ b/include/improc/ml/augment/noise.hpp
@@ -32,7 +32,7 @@ struct RandomGaussianNoise : detail::BindMixin<RandomGaussianNoise> {
     RandomGaussianNoise& mean(float m) { mean_ = m; return *this; }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         std::uniform_real_distribution<float> d(std_low_, std_high_);
         float std_dev = d(rng);
         const int ch = img.mat().channels();
@@ -50,7 +50,7 @@ struct RandomGaussianNoise : detail::BindMixin<RandomGaussianNoise> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }
@@ -75,7 +75,7 @@ struct RandomSaltAndPepper : detail::BindMixin<RandomSaltAndPepper> {
     }
 
     template<AnyFormat Format>
-    Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
+    [[nodiscard]] Image<Format> operator()(Image<Format> img, std::mt19937& rng) const {
         cv::Mat dst = img.mat().clone();
         std::bernoulli_distribution noise_dist(p_);
         std::bernoulli_distribution salt_dist(0.5);
@@ -103,7 +103,7 @@ struct RandomSaltAndPepper : detail::BindMixin<RandomSaltAndPepper> {
     }
 
     template<AnyFormat Format>
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         seg.image = (*this)(std::move(seg.image), rng);
         return seg;
     }

--- a/include/improc/ml/augment/seg_compose.hpp
+++ b/include/improc/ml/augment/seg_compose.hpp
@@ -27,7 +27,7 @@ struct SegCompose : detail::BindMixin<SegCompose<Format>> {
         return *this;
     }
 
-    SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
+    [[nodiscard]] SegmentedImage<Format> operator()(SegmentedImage<Format> seg, std::mt19937& rng) const {
         for (const auto& op : ops_)
             seg = op(std::move(seg), rng);
         return seg;

--- a/include/improc/ml/coco_dataset.hpp
+++ b/include/improc/ml/coco_dataset.hpp
@@ -28,7 +28,7 @@ using improc::core::BGR;
  * @param filter_unknown Drop annotations whose class name is not already in `class_map`.
  * @return Vector of `AnnotatedImage<BGR>` (one per image in the JSON), or an `improc::Error`.
  */
-std::expected<std::vector<AnnotatedImage<BGR>>, improc::Error>
+[[nodiscard]] std::expected<std::vector<AnnotatedImage<BGR>>, improc::Error>
 parse_coco_json(const std::filesystem::path& json_path,
                 const std::filesystem::path& images_dir,
                 std::unordered_map<std::string, int>& class_map,
@@ -59,17 +59,17 @@ public:
     CocoDataset& skip_crowd(bool v) { skip_crowd_ = v; return *this; }
 
     /// @brief Load (or replace) the train split from a COCO JSON file.
-    std::expected<void, improc::Error>
+    [[nodiscard]] std::expected<void, improc::Error>
     load_train(const std::filesystem::path& json_path,
                const std::filesystem::path& images_dir);
 
     /// @brief Load (or replace) the val split from a COCO JSON file.
-    std::expected<void, improc::Error>
+    [[nodiscard]] std::expected<void, improc::Error>
     load_val(const std::filesystem::path& json_path,
              const std::filesystem::path& images_dir);
 
     /// @brief Load (or replace) the test split from a COCO JSON file.
-    std::expected<void, improc::Error>
+    [[nodiscard]] std::expected<void, improc::Error>
     load_test(const std::filesystem::path& json_path,
               const std::filesystem::path& images_dir);
 
@@ -82,7 +82,7 @@ public:
 
     /// @brief Returns the class name for a given integer id.
     /// @throws std::out_of_range if the id is unknown.
-    std::string class_name_for(int id) const { return id_to_class_.at(id); }
+    [[nodiscard]] std::string class_name_for(int id) const { return id_to_class_.at(id); }
 
 private:
     std::vector<std::string>              user_classes_;

--- a/include/improc/ml/dataset.hpp
+++ b/include/improc/ml/dataset.hpp
@@ -37,34 +37,34 @@ public:
      * @param max_per_class Optional: maximum number of images to load per class
      * @return std::expected with error if loading fails
      */
-    std::expected<void, improc::Error> load_from_directory(const std::filesystem::path& root,
+    [[nodiscard]] std::expected<void, improc::Error> load_from_directory(const std::filesystem::path& root,
                                                          float test_ratio = 0.2f,
                                                          float val_ratio = 0.1f,
                                                          std::optional<size_t> max_per_class = std::nullopt);
 
     /// @brief Returns the training split images.
-    const std::vector<cv::Mat>& train_images() const;
+    [[nodiscard]] const std::vector<cv::Mat>& train_images() const;
     /// @brief Returns the validation split images.
-    const std::vector<cv::Mat>& val_images() const;
+    [[nodiscard]] const std::vector<cv::Mat>& val_images() const;
     /// @brief Returns the test split images.
-    const std::vector<cv::Mat>& test_images() const;
+    [[nodiscard]] const std::vector<cv::Mat>& test_images() const;
 
     /// @brief Returns the integer class labels for the training split.
-    const std::vector<int>& train_labels() const;
+    [[nodiscard]] const std::vector<int>& train_labels() const;
     /// @brief Returns the integer class labels for the validation split.
-    const std::vector<int>& val_labels() const;
+    [[nodiscard]] const std::vector<int>& val_labels() const;
     /// @brief Returns the integer class labels for the test split.
-    const std::vector<int>& test_labels() const;
+    [[nodiscard]] const std::vector<int>& test_labels() const;
 
     /// @brief Returns the mapping from class name to integer label index.
-    const std::unordered_map<std::string, int>& class_mapping() const;
+    [[nodiscard]] const std::unordered_map<std::string, int>& class_mapping() const;
 
     /**
      * @brief Returns the class name for the given integer label.
      * @param label Integer label index as stored in the label vectors.
      * @return The corresponding class name string.
      */
-    std::string class_name_for(int label) const;
+    [[nodiscard]] std::string class_name_for(int label) const;
 
     /**
      * @brief Sets the random seed used when shuffling samples before splitting.

--- a/include/improc/ml/dataset.hpp
+++ b/include/improc/ml/dataset.hpp
@@ -70,7 +70,7 @@ public:
      * @brief Sets the random seed used when shuffling samples before splitting.
      * @param seed Seed value for the internal `std::mt19937`.
      */
-    void set_shuffle_seed(unsigned int seed);
+    void shuffle_seed(unsigned int seed);
 
 private:
     std::vector<cv::Mat> train_;

--- a/include/improc/ml/dnn_classifier.hpp
+++ b/include/improc/ml/dnn_classifier.hpp
@@ -98,7 +98,7 @@ struct DnnClassifier {
      * @param img Input image in BGR format.
      * @return Up to `top_k` `ClassResult` entries sorted by score descending.
      */
-    std::vector<ClassResult> operator()(const Image<BGR>& img) const;
+    [[nodiscard]] std::vector<ClassResult> operator()(const Image<BGR>& img) const;
 
 private:
     mutable cv::dnn::Net     net_;

--- a/include/improc/ml/dnn_detector.hpp
+++ b/include/improc/ml/dnn_detector.hpp
@@ -150,7 +150,7 @@ struct DnnDetector {
      * @return `Detection` entries that passed confidence and NMS filtering.
      * @throws improc::Exception if the forward pass or output parsing fails.
      */
-    std::vector<Detection> operator()(const Image<BGR>& img) const;
+    [[nodiscard]] std::vector<Detection> operator()(const Image<BGR>& img) const;
 
 private:
     mutable cv::dnn::Net     net_;

--- a/include/improc/ml/dnn_forward.hpp
+++ b/include/improc/ml/dnn_forward.hpp
@@ -77,7 +77,7 @@ struct DnnForward {
      * @param img Input image in BGR format.
      * @return All output values concatenated into a flat `std::vector<float>`.
      */
-    std::vector<float> operator()(const Image<BGR>& img) const;
+    [[nodiscard]] std::vector<float> operator()(const Image<BGR>& img) const;
 
 private:
     mutable cv::dnn::Net  net_;

--- a/include/improc/ml/haar_cascade_loader.hpp
+++ b/include/improc/ml/haar_cascade_loader.hpp
@@ -23,7 +23,7 @@ public:
    * @brief Returns the loaded classifier, or an error if not yet loaded.
    * @return The `cv::CascadeClassifier` on success, or an `improc::Error`.
    */
-  std::expected<cv::CascadeClassifier, improc::Error> get_impl() const;
+  [[nodiscard]] std::expected<cv::CascadeClassifier, improc::Error> get_impl() const;
 
 private:
   cv::CascadeClassifier classifier_;

--- a/include/improc/ml/voc_dataset.hpp
+++ b/include/improc/ml/voc_dataset.hpp
@@ -30,7 +30,7 @@ using improc::core::BGR;
  * @param filter_unknown Drop objects whose class name is not already in `class_map` (default: false).
  * @return Parsed `AnnotatedImage<BGR>` or an `improc::Error`.
  */
-std::expected<AnnotatedImage<BGR>, improc::Error>
+[[nodiscard]] std::expected<AnnotatedImage<BGR>, improc::Error>
 parse_voc_xml(const std::filesystem::path& xml_path,
               const std::filesystem::path& images_dir,
               std::unordered_map<std::string, int>& class_map,
@@ -71,7 +71,7 @@ public:
     VocDataset& shuffle_seed(unsigned int s) { shuffle_seed_ = s; return *this; }
 
     /// @brief Loads the dataset from a VOC-structured directory.
-    std::expected<void, improc::Error>
+    [[nodiscard]] std::expected<void, improc::Error>
     load_from_directory(const std::filesystem::path& root);
 
     const std::vector<AnnotatedImage<BGR>>& train() const { return train_; }
@@ -83,7 +83,7 @@ public:
 
     /// @brief Returns the class name for the given integer id.
     /// @throws std::out_of_range if the id is unknown.
-    std::string class_name_for(int id) const { return id_to_class_.at(id); }
+    [[nodiscard]] std::string class_name_for(int id) const { return id_to_class_.at(id); }
 
 private:
     std::vector<std::string>              user_classes_;

--- a/include/improc/ml/voc_seg_dataset.hpp
+++ b/include/improc/ml/voc_seg_dataset.hpp
@@ -22,7 +22,7 @@ using improc::core::BGR;
  * @param instance_masks_dir Directory containing instance segmentation PNGs, or empty to skip.
  * @return Parsed `SegmentedImage<BGR>` or an `improc::Error`.
  */
-std::expected<SegmentedImage<BGR>, improc::Error>
+[[nodiscard]] std::expected<SegmentedImage<BGR>, improc::Error>
 parse_voc_seg(const std::filesystem::path& stem,
               const std::filesystem::path& images_dir,
               const std::filesystem::path& class_masks_dir,
@@ -41,7 +41,7 @@ public:
     VocSegDataset& load_instance_masks(bool v) { load_instance_ = v; return *this; }
 
     /// @brief Load from a VOC-structured directory root.
-    std::expected<void, improc::Error>
+    [[nodiscard]] std::expected<void, improc::Error>
     load_from_directory(const std::filesystem::path& root);
 
     const std::vector<SegmentedImage<BGR>>& train() const { return train_; }
@@ -51,7 +51,7 @@ public:
     const std::unordered_map<int, std::string>& class_mapping() const { return id_to_class_; }
 
     /// @throws std::out_of_range if id has no name.
-    std::string class_name_for(int id) const { return id_to_class_.at(id); }
+    [[nodiscard]] std::string class_name_for(int id) const { return id_to_class_.at(id); }
 
 private:
     bool load_instance_ = false;

--- a/include/improc/onnx/onnx_classifier.hpp
+++ b/include/improc/onnx/onnx_classifier.hpp
@@ -95,7 +95,7 @@ public:
      * @return Up to `top_k` `ClassResult` entries sorted by score descending,
      *         or an `improc::Error` if inference fails.
      */
-    std::expected<std::vector<ClassResult>, improc::Error>
+    [[nodiscard]] std::expected<std::vector<ClassResult>, improc::Error>
     operator()(const Image<BGR>& img) const;
 
 private:

--- a/include/improc/onnx/onnx_detector.hpp
+++ b/include/improc/onnx/onnx_detector.hpp
@@ -125,7 +125,7 @@ public:
      * @return `Detection` entries that passed confidence and NMS filtering,
      *         or an `improc::Error` if inference fails.
      */
-    std::expected<std::vector<Detection>, improc::Error>
+    [[nodiscard]] std::expected<std::vector<Detection>, improc::Error>
     operator()(const Image<BGR>& img) const;
 
 private:

--- a/include/improc/onnx/onnx_session.hpp
+++ b/include/improc/onnx/onnx_session.hpp
@@ -55,7 +55,7 @@ public:
      * @return `{}` on success; an `improc::Error` if the file is missing,
      *         has the wrong extension, or ORT fails to parse it.
      */
-    std::expected<void, improc::Error> load(const std::filesystem::path& path);
+    [[nodiscard]] std::expected<void, improc::Error> load(const std::filesystem::path& path);
 
     /**
      * @brief Runs inference with the provided input tensors.
@@ -63,7 +63,7 @@ public:
      * @return Output tensors in model declaration order, or an `improc::Error`
      *         if the session is not loaded or ORT returns an error.
      */
-    std::expected<std::vector<TensorInfo>, improc::Error>
+    [[nodiscard]] std::expected<std::vector<TensorInfo>, improc::Error>
     run(const std::vector<TensorInfo>& inputs) const;
 
     /**

--- a/include/improc/visualization/class_bar_chart.hpp
+++ b/include/improc/visualization/class_bar_chart.hpp
@@ -69,7 +69,7 @@ struct ClassBarChart {
 
     /// @brief Renders and returns the chart as a BGR image.
     /// @throws improc::ParameterError if width or height <= 0.
-    Image<BGR> operator()() const {
+    [[nodiscard]] Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "ClassBarChart"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "ClassBarChart"};
 

--- a/include/improc/visualization/confusion_matrix_plot.hpp
+++ b/include/improc/visualization/confusion_matrix_plot.hpp
@@ -72,7 +72,7 @@ struct ConfusionMatrixPlot {
 
     /// @brief Renders and returns the confusion matrix plot as a BGR image.
     /// @throws improc::ParameterError if width or height <= 0 or canvas is too small for the matrix.
-    Image<BGR> operator()() const {
+    [[nodiscard]] Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "ConfusionMatrixPlot"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "ConfusionMatrixPlot"};
 

--- a/include/improc/visualization/draw.hpp
+++ b/include/improc/visualization/draw.hpp
@@ -50,7 +50,7 @@ struct DrawBoundingBoxes {
     DrawBoundingBoxes& show_confidence(bool b) { show_confidence_ = b; return *this; }
 
     /// @brief Draws all detections onto a clone of `img` and returns the annotated copy.
-    Image<BGR> operator()(Image<BGR> img) const {
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const {
         cv::Mat canvas = img.mat().clone();
 
         for (const auto& det : detections_) {

--- a/include/improc/visualization/draw_contours.hpp
+++ b/include/improc/visualization/draw_contours.hpp
@@ -1,0 +1,51 @@
+// include/improc/visualization/draw_contours.hpp
+#pragma once
+#include <opencv2/imgproc.hpp>
+#include "improc/core/image.hpp"
+#include "improc/core/ops/contours.hpp"
+#include "improc/exceptions.hpp"
+
+namespace improc::visualization {
+
+using improc::core::Image;
+using improc::core::BGR;
+using improc::core::ContourSet;
+
+/**
+ * @brief Pipeline op: draws contours from a `ContourSet` onto a BGR image clone.
+ *
+ * Wraps `cv::drawContours`. Pass `index(-1)` to draw all (default).
+ * Pass `thickness(-1)` to fill contours.
+ * The source image is never mutated.
+ *
+ * @throws improc::ParameterError if `thickness` is not positive and not -1.
+ *
+ * @code
+ * Image<BGR> annotated = bgr | DrawContours{cs}.color({0, 255, 0});
+ * Image<BGR> filled    = bgr | DrawContours{cs}.thickness(-1);
+ * @endcode
+ */
+struct DrawContours {
+    explicit DrawContours(ContourSet cs) : cs_(std::move(cs)) {}
+
+    DrawContours& index(int i) { index_ = i; return *this; }
+
+    DrawContours& color(cv::Scalar c) { color_ = c; return *this; }
+
+    DrawContours& thickness(int t) {
+        if (t <= 0 && t != -1)
+            throw improc::ParameterError{"thickness", "must be positive or -1 (fill)", "DrawContours"};
+        thickness_ = t;
+        return *this;
+    }
+
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const;
+
+private:
+    ContourSet cs_;
+    int        index_{-1};
+    cv::Scalar color_{0, 255, 0};
+    int        thickness_{1};
+};
+
+} // namespace improc::visualization

--- a/include/improc/visualization/draw_matches.hpp
+++ b/include/improc/visualization/draw_matches.hpp
@@ -1,0 +1,62 @@
+// include/improc/visualization/draw_matches.hpp
+#pragma once
+#include <utility>
+#include <opencv2/features2d.hpp>
+#include "improc/core/ops/matching.hpp"
+
+namespace improc::visualization {
+
+using improc::core::Image;
+using improc::core::BGR;
+using improc::core::Gray;
+using improc::core::KeypointSet;
+using improc::core::MatchSet;
+
+/**
+ * @brief Pipeline op: draws keypoints onto an image.
+ *
+ * Accepts Image<Gray> or Image<BGR>; always returns Image<BGR>.
+ * Uses cv::DrawMatchesFlags::DRAW_RICH_KEYPOINTS (oriented, scaled circles).
+ * An empty KeypointSet produces a valid BGR image with no annotations.
+ *
+ * @code
+ * Image<BGR> vis = gray | DrawKeypoints{kps};
+ * @endcode
+ */
+struct DrawKeypoints {
+    explicit DrawKeypoints(KeypointSet kps) : kps_(std::move(kps)) {}
+
+    [[nodiscard]] Image<BGR> operator()(Image<Gray> img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<BGR>  img) const;
+
+private:
+    KeypointSet kps_;
+};
+
+/**
+ * @brief Callable: draws matches between two BGR images side-by-side.
+ *
+ * Output width: img1.cols + img2.cols. Height: max(img1.rows, img2.rows).
+ * An empty MatchSet produces a side-by-side image with no connecting lines.
+ *
+ * @code
+ * Image<BGR> vis = DrawMatches{img1, kps1, img2, kps2, matches}();
+ * @endcode
+ */
+struct DrawMatches {
+    DrawMatches(Image<BGR> img1, KeypointSet kps1,
+                Image<BGR> img2, KeypointSet kps2,
+                MatchSet   ms)
+        : img1_(std::move(img1)), kps1_(std::move(kps1)),
+          img2_(std::move(img2)), kps2_(std::move(kps2)),
+          ms_(std::move(ms)) {}
+
+    [[nodiscard]] Image<BGR> operator()() const;
+
+private:
+    Image<BGR>  img1_, img2_;
+    KeypointSet kps1_, kps2_;
+    MatchSet    ms_;
+};
+
+} // namespace improc::visualization

--- a/include/improc/visualization/draw_tracks.hpp
+++ b/include/improc/visualization/draw_tracks.hpp
@@ -46,7 +46,7 @@ struct DrawTracks {
     DrawTracks& show_id(bool b) { show_id_ = b; return *this; }
 
     /// @brief Draws all tracks onto a clone of `img` and returns the annotated copy.
-    Image<BGR> operator()(Image<BGR> img) const {
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const {
         cv::Mat canvas = img.mat().clone();
 
         for (const auto& t : tracks_) {

--- a/include/improc/visualization/histogram.hpp
+++ b/include/improc/visualization/histogram.hpp
@@ -48,11 +48,11 @@ struct Histogram {
     }
 
     /// @brief Renders a three-channel BGR histogram chart.
-    Image<BGR> operator()(Image<BGR>     img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<BGR>     img) const;
     /// @brief Renders a single-channel grayscale histogram chart.
-    Image<BGR> operator()(Image<Gray>    img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<Gray>    img) const;
     /// @brief Renders a single-channel Float32 histogram chart (values in [0,1]).
-    Image<BGR> operator()(Image<Float32> img) const;
+    [[nodiscard]] Image<BGR> operator()(Image<Float32> img) const;
 
 private:
     cv::Mat render(const std::vector<cv::Mat>& hists,

--- a/include/improc/visualization/iou_histogram.hpp
+++ b/include/improc/visualization/iou_histogram.hpp
@@ -64,7 +64,7 @@ struct IoUHistogram {
 
     /// @brief Renders and returns the histogram as a BGR image.
     /// @throws improc::ParameterError if width, height, or bins <= 0, or threshold outside [0, 1].
-    Image<BGR> operator()() const {
+    [[nodiscard]] Image<BGR> operator()() const {
         if (width_ <= 0)
             throw improc::ParameterError{"width",     "must be positive",   "IoUHistogram"};
         if (height_ <= 0)

--- a/include/improc/visualization/line_plot.hpp
+++ b/include/improc/visualization/line_plot.hpp
@@ -44,7 +44,7 @@ struct LinePlot {
 
     /// @brief Renders the line chart from the given scalar values.
     /// @throws improc::ParameterError if `values` is empty.
-    Image<BGR> operator()(const std::vector<float>& values) const;
+    [[nodiscard]] Image<BGR> operator()(const std::vector<float>& values) const;
 
 private:
     std::string title_;

--- a/include/improc/visualization/montage.hpp
+++ b/include/improc/visualization/montage.hpp
@@ -50,7 +50,7 @@ struct Montage {
     Montage& background(cv::Scalar color);
 
     /// @brief Renders and returns the grid as `Image<BGR>`.
-    Image<BGR> operator()() const;
+    [[nodiscard]] Image<BGR> operator()() const;
 
 private:
     std::vector<Image<BGR>> images_;

--- a/include/improc/visualization/pr_curve_plot.hpp
+++ b/include/improc/visualization/pr_curve_plot.hpp
@@ -69,7 +69,7 @@ struct PRCurvePlot {
 
     /// @brief Renders and returns the PR curve plot as a BGR image.
     /// @throws improc::ParameterError if width or height <= 0.
-    Image<BGR> operator()() const {
+    [[nodiscard]] Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "PRCurvePlot"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "PRCurvePlot"};
 

--- a/include/improc/visualization/roc_curve_plot.hpp
+++ b/include/improc/visualization/roc_curve_plot.hpp
@@ -62,7 +62,7 @@ struct ROCCurvePlot {
 
     /// @brief Renders and returns the ROC curve plot as a BGR image.
     /// @throws improc::ParameterError if width or height <= 0.
-    Image<BGR> operator()() const {
+    [[nodiscard]] Image<BGR> operator()() const {
         if (width_ <= 0)  throw improc::ParameterError{"width",  "must be positive", "ROCCurvePlot"};
         if (height_ <= 0) throw improc::ParameterError{"height", "must be positive", "ROCCurvePlot"};
 

--- a/include/improc/visualization/scatter.hpp
+++ b/include/improc/visualization/scatter.hpp
@@ -50,8 +50,8 @@ struct Scatter {
 
     /// @brief Renders the scatter chart from parallel x/y value arrays.
     /// @throws improc::ParameterError if `xs` or `ys` is empty, or their sizes differ.
-    Image<BGR> operator()(const std::vector<float>& xs,
-                          const std::vector<float>& ys) const;
+    [[nodiscard]] Image<BGR> operator()(const std::vector<float>& xs,
+                                        const std::vector<float>& ys) const;
 
 private:
     std::string title_;

--- a/include/improc/visualization/show.hpp
+++ b/include/improc/visualization/show.hpp
@@ -35,7 +35,7 @@ struct Show {
     }
 
     /// @brief Displays the image via `cv::imshow`, waits `wait_ms` ms, and returns the image unchanged.
-    Image<BGR> operator()(Image<BGR> img) const {
+    [[nodiscard]] Image<BGR> operator()(Image<BGR> img) const {
         cv::imshow(window_name_, img.mat());
         cv::waitKey(wait_ms_);
         return img;

--- a/include/improc/visualization/visualization.hpp
+++ b/include/improc/visualization/visualization.hpp
@@ -3,7 +3,8 @@
 
 /** @file visualization.hpp
  *  @brief Convenience header — includes all `improc::visualization` rendering types
- *         (Histogram, LinePlot, Scatter, Show, Draw, DrawTracks, Montage).
+ *         (Histogram, LinePlot, Scatter, Show, Draw, DrawTracks, Montage,
+ *          DrawContours, DrawKeypoints, DrawMatches).
  */
 
 #include "improc/visualization/histogram.hpp"
@@ -13,3 +14,5 @@
 #include "improc/visualization/draw.hpp"
 #include "improc/visualization/draw_tracks.hpp"
 #include "improc/visualization/montage.hpp"
+#include "improc/visualization/draw_contours.hpp"
+#include "improc/visualization/draw_matches.hpp"

--- a/src/calib/aruco.cpp
+++ b/src/calib/aruco.cpp
@@ -1,5 +1,6 @@
 // src/calib/aruco.cpp
 #include "improc/calib/ops/aruco.hpp"
+#include "improc/exceptions.hpp"
 #include <opencv2/objdetect/charuco_detector.hpp>
 #include <opencv2/calib3d.hpp>
 #include <opencv2/imgproc.hpp>
@@ -49,11 +50,9 @@ cv::Mat DrawAruco::operator()(cv::Mat img,
 Image<Gray> GenerateAruco::operator()(const cv::aruco::Dictionary& dict,
                                        int id, int side_pixels) const {
     if (id < 0)
-        throw std::invalid_argument(
-            "GenerateAruco: id must be >= 0");
+        throw improc::ParameterError{"id", "must be >= 0", "GenerateAruco"};
     if (side_pixels < 1)
-        throw std::invalid_argument(
-            "GenerateAruco: side_pixels must be >= 1");
+        throw improc::ParameterError{"side_pixels", "must be >= 1", "GenerateAruco"};
     cv::Mat img;
     cv::aruco::generateImageMarker(dict, id, side_pixels, img, border_bits_);
     return Image<Gray>(img);
@@ -85,14 +84,11 @@ std::vector<ArucoPoseResult> ArucoPose::operator()(const ArucoResult& result,
 namespace {
 void validate_charuco(bool has_size, float square_length, float marker_length) {
     if (!has_size)
-        throw std::invalid_argument(
-            "CharucoBoard: board_size must be set before use");
+        throw improc::ParameterError{"board_size", "must be set before use", "CharucoBoard"};
     if (square_length <= 0.f)
-        throw std::invalid_argument(
-            "CharucoBoard: square_length must be positive");
+        throw improc::ParameterError{"square_length", "must be positive", "CharucoBoard"};
     if (marker_length <= 0.f)
-        throw std::invalid_argument(
-            "CharucoBoard: marker_length must be positive");
+        throw improc::ParameterError{"marker_length", "must be positive", "CharucoBoard"};
 }
 
 CharucoResult run_charuco_detection(const cv::Mat& mat,

--- a/src/calib/calibrate.cpp
+++ b/src/calib/calibrate.cpp
@@ -8,14 +8,11 @@ CalibrationResult CalibrateCamera::operator()(
         const std::vector<std::vector<cv::Point2f>>& img_pts,
         cv::Size image_size) const {
     if (obj_pts.size() != img_pts.size())
-        throw std::invalid_argument(
-            "CalibrateCamera: obj_pts and img_pts must have the same number of views");
+        throw improc::ParameterError{"obj_pts", "must have the same number of views as img_pts", "CalibrateCamera"};
     if (obj_pts.size() < 3)
-        throw std::invalid_argument(
-            "CalibrateCamera: at least 3 views required");
+        throw improc::ParameterError{"obj_pts", "at least 3 views required", "CalibrateCamera"};
     if (image_size.width <= 0 || image_size.height <= 0)
-        throw std::invalid_argument(
-            "CalibrateCamera: image_size dimensions must be positive");
+        throw improc::ParameterError{"image_size", "dimensions must be positive", "CalibrateCamera"};
 
     CalibrationResult result;
     result.rms = cv::calibrateCamera(obj_pts, img_pts, image_size,

--- a/src/calib/chessboard.cpp
+++ b/src/calib/chessboard.cpp
@@ -1,12 +1,13 @@
 // src/calib/chessboard.cpp
 #include "improc/calib/ops/chessboard.hpp"
+#include "improc/exceptions.hpp"
 #include <opencv2/imgproc.hpp>
 
 namespace improc::calib {
 
 FindChessboardResult FindChessboardCorners::operator()(Image<Gray> img) const {
     if (!has_board_size_)
-        throw std::invalid_argument("FindChessboardCorners: board_size must be set");
+        throw improc::ParameterError{"board_size", "must be set before calling operator()", "FindChessboardCorners"};
     FindChessboardResult result;
     result.found = cv::findChessboardCorners(img.mat(), board_size_,
                                              result.corners, flags_);
@@ -22,7 +23,7 @@ FindChessboardResult FindChessboardCorners::operator()(Image<BGR> img) const {
 
 FindChessboardResult FindChessboardCornersSB::operator()(Image<Gray> img) const {
     if (!has_board_size_)
-        throw std::invalid_argument("FindChessboardCornersSB: board_size must be set");
+        throw improc::ParameterError{"board_size", "must be set before calling operator()", "FindChessboardCornersSB"};
     FindChessboardResult result;
     result.found = cv::findChessboardCornersSB(img.mat(), board_size_,
                                                result.corners, flags_);

--- a/src/calib/epipolar.cpp
+++ b/src/calib/epipolar.cpp
@@ -1,5 +1,6 @@
 // src/calib/epipolar.cpp
 #include "improc/calib/ops/epipolar.hpp"
+#include "improc/exceptions.hpp"
 #include <opencv2/calib3d.hpp>
 
 namespace improc::calib {
@@ -8,11 +9,9 @@ FundamentalMatResult FindFundamentalMat::operator()(
         const std::vector<cv::Point2f>& pts1,
         const std::vector<cv::Point2f>& pts2) const {
     if (pts1.size() != pts2.size())
-        throw std::invalid_argument(
-            "FindFundamentalMat: pts1 and pts2 must have the same number of points");
+        throw improc::ParameterError{"pts1", "must be same size as pts2", "FindFundamentalMat"};
     if (pts1.size() < 8)
-        throw std::invalid_argument(
-            "FindFundamentalMat: at least 8 point correspondences required");
+        throw improc::ParameterError{"pts1", "at least 8 point correspondences required", "FindFundamentalMat"};
 
     FundamentalMatResult result;
     result.F = cv::findFundamentalMat(pts1, pts2, method_,
@@ -25,11 +24,9 @@ EssentialMatResult FindEssentialMat::operator()(
         const std::vector<cv::Point2f>& pts2,
         const cv::Mat& K) const {
     if (pts1.size() != pts2.size())
-        throw std::invalid_argument(
-            "FindEssentialMat: pts1 and pts2 must have the same number of points");
+        throw improc::ParameterError{"pts1", "must be same size as pts2", "FindEssentialMat"};
     if (pts1.size() < 5)
-        throw std::invalid_argument(
-            "FindEssentialMat: at least 5 point correspondences required");
+        throw improc::ParameterError{"pts1", "at least 5 point correspondences required", "FindEssentialMat"};
 
     EssentialMatResult result;
     result.E = cv::findEssentialMat(pts1, pts2, K, method_,

--- a/src/calib/fisheye.cpp
+++ b/src/calib/fisheye.cpp
@@ -1,0 +1,89 @@
+// src/calib/fisheye.cpp
+#include "improc/calib/ops/fisheye.hpp"
+#include <opencv2/calib3d.hpp>
+
+namespace improc::calib {
+
+// ── FisheyeCalibrate ──────────────────────────────────────────────────────────
+
+CalibrationResult FisheyeCalibrate::operator()(
+    const std::vector<std::vector<cv::Point3f>>& object_pts,
+    const std::vector<std::vector<cv::Point2f>>& image_pts,
+    cv::Size image_size) const
+{
+    CalibrationResult r;
+    r.rms = cv::fisheye::calibrate(
+        object_pts, image_pts, image_size,
+        r.camera_matrix, r.dist_coeffs, r.rvecs, r.tvecs,
+        flags_, criteria_);
+    return r;
+}
+
+// ── FisheyeUndistortPoints ────────────────────────────────────────────────────
+
+std::vector<cv::Point2f> FisheyeUndistortPoints::operator()(
+    const std::vector<cv::Point2f>& pts) const
+{
+    std::vector<cv::Point2f> result;
+    cv::fisheye::undistortPoints(pts, result, K_, dist_,
+                                 R_.empty() ? cv::Mat{} : R_,
+                                 P_.empty() ? cv::Mat{} : P_);
+    return result;
+}
+
+// ── FisheyeInitRectifyMap ─────────────────────────────────────────────────────
+
+UndistortMapResult FisheyeInitRectifyMap::operator()(cv::Size image_size) const {
+    UndistortMapResult r;
+    cv::fisheye::initUndistortRectifyMap(
+        K_, dist_,
+        R_.empty() ? cv::Mat::eye(3, 3, CV_64F) : R_,
+        new_K_.empty() ? K_ : new_K_,
+        image_size, CV_32FC1, r.map1, r.map2);
+    return r;
+}
+
+// ── FisheyeStereoCalibrate ────────────────────────────────────────────────────
+
+StereoCalibrationResult FisheyeStereoCalibrate::operator()(
+    const std::vector<std::vector<cv::Point3f>>& object_pts,
+    const std::vector<std::vector<cv::Point2f>>& left_pts,
+    const std::vector<std::vector<cv::Point2f>>& right_pts,
+    cv::Size image_size) const
+{
+    StereoCalibrationResult result;
+    result.K1    = K1_.empty()    ? cv::Mat() : K1_.clone();
+    result.dist1 = dist1_.empty() ? cv::Mat() : dist1_.clone();
+    result.K2    = K2_.empty()    ? cv::Mat() : K2_.clone();
+    result.dist2 = dist2_.empty() ? cv::Mat() : dist2_.clone();
+
+    // cv::fisheye::stereoCalibrate does not output E and F.
+    // Use the overload without per-view rvecs/tvecs.
+    result.rms = cv::fisheye::stereoCalibrate(
+        object_pts, left_pts, right_pts,
+        result.K1, result.dist1, result.K2, result.dist2,
+        image_size, result.R, result.T,
+        flags_,
+        cv::TermCriteria(cv::TermCriteria::COUNT + cv::TermCriteria::EPS, 100, 1e-6));
+    // E and F are not computed by the fisheye model; leave them empty.
+    return result;
+}
+
+// ── FisheyeStereoRectify ──────────────────────────────────────────────────────
+
+StereoRectifyResult FisheyeStereoRectify::operator()(
+    const cv::Mat& K1, const cv::Mat& D1,
+    const cv::Mat& K2, const cv::Mat& D2,
+    const cv::Mat& R,  const cv::Mat& T) const
+{
+    StereoRectifyResult result;
+    // cv::fisheye::stereoRectify(K1, D1, K2, D2, imageSize, R, tvec,
+    //     R1, R2, P1, P2, Q, flags, newImageSize={0,0}, balance=0, fov_scale=1)
+    cv::fisheye::stereoRectify(
+        K1, D1, K2, D2, image_size_, R, T,
+        result.R1, result.R2, result.P1, result.P2, result.Q,
+        flags_, cv::Size{0, 0}, balance_, fov_scale_);
+    return result;
+}
+
+} // namespace improc::calib

--- a/src/calib/project.cpp
+++ b/src/calib/project.cpp
@@ -1,5 +1,6 @@
 // src/calib/project.cpp
 #include "improc/calib/ops/project.hpp"
+#include "improc/exceptions.hpp"
 #include <opencv2/calib3d.hpp>
 
 namespace improc::calib {
@@ -9,7 +10,7 @@ std::vector<cv::Point2f> ProjectPoints::operator()(
         const cv::Mat& rvec, const cv::Mat& tvec,
         const cv::Mat& K, const cv::Mat& dist) const {
     if (obj_pts.empty())
-        throw std::invalid_argument("ProjectPoints: obj_pts must not be empty");
+        throw improc::ParameterError{"obj_pts", "must not be empty", "ProjectPoints"};
     std::vector<cv::Point2f> img_pts;
     cv::projectPoints(obj_pts, rvec, tvec, K, dist, img_pts);
     return img_pts;
@@ -19,9 +20,9 @@ PnPResult SolvePnP::operator()(const std::vector<cv::Point3f>& obj_pts,
                                 const std::vector<cv::Point2f>& img_pts,
                                 const cv::Mat& K, const cv::Mat& dist) const {
     if (obj_pts.size() != img_pts.size())
-        throw std::invalid_argument("SolvePnP: obj_pts and img_pts must have the same size");
+        throw improc::ParameterError{"obj_pts", "must be same size as img_pts", "SolvePnP"};
     if (obj_pts.size() < 4)
-        throw std::invalid_argument("SolvePnP: at least 4 point correspondences required");
+        throw improc::ParameterError{"obj_pts", "at least 4 correspondences required", "SolvePnP"};
     PnPResult result;
     result.success = cv::solvePnP(obj_pts, img_pts, K, dist,
                                   result.rvec, result.tvec,
@@ -33,9 +34,9 @@ PnPRansacResult SolvePnPRansac::operator()(const std::vector<cv::Point3f>& obj_p
                                             const std::vector<cv::Point2f>& img_pts,
                                             const cv::Mat& K, const cv::Mat& dist) const {
     if (obj_pts.size() != img_pts.size())
-        throw std::invalid_argument("SolvePnPRansac: obj_pts and img_pts must have the same size");
+        throw improc::ParameterError{"obj_pts", "must be same size as img_pts", "SolvePnPRansac"};
     if (obj_pts.size() < 4)
-        throw std::invalid_argument("SolvePnPRansac: at least 4 point correspondences required");
+        throw improc::ParameterError{"obj_pts", "at least 4 correspondences required", "SolvePnPRansac"};
     PnPRansacResult result;
     result.success = cv::solvePnPRansac(obj_pts, img_pts, K, dist,
                                         result.rvec, result.tvec,

--- a/src/calib/stereo.cpp
+++ b/src/calib/stereo.cpp
@@ -38,7 +38,7 @@ StereoRectifyResult StereoRectify::operator()(
         cv::Size image_size) const {
     if (K1.empty() || dist1.empty() || K2.empty() || dist2.empty() ||
         R.empty()  || T.empty())
-        throw improc::ParameterError{"K1", "K1, dist1, K2, dist2, R, T must not be empty", "StereoRectify"};
+        throw improc::ParameterError{"inputs", "K1, dist1, K2, dist2, R, T must not be empty", "StereoRectify"};
 
     StereoRectifyResult result;
     cv::stereoRectify(K1, dist1, K2, dist2, image_size, R, T,
@@ -50,7 +50,7 @@ StereoRectifyResult StereoRectify::operator()(
 
 cv::Mat StereoBM::operator()(Image<Gray> left, Image<Gray> right) const {
     if (left.mat().size() != right.mat().size())
-        throw improc::ParameterError{"left", "left and right images must have the same size", "StereoBM"};
+        throw improc::ParameterError{"left", "must be the same size as right", "StereoBM"};
     auto bm = cv::StereoBM::create(num_disparities_, block_size_);
     cv::Mat disparity;
     bm->compute(left.mat(), right.mat(), disparity);
@@ -59,7 +59,7 @@ cv::Mat StereoBM::operator()(Image<Gray> left, Image<Gray> right) const {
 
 cv::Mat StereoSGBM::operator()(Image<Gray> left, Image<Gray> right) const {
     if (left.mat().size() != right.mat().size())
-        throw improc::ParameterError{"left", "left and right images must have the same size", "StereoSGBM"};
+        throw improc::ParameterError{"left", "must be the same size as right", "StereoSGBM"};
     auto sgbm = cv::StereoSGBM::create(min_disparity_, num_disparities_, block_size_,
                                         p1_, p2_, 0, 0, 0, 0, 0, mode_);
     cv::Mat disparity;

--- a/src/calib/stereo.cpp
+++ b/src/calib/stereo.cpp
@@ -1,5 +1,6 @@
 // src/calib/stereo.cpp
 #include "improc/calib/ops/stereo.hpp"
+#include "improc/exceptions.hpp"
 #include <opencv2/calib3d.hpp>
 
 namespace improc::calib {
@@ -10,14 +11,11 @@ StereoCalibrationResult StereoCalibrate::operator()(
         const std::vector<std::vector<cv::Point2f>>& img_pts2,
         cv::Size image_size) const {
     if (obj_pts.size() != img_pts1.size() || obj_pts.size() != img_pts2.size())
-        throw std::invalid_argument(
-            "StereoCalibrate: obj_pts, img_pts1, img_pts2 must have the same number of views");
+        throw improc::ParameterError{"obj_pts", "must have same number of views as img_pts1 and img_pts2", "StereoCalibrate"};
     if (obj_pts.size() < 3)
-        throw std::invalid_argument(
-            "StereoCalibrate: at least 3 views required");
+        throw improc::ParameterError{"obj_pts", "at least 3 views required", "StereoCalibrate"};
     if (image_size.width <= 0 || image_size.height <= 0)
-        throw std::invalid_argument(
-            "StereoCalibrate: image_size dimensions must be positive");
+        throw improc::ParameterError{"image_size", "dimensions must be positive", "StereoCalibrate"};
 
     StereoCalibrationResult result;
     result.K1    = K1_.empty()    ? cv::Mat() : K1_.clone();
@@ -40,8 +38,7 @@ StereoRectifyResult StereoRectify::operator()(
         cv::Size image_size) const {
     if (K1.empty() || dist1.empty() || K2.empty() || dist2.empty() ||
         R.empty()  || T.empty())
-        throw std::invalid_argument(
-            "StereoRectify: K1, dist1, K2, dist2, R, T must not be empty");
+        throw improc::ParameterError{"K1", "K1, dist1, K2, dist2, R, T must not be empty", "StereoRectify"};
 
     StereoRectifyResult result;
     cv::stereoRectify(K1, dist1, K2, dist2, image_size, R, T,
@@ -53,8 +50,7 @@ StereoRectifyResult StereoRectify::operator()(
 
 cv::Mat StereoBM::operator()(Image<Gray> left, Image<Gray> right) const {
     if (left.mat().size() != right.mat().size())
-        throw std::invalid_argument(
-            "StereoBM: left and right images must have the same size");
+        throw improc::ParameterError{"left", "left and right images must have the same size", "StereoBM"};
     auto bm = cv::StereoBM::create(num_disparities_, block_size_);
     cv::Mat disparity;
     bm->compute(left.mat(), right.mat(), disparity);
@@ -63,8 +59,7 @@ cv::Mat StereoBM::operator()(Image<Gray> left, Image<Gray> right) const {
 
 cv::Mat StereoSGBM::operator()(Image<Gray> left, Image<Gray> right) const {
     if (left.mat().size() != right.mat().size())
-        throw std::invalid_argument(
-            "StereoSGBM: left and right images must have the same size");
+        throw improc::ParameterError{"left", "left and right images must have the same size", "StereoSGBM"};
     auto sgbm = cv::StereoSGBM::create(min_disparity_, num_disparities_, block_size_,
                                         p1_, p2_, 0, 0, 0, 0, 0, mode_);
     cv::Mat disparity;

--- a/src/calib/undistort.cpp
+++ b/src/calib/undistort.cpp
@@ -5,11 +5,11 @@ namespace improc::calib {
 
 UndistortMapResult UndistortMap::operator()(cv::Size image_size) const {
     if (K_.empty())
-        throw std::invalid_argument("UndistortMap: K must be set");
+        throw improc::ParameterError{"K", "must be set before calling operator()", "UndistortMap"};
     if (dist_.empty())
-        throw std::invalid_argument("UndistortMap: dist must be set");
+        throw improc::ParameterError{"dist", "must be set before calling operator()", "UndistortMap"};
     if (image_size.width <= 0 || image_size.height <= 0)
-        throw std::invalid_argument("UndistortMap: image_size dimensions must be positive");
+        throw improc::ParameterError{"image_size", "dimensions must be positive", "UndistortMap"};
     cv::Mat R = R_.empty() ? cv::Mat::eye(3, 3, CV_64F) : R_;
     cv::Mat new_K = new_K_.empty() ? K_ : new_K_;
     UndistortMapResult result;

--- a/src/core/match_template.cpp
+++ b/src/core/match_template.cpp
@@ -1,5 +1,6 @@
 // src/core/match_template.cpp
 #include "improc/core/ops/match_template.hpp"
+#include "improc/exceptions.hpp"
 #include <stdexcept>
 
 namespace improc::core {
@@ -12,7 +13,7 @@ MatchTemplate& MatchTemplate::method(int m) {
 std::pair<cv::Point, double> MatchTemplate::operator()(const Image<BGR>& img,
                                                         const Image<BGR>& templ) const {
     if (templ.mat().cols > img.mat().cols || templ.mat().rows > img.mat().rows)
-        throw std::invalid_argument("template must not be larger than the image");
+        throw improc::ParameterError{"templ", "must not be larger than the image", "MatchTemplate"};
 
     cv::Mat result;
     cv::matchTemplate(img.mat(), templ.mat(), result, method_);

--- a/src/core/match_template.cpp
+++ b/src/core/match_template.cpp
@@ -1,7 +1,6 @@
 // src/core/match_template.cpp
 #include "improc/core/ops/match_template.hpp"
 #include "improc/exceptions.hpp"
-#include <stdexcept>
 
 namespace improc::core {
 

--- a/src/core/ops/analysis.cpp
+++ b/src/core/ops/analysis.cpp
@@ -27,8 +27,8 @@ MinMaxLocResult MinMaxLoc::operator()(const cv::Mat& mat) const {
     return run_minmaxloc(mat);
 }
 
-int CountNonZero::operator()(const Image<Gray>& img) const {
-    return cv::countNonZero(img.mat());
+std::size_t CountNonZero::operator()(const Image<Gray>& img) const {
+    return static_cast<std::size_t>(cv::countNonZero(img.mat()));
 }
 
 cv::Mat Reduce::operator()(const Image<Gray>& img) const {

--- a/src/core/ops/channels.cpp
+++ b/src/core/ops/channels.cpp
@@ -1,5 +1,6 @@
 // src/core/ops/channels.cpp
 #include "improc/core/ops/channels.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
@@ -19,7 +20,7 @@ std::array<Image<Gray>, 4> SplitChannels::operator()(const Image<BGRA>& img) con
 static void check_sizes(const Image<Gray>& a, const Image<Gray>& b, const Image<Gray>& c) {
     if (a.rows() != b.rows() || a.rows() != c.rows() ||
         a.cols() != b.cols() || a.cols() != c.cols())
-        throw std::invalid_argument("MergeChannels: all channels must have the same size");
+        throw improc::ParameterError{"channels", "all channels must have the same size", "MergeChannels"};
 }
 
 Image<BGR> MergeChannels::operator()(const Image<Gray>& b, const Image<Gray>& g,
@@ -34,7 +35,7 @@ Image<BGRA> MergeChannels::operator()(const Image<Gray>& b, const Image<Gray>& g
                                        const Image<Gray>& r, const Image<Gray>& a) const {
     check_sizes(b, g, r);
     if (a.rows() != b.rows() || a.cols() != b.cols())
-        throw std::invalid_argument("MergeChannels: all channels must have the same size");
+        throw improc::ParameterError{"channels", "all channels must have the same size", "MergeChannels"};
     cv::Mat result;
     cv::merge(std::vector<cv::Mat>{b.mat(), g.mat(), r.mat(), a.mat()}, result);
     return Image<BGRA>(std::move(result));

--- a/src/core/ops/connected_components.cpp
+++ b/src/core/ops/connected_components.cpp
@@ -1,10 +1,11 @@
 // src/core/ops/connected_components.cpp
+#include <cstddef>
 #include "improc/core/ops/connected_components.hpp"
 
 namespace improc::core {
 
 void ComponentMap::check(int label) const {
-    if (label < 0 || label >= num_labels)
+    if (label < 0 || static_cast<std::size_t>(label) >= num_labels)
         throw std::out_of_range{"ComponentMap: label out of range"};
 }
 
@@ -37,9 +38,10 @@ cv::Mat ComponentMap::mask(int label) const {
 
 ComponentMap ConnectedComponents::operator()(Image<Gray> img) const {
     ComponentMap result;
-    result.num_labels = cv::connectedComponentsWithStats(
-        img.mat(), result.labels, result.stats, result.centroids,
-        static_cast<int>(conn_), CV_32S);
+    result.num_labels = static_cast<std::size_t>(
+        cv::connectedComponentsWithStats(
+            img.mat(), result.labels, result.stats, result.centroids,
+            static_cast<int>(conn_), CV_32S));
     return result;
 }
 

--- a/src/core/ops/contours.cpp
+++ b/src/core/ops/contours.cpp
@@ -34,13 +34,6 @@ ContourSet FindContours::operator()(Image<Gray> img) const {
     return result;
 }
 
-Image<BGR> DrawContours::operator()(Image<BGR> img) const {
-    cv::Mat dst = img.mat().clone();
-    cv::drawContours(dst, cs_.contours, index_, color_, thickness_,
-                     cv::LINE_AA, cs_.hierarchy);
-    return Image<BGR>(std::move(dst));
-}
-
 std::vector<cv::Point> ConvexHull::operator()(const std::vector<cv::Point>& contour) const {
     std::vector<cv::Point> hull;
     cv::convexHull(contour, hull);

--- a/src/core/ops/face.cpp
+++ b/src/core/ops/face.cpp
@@ -9,7 +9,7 @@ namespace improc::core {
 
 void DetectFaceYN::ensure_initialized(cv::Size frame_size) {
     if (model_path_.empty())
-        throw std::invalid_argument("DetectFaceYN: model path not set — call .model(path) first");
+        throw improc::ParameterError{"model_path", "must be set — call .model(path) first", "DetectFaceYN"};
     if (!detector_) {
         if (!std::filesystem::exists(model_path_))
             throw improc::FileNotFoundError{model_path_};
@@ -54,7 +54,7 @@ std::vector<FaceDetection> DetectFaceYN::operator()(Image<BGR> img) {
 
 void RecognizeFace::ensure_initialized() {
     if (model_path_.empty())
-        throw std::invalid_argument("RecognizeFace: model path not set — call .model(path) first");
+        throw improc::ParameterError{"model_path", "must be set — call .model(path) first", "RecognizeFace"};
     if (!recognizer_) {
         if (!std::filesystem::exists(model_path_))
             throw improc::FileNotFoundError{model_path_};

--- a/src/core/ops/face.cpp
+++ b/src/core/ops/face.cpp
@@ -66,18 +66,15 @@ void RecognizeFace::ensure_initialized() {
     }
 }
 
-cv::Mat RecognizeFace::embed(Image<BGR> face_chip) {
+FaceEmbedding RecognizeFace::embed(Image<BGR> face_chip) {
     ensure_initialized();
     cv::Mat emb;
     recognizer_->feature(face_chip.mat(), emb);
-    return emb;
+    return FaceEmbedding{std::move(emb)};
 }
 
-float RecognizeFace::match(const cv::Mat& emb_a, const cv::Mat& emb_b) {
-    cv::Mat a_norm, b_norm;
-    cv::normalize(emb_a, a_norm, 1.0, 0.0, cv::NORM_L2);
-    cv::normalize(emb_b, b_norm, 1.0, 0.0, cv::NORM_L2);
-    return static_cast<float>(a_norm.dot(b_norm));
+float RecognizeFace::match(const FaceEmbedding& emb_a, const FaceEmbedding& emb_b) {
+    return emb_a.cosine_similarity(emb_b);
 }
 
 } // namespace improc::core

--- a/src/core/ops/flood_fill.cpp
+++ b/src/core/ops/flood_fill.cpp
@@ -1,13 +1,14 @@
 // src/core/ops/flood_fill.cpp
 #include <stdexcept>
 #include "improc/core/ops/flood_fill.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
 namespace {
 void check_seed(int rows, int cols, cv::Point seed) {
     if (seed.x < 0 || seed.y < 0 || seed.x >= cols || seed.y >= rows)
-        throw std::invalid_argument("FloodFill: seed point is outside image bounds");
+        throw improc::ParameterError{"seed", "is outside image bounds", "FloodFill"};
 }
 } // namespace
 

--- a/src/core/ops/flood_fill.cpp
+++ b/src/core/ops/flood_fill.cpp
@@ -1,5 +1,4 @@
 // src/core/ops/flood_fill.cpp
-#include <stdexcept>
 #include "improc/core/ops/flood_fill.hpp"
 #include "improc/exceptions.hpp"
 

--- a/src/core/ops/grabcut.cpp
+++ b/src/core/ops/grabcut.cpp
@@ -1,7 +1,6 @@
 // src/core/ops/grabcut.cpp
 #include "improc/core/ops/grabcut.hpp"
 #include "improc/exceptions.hpp"
-#include <stdexcept>
 
 namespace improc::core {
 

--- a/src/core/ops/grabcut.cpp
+++ b/src/core/ops/grabcut.cpp
@@ -1,5 +1,6 @@
 // src/core/ops/grabcut.cpp
 #include "improc/core/ops/grabcut.hpp"
+#include "improc/exceptions.hpp"
 #include <stdexcept>
 
 namespace improc::core {
@@ -11,11 +12,11 @@ GrabCut& GrabCut::iterations(int n) {
 
 Image<Gray> GrabCut::operator()(const Image<BGR>& img, cv::Rect roi) const {
     if (roi.empty())
-        throw std::invalid_argument("GrabCut: roi must not be empty");
+        throw improc::ParameterError{"roi", "must not be empty", "GrabCut"};
     if (roi.x < 0 || roi.y < 0 ||
         roi.x + roi.width  > img.cols() ||
         roi.y + roi.height > img.rows())
-        throw std::invalid_argument("GrabCut: roi extends outside image bounds");
+        throw improc::ParameterError{"roi", "extends outside image bounds", "GrabCut"};
 
     cv::Mat mask;
     cv::Mat bgModel, fgModel;

--- a/src/core/ops/hist.cpp
+++ b/src/core/ops/hist.cpp
@@ -14,28 +14,27 @@ CalcHist& CalcHist::range(float lo, float hi) {
     return *this;
 }
 
-cv::Mat CalcHist::operator()(const Image<Gray>& img) const {
+HistogramData CalcHist::operator()(const Image<Gray>& img) const {
     cv::Mat hist;
     const float range[] = {range_lo_, range_hi_};
     const float* ranges[] = {range};
     int ch = 0;
     cv::calcHist(&img.mat(), 1, &ch, cv::noArray(),
                  hist, 1, &bins_, ranges);
-    return hist;
+    return HistogramData{hist, bins_, range_lo_, range_hi_, 1};
 }
 
-cv::Mat CalcHist::operator()(const Image<BGR>& img) const {
+HistogramData CalcHist::operator()(const Image<BGR>& img) const {
     const float range[] = {range_lo_, range_hi_};
     const float* ranges[] = {range};
-
-    cv::Mat hists[3];
-    for (int ch = 0; ch < 3; ++ch) {
-        cv::calcHist(&img.mat(), 1, &ch, cv::noArray(),
-                     hists[ch], 1, &bins_, ranges);
+    cv::Mat combined(bins_, 3, CV_32F);
+    for (int c = 0; c < 3; ++c) {
+        cv::Mat col_hist;
+        cv::calcHist(&img.mat(), 1, &c, cv::noArray(),
+                     col_hist, 1, &bins_, ranges);
+        col_hist.copyTo(combined.col(c));
     }
-    cv::Mat stacked;
-    cv::vconcat(hists, 3, stacked);
-    return stacked;
+    return HistogramData{combined, bins_, range_lo_, range_hi_, 3};
 }
 
 CompareHist& CompareHist::method(int m) {
@@ -43,8 +42,8 @@ CompareHist& CompareHist::method(int m) {
     return *this;
 }
 
-double CompareHist::operator()(const cv::Mat& h1, const cv::Mat& h2) const {
-    return cv::compareHist(h1, h2, method_);
+double CompareHist::operator()(const HistogramData& h1, const HistogramData& h2) const {
+    return cv::compareHist(h1.data, h2.data, method_);
 }
 
 } // namespace improc::core

--- a/src/core/ops/img_hash.cpp
+++ b/src/core/ops/img_hash.cpp
@@ -40,7 +40,7 @@ cv::Mat to_gray_resized(const Image<BGR>& img, int size) {
 // ── AverageHash ───────────────────────────────────────────────────────────────
 // Resize to 8×8 gray. Bit = pixel > mean. 64 bits = 8 bytes.
 
-cv::Mat AverageHash::operator()(const Image<BGR>& img) const {
+ImageHash AverageHash::operator()(const Image<BGR>& img) const {
     cv::Mat small = to_gray_resized(img, 8);
     double mean = cv::mean(small)[0];
     std::vector<bool> bits;
@@ -48,17 +48,18 @@ cv::Mat AverageHash::operator()(const Image<BGR>& img) const {
     for (int r = 0; r < 8; ++r)
         for (int c = 0; c < 8; ++c)
             bits.push_back(small.at<uint8_t>(r, c) > mean);
-    return pack_bits(bits);
+    cv::Mat h = pack_bits(bits);
+    return ImageHash{std::move(h)};
 }
-double AverageHash::distance(const cv::Mat& a, const cv::Mat& b) {
-    return hamming(a, b);
+double AverageHash::distance(const ImageHash& a, const ImageHash& b) {
+    return hamming(a.value, b.value);
 }
 
 // ── PHash ─────────────────────────────────────────────────────────────────────
 // Resize to 32×32, apply DCT, take 8×8 top-left (skip DC), bit = value > mean.
 // 63 meaningful bits packed into 8 bytes.
 
-cv::Mat PHash::operator()(const Image<BGR>& img) const {
+ImageHash PHash::operator()(const Image<BGR>& img) const {
     cv::Mat small = to_gray_resized(img, 32);
     cv::Mat floatMat, dctMat;
     small.convertTo(floatMat, CV_32F);
@@ -77,17 +78,18 @@ cv::Mat PHash::operator()(const Image<BGR>& img) const {
             bits.push_back(top.at<float>(r, c) > mean);
         }
     bits.push_back(false); // pad to 64 bits
-    return pack_bits(bits);
+    cv::Mat h = pack_bits(bits);
+    return ImageHash{std::move(h)};
 }
-double PHash::distance(const cv::Mat& a, const cv::Mat& b) {
-    return hamming(a, b);
+double PHash::distance(const ImageHash& a, const ImageHash& b) {
+    return hamming(a.value, b.value);
 }
 
 // ── MarrHildrethHash ──────────────────────────────────────────────────────────
 // Apply Laplacian of Gaussian, encode zero-crossing sign pattern.
 // 576 bits (24×24 sign map) = 72 bytes.
 
-cv::Mat MarrHildrethHash::operator()(const Image<BGR>& img) const {
+ImageHash MarrHildrethHash::operator()(const Image<BGR>& img) const {
     cv::Mat gray, resized, blurred, laplacian;
     cv::cvtColor(img.mat(), gray, cv::COLOR_BGR2GRAY);
     cv::resize(gray, resized, {24, 24}, 0, 0, cv::INTER_AREA);
@@ -102,24 +104,25 @@ cv::Mat MarrHildrethHash::operator()(const Image<BGR>& img) const {
     for (int r = 0; r < 24; ++r)
         for (int c = 0; c < 24; ++c)
             bits.push_back(laplacian.at<double>(r, c) >= 0);
-    return pack_bits(bits);
+    cv::Mat h = pack_bits(bits);
+    return ImageHash{std::move(h)};
 }
-double MarrHildrethHash::distance(const cv::Mat& a, const cv::Mat& b) {
-    return hamming(a, b);
+double MarrHildrethHash::distance(const ImageHash& a, const ImageHash& b) {
+    return hamming(a.value, b.value);
 }
 
 // ── RadialVarianceHash ────────────────────────────────────────────────────────
 // Sample 40 radial lines from the center, compute variance per line.
 // Result: 1×40 CV_64F. Distance: L2 norm.
 
-cv::Mat RadialVarianceHash::operator()(const Image<BGR>& img) const {
+ImageHash RadialVarianceHash::operator()(const Image<BGR>& img) const {
     cv::Mat gray, resized;
     cv::cvtColor(img.mat(), gray, cv::COLOR_BGR2GRAY);
     cv::resize(gray, resized, {64, 64}, 0, 0, cv::INTER_AREA);
     resized.convertTo(resized, CV_64F);
     resized /= 255.0;
 
-    cv::Mat hash(1, 40, CV_64F);
+    cv::Mat h(1, 40, CV_64F);
     const double cx = 32.0, cy = 32.0, radius = 32.0;
 
     for (int i = 0; i < 40; ++i) {
@@ -139,24 +142,24 @@ cv::Mat RadialVarianceHash::operator()(const Image<BGR>& img) const {
         double var = 0;
         for (double v : samples) var += (v - mean) * (v - mean);
         var /= static_cast<double>(samples.size());
-        hash.at<double>(0, i) = var;
+        h.at<double>(0, i) = var;
     }
-    return hash;
+    return ImageHash{std::move(h)};
 }
-double RadialVarianceHash::distance(const cv::Mat& a, const cv::Mat& b) {
-    return cv::norm(a, b, cv::NORM_L2);
+double RadialVarianceHash::distance(const ImageHash& a, const ImageHash& b) {
+    return cv::norm(a.value, b.value, cv::NORM_L2);
 }
 
 // ── ColorMomentHash ───────────────────────────────────────────────────────────
 // Compute 14 statistical values per channel of YCrCb (3 × 14 = 42).
 // Result: 1×42 CV_64F. Distance: L2 norm.
 
-cv::Mat ColorMomentHash::operator()(const Image<BGR>& img) const {
+ImageHash ColorMomentHash::operator()(const Image<BGR>& img) const {
     cv::Mat resized, ycrcb;
     cv::resize(img.mat(), resized, {16, 16}, 0, 0, cv::INTER_AREA);
     cv::cvtColor(resized, ycrcb, cv::COLOR_BGR2YCrCb);
 
-    cv::Mat hash(1, 42, CV_64F, cv::Scalar(0));
+    cv::Mat h(1, 42, CV_64F, cv::Scalar(0));
     std::vector<cv::Mat> channels;
     cv::split(ycrcb, channels);
 
@@ -196,26 +199,26 @@ cv::Mat ColorMomentHash::operator()(const Image<BGR>& img) const {
         hist /= static_cast<float>(n);
 
         int base = ch * 14;
-        hash.at<double>(0, base + 0) = mu;
-        hash.at<double>(0, base + 1) = sigma;
-        hash.at<double>(0, base + 2) = (sigma > 1e-10) ? m3 / s3 : 0.0;
-        hash.at<double>(0, base + 3) = (sigma > 1e-10) ? m4 / s4 : 0.0;
-        hash.at<double>(0, base + 4) = m5;
-        hash.at<double>(0, base + 5) = m6;
+        h.at<double>(0, base + 0) = mu;
+        h.at<double>(0, base + 1) = sigma;
+        h.at<double>(0, base + 2) = (sigma > 1e-10) ? m3 / s3 : 0.0;
+        h.at<double>(0, base + 3) = (sigma > 1e-10) ? m4 / s4 : 0.0;
+        h.at<double>(0, base + 4) = m5;
+        h.at<double>(0, base + 5) = m6;
         for (int b = 0; b < 8; ++b)
-            hash.at<double>(0, base + 6 + b) = hist.at<float>(b);
+            h.at<double>(0, base + 6 + b) = hist.at<float>(b);
     }
-    return hash;
+    return ImageHash{std::move(h)};
 }
-double ColorMomentHash::distance(const cv::Mat& a, const cv::Mat& b) {
-    return cv::norm(a, b, cv::NORM_L2);
+double ColorMomentHash::distance(const ImageHash& a, const ImageHash& b) {
+    return cv::norm(a.value, b.value, cv::NORM_L2);
 }
 
 // ── BlockMeanHash ─────────────────────────────────────────────────────────────
 // Resize to 256×256, divide into 16×16 blocks of 16×16 pixels.
 // Bit = block mean > overall mean. 256 bits = 32 bytes.
 
-cv::Mat BlockMeanHash::operator()(const Image<BGR>& img) const {
+ImageHash BlockMeanHash::operator()(const Image<BGR>& img) const {
     cv::Mat gray, resized;
     cv::cvtColor(img.mat(), gray, cv::COLOR_BGR2GRAY);
     cv::resize(gray, resized, {256, 256}, 0, 0, cv::INTER_AREA);
@@ -231,10 +234,11 @@ cv::Mat BlockMeanHash::operator()(const Image<BGR>& img) const {
             bits.push_back(cv::mean(block)[0] > overall_mean);
         }
     }
-    return pack_bits(bits);
+    cv::Mat h = pack_bits(bits);
+    return ImageHash{std::move(h)};
 }
-double BlockMeanHash::distance(const cv::Mat& a, const cv::Mat& b) {
-    return hamming(a, b);
+double BlockMeanHash::distance(const ImageHash& a, const ImageHash& b) {
+    return hamming(a.value, b.value);
 }
 
 } // namespace improc::core

--- a/src/core/ops/optical_flow.cpp
+++ b/src/core/ops/optical_flow.cpp
@@ -11,7 +11,7 @@ SparseLKFlowResult SparseLKFlow::operator()(const Image<Gray>& prev,
     if (prev_pts.empty())
         throw improc::ParameterError{"prev_pts", "must not be empty", "SparseLKFlow"};
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw improc::ParameterError{"prev", "prev and next must have the same size", "SparseLKFlow"};
+        throw improc::ParameterError{"prev", "must be the same size as next", "SparseLKFlow"};
 
     SparseLKFlowResult result;
     cv::calcOpticalFlowPyrLK(
@@ -26,7 +26,7 @@ SparseLKFlowResult SparseLKFlow::operator()(const Image<Gray>& prev,
 Image<Flow> DenseFarnebackFlow::operator()(const Image<Gray>& prev,
                                             const Image<Gray>& next) const {
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw improc::ParameterError{"prev", "prev and next must have the same size", "DenseFarnebackFlow"};
+        throw improc::ParameterError{"prev", "must be the same size as next", "DenseFarnebackFlow"};
     cv::Mat flow;
     cv::calcOpticalFlowFarneback(prev.mat(), next.mat(), flow,
                                   pyr_scale_, levels_, win_size_,
@@ -37,7 +37,7 @@ Image<Flow> DenseFarnebackFlow::operator()(const Image<Gray>& prev,
 Image<Flow> DenseDISFlow::operator()(const Image<Gray>& prev,
                                       const Image<Gray>& next) const {
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw improc::ParameterError{"prev", "prev and next must have the same size", "DenseDISFlow"};
+        throw improc::ParameterError{"prev", "must be the same size as next", "DenseDISFlow"};
     int preset_flag;
     switch (preset_) {
         case Preset::UltraFast: preset_flag = cv::DISOpticalFlow::PRESET_ULTRAFAST; break;

--- a/src/core/ops/optical_flow.cpp
+++ b/src/core/ops/optical_flow.cpp
@@ -1,5 +1,6 @@
 // src/core/ops/optical_flow.cpp
 #include "improc/core/ops/optical_flow.hpp"
+#include "improc/exceptions.hpp"
 #include <stdexcept>
 
 namespace improc::core {
@@ -8,9 +9,9 @@ SparseLKFlowResult SparseLKFlow::operator()(const Image<Gray>& prev,
                                              const Image<Gray>& next,
                                              const std::vector<cv::Point2f>& prev_pts) const {
     if (prev_pts.empty())
-        throw std::invalid_argument("SparseLKFlow: prev_pts must not be empty");
+        throw improc::ParameterError{"prev_pts", "must not be empty", "SparseLKFlow"};
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw std::invalid_argument("SparseLKFlow: prev and next must have the same size");
+        throw improc::ParameterError{"prev", "prev and next must have the same size", "SparseLKFlow"};
 
     SparseLKFlowResult result;
     cv::calcOpticalFlowPyrLK(
@@ -25,7 +26,7 @@ SparseLKFlowResult SparseLKFlow::operator()(const Image<Gray>& prev,
 Image<Flow> DenseFarnebackFlow::operator()(const Image<Gray>& prev,
                                             const Image<Gray>& next) const {
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw std::invalid_argument("DenseFarnebackFlow: prev and next must have the same size");
+        throw improc::ParameterError{"prev", "prev and next must have the same size", "DenseFarnebackFlow"};
     cv::Mat flow;
     cv::calcOpticalFlowFarneback(prev.mat(), next.mat(), flow,
                                   pyr_scale_, levels_, win_size_,
@@ -36,7 +37,7 @@ Image<Flow> DenseFarnebackFlow::operator()(const Image<Gray>& prev,
 Image<Flow> DenseDISFlow::operator()(const Image<Gray>& prev,
                                       const Image<Gray>& next) const {
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw std::invalid_argument("DenseDISFlow: prev and next must have the same size");
+        throw improc::ParameterError{"prev", "prev and next must have the same size", "DenseDISFlow"};
     int preset_flag;
     switch (preset_) {
         case Preset::UltraFast: preset_flag = cv::DISOpticalFlow::PRESET_ULTRAFAST; break;

--- a/src/core/ops/phase_correlate.cpp
+++ b/src/core/ops/phase_correlate.cpp
@@ -7,7 +7,7 @@ namespace improc::core {
 PhaseCorrelateResult PhaseCorrelate::operator()(const Image<Float32>& prev,
                                                  const Image<Float32>& next) const {
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw improc::ParameterError{"prev", "prev and next must have the same size", "PhaseCorrelate"};
+        throw improc::ParameterError{"prev", "must be the same size as next", "PhaseCorrelate"};
     cv::Mat hann;
     cv::createHanningWindow(hann, prev.mat().size(), CV_32F);
     double response;

--- a/src/core/ops/phase_correlate.cpp
+++ b/src/core/ops/phase_correlate.cpp
@@ -1,12 +1,13 @@
 // src/core/ops/phase_correlate.cpp
 #include "improc/core/ops/phase_correlate.hpp"
+#include "improc/exceptions.hpp"
 
 namespace improc::core {
 
 PhaseCorrelateResult PhaseCorrelate::operator()(const Image<Float32>& prev,
                                                  const Image<Float32>& next) const {
     if (prev.rows() != next.rows() || prev.cols() != next.cols())
-        throw std::invalid_argument("PhaseCorrelate: prev and next must have the same size");
+        throw improc::ParameterError{"prev", "prev and next must have the same size", "PhaseCorrelate"};
     cv::Mat hann;
     cv::createHanningWindow(hann, prev.mat().size(), CV_32F);
     double response;

--- a/src/core/ops/tracking.cpp
+++ b/src/core/ops/tracking.cpp
@@ -1,5 +1,6 @@
 // src/core/ops/tracking.cpp
 #include "improc/core/ops/tracking.hpp"
+#include "improc/exceptions.hpp"
 #include <stdexcept>
 
 namespace improc::core {
@@ -9,7 +10,7 @@ void check_window(const cv::Rect& window, int rows, int cols) {
     if (window.x < 0 || window.y < 0 ||
         window.x + window.width  > cols ||
         window.y + window.height > rows)
-        throw std::invalid_argument("CamShift/MeanShift: window is outside image bounds");
+        throw improc::ParameterError{"window", "is outside image bounds", "CamShift/MeanShift"};
 }
 } // namespace
 

--- a/src/core/ops/tracking.cpp
+++ b/src/core/ops/tracking.cpp
@@ -1,7 +1,6 @@
 // src/core/ops/tracking.cpp
 #include "improc/core/ops/tracking.hpp"
 #include "improc/exceptions.hpp"
-#include <stdexcept>
 
 namespace improc::core {
 
@@ -10,7 +9,7 @@ void check_window(const cv::Rect& window, int rows, int cols) {
     if (window.x < 0 || window.y < 0 ||
         window.x + window.width  > cols ||
         window.y + window.height > rows)
-        throw improc::ParameterError{"window", "is outside image bounds", "CamShift/MeanShift"};
+        throw improc::ParameterError{"window", "is outside image bounds", "Tracking"};
 }
 } // namespace
 

--- a/src/core/ops/watershed.cpp
+++ b/src/core/ops/watershed.cpp
@@ -1,14 +1,15 @@
 // src/core/ops/watershed.cpp
 #include "improc/core/ops/watershed.hpp"
+#include "improc/exceptions.hpp"
 #include <stdexcept>
 
 namespace improc::core {
 
 void Watershed::operator()(const Image<BGR>& img, cv::Mat& markers) const {
     if (markers.type() != CV_32SC1)
-        throw std::invalid_argument("Watershed: markers must be CV_32SC1");
+        throw improc::ParameterError{"markers", "must be CV_32SC1", "Watershed"};
     if (markers.size() != img.mat().size())
-        throw std::invalid_argument("Watershed: markers size must match image size");
+        throw improc::ParameterError{"markers", "size must match image size", "Watershed"};
     cv::watershed(img.mat(), markers);
 }
 

--- a/src/core/ops/watershed.cpp
+++ b/src/core/ops/watershed.cpp
@@ -1,7 +1,6 @@
 // src/core/ops/watershed.cpp
 #include "improc/core/ops/watershed.hpp"
 #include "improc/exceptions.hpp"
-#include <stdexcept>
 
 namespace improc::core {
 

--- a/src/ml/dataset.cpp
+++ b/src/ml/dataset.cpp
@@ -101,7 +101,7 @@ std::string Dataset::class_name_for(int label) const {
     return "<unknown>";
 }
 
-void Dataset::set_shuffle_seed(unsigned int seed) {
+void Dataset::shuffle_seed(unsigned int seed) {
     shuffle_seed_ = seed;
 }
 

--- a/src/ml/segmentation_eval.cpp
+++ b/src/ml/segmentation_eval.cpp
@@ -1,5 +1,6 @@
 // src/ml/segmentation_eval.cpp
 #include "improc/ml/eval/segmentation.hpp"
+#include "improc/exceptions.hpp"
 #include <stdexcept>
 
 namespace improc::ml {
@@ -8,7 +9,7 @@ float pixel_iou(const Image<Gray>& pred, const Image<Gray>& gt, int class_id) {
     const auto& pm = pred.mat();
     const auto& gm = gt.mat();
     if (pm.rows != gm.rows || pm.cols != gm.cols)
-        throw std::invalid_argument("pixel_iou: pred and gt dimensions must match");
+        throw improc::ParameterError{"pred", "pred and gt dimensions must match", "pixel_iou"};
     int64_t tp = 0, fp = 0, fn = 0;
     for (int r = 0; r < pm.rows; ++r) {
         for (int c = 0; c < pm.cols; ++c) {
@@ -30,7 +31,7 @@ float dice(const Image<Gray>& pred, const Image<Gray>& gt, int class_id) {
     const auto& pm = pred.mat();
     const auto& gm = gt.mat();
     if (pm.rows != gm.rows || pm.cols != gm.cols)
-        throw std::invalid_argument("dice: pred and gt dimensions must match");
+        throw improc::ParameterError{"pred", "pred and gt dimensions must match", "dice"};
     int64_t tp = 0, fp = 0, fn = 0;
     for (int r = 0; r < pm.rows; ++r) {
         for (int c = 0; c < pm.cols; ++c) {
@@ -52,7 +53,7 @@ void SegEval::update(const Image<Gray>& pred, const Image<Gray>& gt) {
     if (num_classes_ <= 0)
         throw std::runtime_error("SegEval: call num_classes() before update()");
     if (pred.mat().rows != gt.mat().rows || pred.mat().cols != gt.mat().cols)
-        throw std::invalid_argument("SegEval: pred and gt dimensions must match");
+        throw improc::ParameterError{"pred", "pred and gt dimensions must match", "SegEval"};
     const auto& pm = pred.mat();
     const auto& gm = gt.mat();
     for (int r = 0; r < pm.rows; ++r) {

--- a/src/visualization/draw_contours.cpp
+++ b/src/visualization/draw_contours.cpp
@@ -1,0 +1,14 @@
+// src/visualization/draw_contours.cpp
+#include "improc/visualization/draw_contours.hpp"
+#include <opencv2/imgproc.hpp>
+
+namespace improc::visualization {
+
+Image<BGR> DrawContours::operator()(Image<BGR> img) const {
+    cv::Mat dst = img.mat().clone();
+    cv::drawContours(dst, cs_.contours, index_, color_, thickness_,
+                     cv::LINE_AA, cs_.hierarchy);
+    return Image<BGR>(std::move(dst));
+}
+
+} // namespace improc::visualization

--- a/src/visualization/draw_matches.cpp
+++ b/src/visualization/draw_matches.cpp
@@ -1,7 +1,7 @@
-// src/core/ops/draw_matches.cpp
-#include "improc/core/ops/draw_matches.hpp"
+// src/visualization/draw_matches.cpp
+#include "improc/visualization/draw_matches.hpp"
 
-namespace improc::core {
+namespace improc::visualization {
 
 Image<BGR> DrawKeypoints::operator()(Image<Gray> img) const {
     cv::Mat out;
@@ -27,4 +27,4 @@ Image<BGR> DrawMatches::operator()() const {
     return Image<BGR>(std::move(out));
 }
 
-} // namespace improc::core
+} // namespace improc::visualization

--- a/tests/calib/test_aruco.cpp
+++ b/tests/calib/test_aruco.cpp
@@ -70,12 +70,12 @@ TEST(GenerateArucoTest, OutputIsGray) {
 
 TEST(GenerateArucoTest, ThrowsOnNegativeId) {
     auto dict = make_dict();
-    EXPECT_THROW(GenerateAruco{}(dict, -1, 100), std::invalid_argument);
+    EXPECT_THROW(GenerateAruco{}(dict, -1, 100), improc::ParameterError);
 }
 
 TEST(GenerateArucoTest, ThrowsOnZeroSidePixels) {
     auto dict = make_dict();
-    EXPECT_THROW(GenerateAruco{}(dict, 0, 0), std::invalid_argument);
+    EXPECT_THROW(GenerateAruco{}(dict, 0, 0), improc::ParameterError);
 }
 
 // ── DetectAruco ───────────────────────────────────────────────────────────────
@@ -255,7 +255,7 @@ TEST(CharucoBoardTest, ThrowsIfBoardSizeNotSet) {
     Image<BGR> img(scene);
     EXPECT_THROW(
         CharucoBoard{}.square_length(kSquareLen).marker_length(kMarkerLen)(img, dict),
-        std::invalid_argument);
+        improc::ParameterError);
 }
 
 TEST(CharucoBoardTest, ThrowsIfSquareLengthZero) {
@@ -264,7 +264,7 @@ TEST(CharucoBoardTest, ThrowsIfSquareLengthZero) {
     Image<BGR> img(scene);
     EXPECT_THROW(
         CharucoBoard{}.board_size(kBoardSize).square_length(0.f).marker_length(kMarkerLen)(img, dict),
-        std::invalid_argument);
+        improc::ParameterError);
 }
 
 TEST(CharucoBoardTest, ThrowsIfMarkerLengthZero) {
@@ -273,5 +273,5 @@ TEST(CharucoBoardTest, ThrowsIfMarkerLengthZero) {
     Image<BGR> img(scene);
     EXPECT_THROW(
         CharucoBoard{}.board_size(kBoardSize).square_length(kSquareLen).marker_length(0.f)(img, dict),
-        std::invalid_argument);
+        improc::ParameterError);
 }

--- a/tests/calib/test_calibrate.cpp
+++ b/tests/calib/test_calibrate.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include "improc/calib/pipeline.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::calib;
 
@@ -90,15 +91,15 @@ TEST(MakeChessboardPointsTest, FirstPointIsOrigin) {
 }
 
 TEST(MakeChessboardPointsTest, ThrowsOnZeroWidth) {
-    EXPECT_THROW(make_chessboard_points({0, 6}, 25.f), std::invalid_argument);
+    EXPECT_THROW(make_chessboard_points({0, 6}, 25.f), improc::ParameterError);
 }
 
 TEST(MakeChessboardPointsTest, ThrowsOnNegativeDimension) {
-    EXPECT_THROW(make_chessboard_points({9, -1}, 25.f), std::invalid_argument);
+    EXPECT_THROW(make_chessboard_points({9, -1}, 25.f), improc::ParameterError);
 }
 
 TEST(MakeChessboardPointsTest, ThrowsOnNonPositiveSquareSize) {
-    EXPECT_THROW(make_chessboard_points({9, 6}, 0.f), std::invalid_argument);
+    EXPECT_THROW(make_chessboard_points({9, 6}, 0.f), improc::ParameterError);
 }
 
 // ── CalibrateCamera ──────────────────────────────────────────────────────────
@@ -108,14 +109,14 @@ TEST(CalibrateCameraTest, ThrowsOnMismatchedVectorSizes) {
     auto obj = data.obj_pts;
     auto img = data.img_pts;
     img.pop_back();
-    EXPECT_THROW(CalibrateCamera{}(obj, img, data.image_size), std::invalid_argument);
+    EXPECT_THROW(CalibrateCamera{}(obj, img, data.image_size), improc::ParameterError);
 }
 
 TEST(CalibrateCameraTest, ThrowsOnFewerThanThreeViews) {
     auto data = make_calib_data();
     std::vector<std::vector<cv::Point3f>> obj2 = {data.obj_pts[0], data.obj_pts[1]};
     std::vector<std::vector<cv::Point2f>> img2 = {data.img_pts[0], data.img_pts[1]};
-    EXPECT_THROW(CalibrateCamera{}(obj2, img2, data.image_size), std::invalid_argument);
+    EXPECT_THROW(CalibrateCamera{}(obj2, img2, data.image_size), improc::ParameterError);
 }
 
 TEST(CalibrateCameraTest, ResultStructIsPopulated) {
@@ -147,5 +148,5 @@ TEST(CalibrateCameraTest, RecoveredFocalLengthCloseToGroundTruth) {
 TEST(CalibrateCameraTest, ThrowsOnZeroImageSize) {
     auto data = make_calib_data();
     EXPECT_THROW(CalibrateCamera{}(data.obj_pts, data.img_pts, {0, 0}),
-                 std::invalid_argument);
+                 improc::ParameterError);
 }

--- a/tests/calib/test_chessboard.cpp
+++ b/tests/calib/test_chessboard.cpp
@@ -51,7 +51,7 @@ TEST(FindChessboardCornersTest, WorksOnBGRInput) {
 
 TEST(FindChessboardCornersTest, ThrowsWhenBoardSizeNotSet) {
     EXPECT_THROW(make_chessboard_img({9, 6}) | FindChessboardCorners{},
-                 std::invalid_argument);
+                 improc::ParameterError);
 }
 
 TEST(FindChessboardCornersTest, FluentBoardSizeReturnsThis) {
@@ -84,7 +84,7 @@ TEST(FindChessboardCornersSBTest, WorksOnBGRInput) {
 
 TEST(FindChessboardCornersSBTest, ThrowsWhenBoardSizeNotSet) {
     EXPECT_THROW(make_chessboard_img({9, 6}) | FindChessboardCornersSB{},
-                 std::invalid_argument);
+                 improc::ParameterError);
 }
 
 TEST(FindChessboardCornersSBTest, FluentBoardSizeReturnsThis) {

--- a/tests/calib/test_epipolar.cpp
+++ b/tests/calib/test_epipolar.cpp
@@ -53,12 +53,12 @@ TEST(FindFundamentalMatTest, ThrowsOnSizeMismatch) {
     auto pts1 = project(scene, K, rvec1, tvec1);
     auto pts2 = project(scene, K, rvec1, tvec2);
     pts2.pop_back();
-    EXPECT_THROW(FindFundamentalMat{}(pts1, pts2), std::invalid_argument);
+    EXPECT_THROW(FindFundamentalMat{}(pts1, pts2), improc::ParameterError);
 }
 
 TEST(FindFundamentalMatTest, ThrowsOnFewerThanEightPoints) {
     std::vector<cv::Point2f> pts(7, {1.f, 1.f});
-    EXPECT_THROW(FindFundamentalMat{}(pts, pts), std::invalid_argument);
+    EXPECT_THROW(FindFundamentalMat{}(pts, pts), improc::ParameterError);
 }
 
 TEST(FindFundamentalMatTest, FIsThreeByThree) {
@@ -115,12 +115,12 @@ TEST(FindEssentialMatTest, ThrowsOnSizeMismatch) {
     auto pts1 = project(scene, K, rvec, tvec1);
     auto pts2 = project(scene, K, rvec, tvec2);
     pts2.pop_back();
-    EXPECT_THROW(FindEssentialMat{}(pts1, pts2, K), std::invalid_argument);
+    EXPECT_THROW(FindEssentialMat{}(pts1, pts2, K), improc::ParameterError);
 }
 
 TEST(FindEssentialMatTest, ThrowsOnFewerThanFivePoints) {
     std::vector<cv::Point2f> pts(4, {1.f, 1.f});
-    EXPECT_THROW(FindEssentialMat{}(pts, pts, make_K()), std::invalid_argument);
+    EXPECT_THROW(FindEssentialMat{}(pts, pts, make_K()), improc::ParameterError);
 }
 
 TEST(FindEssentialMatTest, EIsThreeByThree) {

--- a/tests/calib/test_fisheye.cpp
+++ b/tests/calib/test_fisheye.cpp
@@ -1,0 +1,229 @@
+// tests/calib/test_fisheye.cpp
+#include <gtest/gtest.h>
+#include <vector>
+#include <opencv2/calib3d.hpp>
+#include "improc/calib/pipeline.hpp"
+
+using namespace improc::calib;
+using improc::core::BGR;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static void make_fisheye_calib_data(
+    std::vector<std::vector<cv::Point3f>>& obj_pts,
+    std::vector<std::vector<cv::Point2f>>& img_pts,
+    cv::Mat& true_K, cv::Mat& true_D,
+    cv::Size& image_size)
+{
+    constexpr int W = 5, H = 5;
+    constexpr float S = 30.0f;
+    std::vector<cv::Point3f> board;
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c)
+            board.push_back({c * S, r * S, 0.0f});
+
+    image_size = {640, 480};
+    true_K = (cv::Mat_<double>(3,3) << 300,0,320, 0,300,240, 0,0,1);
+    true_D = (cv::Mat_<double>(4,1) << 0.01, 0.005, 0.001, 0.001);
+
+    for (int v = 0; v < 5; ++v) {
+        cv::Mat rvec = (cv::Mat_<double>(3,1) << 0.1*v, 0.05*v, 0.0);
+        cv::Mat tvec = (cv::Mat_<double>(3,1) << -60 + 30*v, -30, 500);
+        std::vector<cv::Point2f> proj;
+        cv::fisheye::projectPoints(board, proj, rvec, tvec, true_K, true_D);
+        obj_pts.push_back(board);
+        img_pts.push_back(proj);
+    }
+}
+
+static void make_fisheye_stereo_data(
+    std::vector<std::vector<cv::Point3f>>& obj_pts,
+    std::vector<std::vector<cv::Point2f>>& left_pts,
+    std::vector<std::vector<cv::Point2f>>& right_pts,
+    cv::Mat& K1, cv::Mat& D1,
+    cv::Mat& K2, cv::Mat& D2,
+    cv::Size& image_size)
+{
+    constexpr int W = 5, H = 5;
+    constexpr float S = 30.0f;
+    std::vector<cv::Point3f> board;
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c)
+            board.push_back({c * S, r * S, 0.0f});
+
+    image_size = {640, 480};
+    K1 = (cv::Mat_<double>(3,3) << 300,0,320, 0,300,240, 0,0,1);
+    D1 = (cv::Mat_<double>(4,1) << 0.01, 0.005, 0.001, 0.001);
+    K2 = (cv::Mat_<double>(3,3) << 300,0,320, 0,300,240, 0,0,1);
+    D2 = (cv::Mat_<double>(4,1) << 0.01, 0.005, 0.001, 0.001);
+
+    // Baseline: right camera is shifted 60 mm in X
+    const double baseline = 60.0;
+    for (int v = 0; v < 5; ++v) {
+        cv::Mat rvec  = (cv::Mat_<double>(3,1) << 0.1*v, 0.05*v, 0.0);
+        cv::Mat tvec1 = (cv::Mat_<double>(3,1) << -60 + 30*v, -30, 500);
+        cv::Mat tvec2 = (cv::Mat_<double>(3,1) << -60 + 30*v + baseline, -30, 500);
+
+        std::vector<cv::Point2f> lp, rp;
+        cv::fisheye::projectPoints(board, lp, rvec, tvec1, K1, D1);
+        cv::fisheye::projectPoints(board, rp, rvec, tvec2, K2, D2);
+        obj_pts.push_back(board);
+        left_pts.push_back(lp);
+        right_pts.push_back(rp);
+    }
+}
+
+// ── FisheyeCalibrate ──────────────────────────────────────────────────────────
+
+TEST(FisheyeCalibrateTest, ReturnsCalibrationResult) {
+    std::vector<std::vector<cv::Point3f>> obj_pts;
+    std::vector<std::vector<cv::Point2f>> img_pts;
+    cv::Mat K, D;
+    cv::Size sz;
+    make_fisheye_calib_data(obj_pts, img_pts, K, D, sz);
+
+    CalibrationResult result = FisheyeCalibrate{}(obj_pts, img_pts, sz);
+    EXPECT_FALSE(result.camera_matrix.empty());
+    EXPECT_FALSE(result.dist_coeffs.empty());
+    EXPECT_GT(result.rvecs.size(), 0u);
+    EXPECT_LT(result.rms, 5.0);
+}
+
+TEST(FisheyeCalibrateTest, FluentSettersReturnThis) {
+    FisheyeCalibrate op;
+    EXPECT_EQ(&op.flags(cv::fisheye::CALIB_FIX_SKEW), &op);
+    EXPECT_EQ(&op.criteria(cv::TermCriteria{}), &op);
+}
+
+// ── FisheyeUndistort ──────────────────────────────────────────────────────────
+
+TEST(FisheyeUndistortTest, OutputSameSize) {
+    cv::Mat K = (cv::Mat_<double>(3,3) << 300,0,320, 0,300,240, 0,0,1);
+    cv::Mat D = (cv::Mat_<double>(4,1) << 0.01, 0.005, 0.001, 0.001);
+    cv::Mat m(480, 640, CV_8UC3, cv::Scalar(128, 64, 32));
+    Image<BGR> img(m);
+    Image<BGR> result = FisheyeUndistort{}.K(K).dist(D)(img);
+    EXPECT_EQ(result.rows(), 480);
+    EXPECT_EQ(result.cols(), 640);
+}
+
+TEST(FisheyeUndistortTest, FluentSettersReturnThis) {
+    FisheyeUndistort op;
+    cv::Mat m;
+    EXPECT_EQ(&op.K(m), &op);
+    EXPECT_EQ(&op.dist(m), &op);
+    EXPECT_EQ(&op.new_K(m), &op);
+}
+
+// ── FisheyeUndistortPoints ────────────────────────────────────────────────────
+
+TEST(FisheyeUndistortPointsTest, ReturnsCorrectCount) {
+    cv::Mat K = (cv::Mat_<double>(3,3) << 300,0,320, 0,300,240, 0,0,1);
+    cv::Mat D = (cv::Mat_<double>(4,1) << 0.01, 0.005, 0.001, 0.001);
+    std::vector<cv::Point2f> pts = {{100.f, 100.f}, {200.f, 200.f}, {320.f, 240.f}};
+    auto result = FisheyeUndistortPoints{}.K(K).dist(D)(pts);
+    EXPECT_EQ(result.size(), 3u);
+}
+
+TEST(FisheyeUndistortPointsTest, FluentSettersReturnThis) {
+    FisheyeUndistortPoints op;
+    cv::Mat m;
+    EXPECT_EQ(&op.K(m), &op);
+    EXPECT_EQ(&op.dist(m), &op);
+    EXPECT_EQ(&op.R(m), &op);
+    EXPECT_EQ(&op.P(m), &op);
+}
+
+// ── FisheyeInitRectifyMap ─────────────────────────────────────────────────────
+
+TEST(FisheyeInitRectifyMapTest, ProducesNonEmptyMaps) {
+    cv::Mat K = (cv::Mat_<double>(3,3) << 300,0,320, 0,300,240, 0,0,1);
+    cv::Mat D = (cv::Mat_<double>(4,1) << 0.01, 0.005, 0.001, 0.001);
+    cv::Mat R = cv::Mat::eye(3, 3, CV_64F);
+    UndistortMapResult maps = FisheyeInitRectifyMap{}.K(K).dist(D).R(R).new_K(K)(cv::Size{640,480});
+    EXPECT_FALSE(maps.map1.empty());
+    EXPECT_FALSE(maps.map2.empty());
+    EXPECT_EQ(maps.map1.size(), maps.map2.size());
+}
+
+TEST(FisheyeInitRectifyMapTest, MapsHaveCorrectSize) {
+    cv::Mat K = (cv::Mat_<double>(3,3) << 300,0,320, 0,300,240, 0,0,1);
+    cv::Mat D = (cv::Mat_<double>(4,1) << 0.01, 0.005, 0.001, 0.001);
+    cv::Size sz{640, 480};
+    UndistortMapResult maps = FisheyeInitRectifyMap{}.K(K).dist(D)(sz);
+    EXPECT_EQ(maps.map1.rows, sz.height);
+    EXPECT_EQ(maps.map1.cols, sz.width);
+}
+
+TEST(FisheyeInitRectifyMapTest, FluentSettersReturnThis) {
+    FisheyeInitRectifyMap op;
+    cv::Mat m;
+    EXPECT_EQ(&op.K(m), &op);
+    EXPECT_EQ(&op.dist(m), &op);
+    EXPECT_EQ(&op.R(m), &op);
+    EXPECT_EQ(&op.new_K(m), &op);
+}
+
+// ── FisheyeStereoCalibrate ────────────────────────────────────────────────────
+
+TEST(FisheyeStereoCalibrateTest, ReturnsPopulatedResult) {
+    std::vector<std::vector<cv::Point3f>> obj_pts;
+    std::vector<std::vector<cv::Point2f>> left_pts, right_pts;
+    cv::Mat K1, D1, K2, D2;
+    cv::Size sz;
+    make_fisheye_stereo_data(obj_pts, left_pts, right_pts, K1, D1, K2, D2, sz);
+
+    StereoCalibrationResult result = FisheyeStereoCalibrate{}
+        .K1(K1).dist1(D1).K2(K2).dist2(D2)
+        .flags(cv::fisheye::CALIB_FIX_INTRINSIC)
+        (obj_pts, left_pts, right_pts, sz);
+
+    EXPECT_FALSE(result.K1.empty());
+    EXPECT_FALSE(result.K2.empty());
+    EXPECT_FALSE(result.R.empty());
+    EXPECT_FALSE(result.T.empty());
+    EXPECT_LT(result.rms, 5.0);
+}
+
+TEST(FisheyeStereoCalibrateTest, FluentSettersReturnThis) {
+    FisheyeStereoCalibrate op;
+    cv::Mat m;
+    EXPECT_EQ(&op.K1(m), &op);
+    EXPECT_EQ(&op.dist1(m), &op);
+    EXPECT_EQ(&op.K2(m), &op);
+    EXPECT_EQ(&op.dist2(m), &op);
+    EXPECT_EQ(&op.flags(0), &op);
+}
+
+// ── FisheyeStereoRectify ──────────────────────────────────────────────────────
+
+TEST(FisheyeStereoRectifyTest, ProducesCorrectShapes) {
+    std::vector<std::vector<cv::Point3f>> obj_pts;
+    std::vector<std::vector<cv::Point2f>> left_pts, right_pts;
+    cv::Mat K1, D1, K2, D2;
+    cv::Size sz;
+    make_fisheye_stereo_data(obj_pts, left_pts, right_pts, K1, D1, K2, D2, sz);
+
+    StereoCalibrationResult cal = FisheyeStereoCalibrate{}
+        .K1(K1).dist1(D1).K2(K2).dist2(D2)
+        .flags(cv::fisheye::CALIB_FIX_INTRINSIC)
+        (obj_pts, left_pts, right_pts, sz);
+
+    StereoRectifyResult rect = FisheyeStereoRectify{}
+        .image_size(sz)
+        (cal.K1, cal.dist1, cal.K2, cal.dist2, cal.R, cal.T);
+
+    EXPECT_EQ(rect.R1.rows, 3);  EXPECT_EQ(rect.R1.cols, 3);
+    EXPECT_EQ(rect.R2.rows, 3);  EXPECT_EQ(rect.R2.cols, 3);
+    EXPECT_EQ(rect.P1.rows, 3);  EXPECT_EQ(rect.P1.cols, 4);
+    EXPECT_EQ(rect.P2.rows, 3);  EXPECT_EQ(rect.P2.cols, 4);
+    EXPECT_EQ(rect.Q.rows, 4);   EXPECT_EQ(rect.Q.cols, 4);
+}
+
+TEST(FisheyeStereoRectifyTest, FluentSettersReturnThis) {
+    FisheyeStereoRectify op;
+    EXPECT_EQ(&op.image_size({640,480}), &op);
+    EXPECT_EQ(&op.flags(cv::CALIB_ZERO_DISPARITY), &op);
+    EXPECT_EQ(&op.balance(0.5), &op);
+    EXPECT_EQ(&op.fov_scale(1.0), &op);
+}

--- a/tests/calib/test_project.cpp
+++ b/tests/calib/test_project.cpp
@@ -41,7 +41,7 @@ TEST(ProjectPointsTest, PointsWithinReasonableBounds) {
 
 TEST(ProjectPointsTest, ThrowsOnEmptyObjectPoints) {
     EXPECT_THROW(ProjectPoints{}({}, make_rvec(), make_tvec(), make_K(), zero_dist()),
-                 std::invalid_argument);
+                 improc::ParameterError);
 }
 
 // ── SolvePnP ─────────────────────────────────────────────────────────────────
@@ -79,7 +79,7 @@ TEST(SolvePnPTest, RoundTripReprojectionErrorLessThanOnePixel) {
 TEST(SolvePnPTest, ThrowsOnFewerThanFourPoints) {
     std::vector<cv::Point3f> obj3 = {{0,0,0},{1,0,0},{0,1,0}};
     std::vector<cv::Point2f> img3 = {{100,100},{200,100},{100,200}};
-    EXPECT_THROW(SolvePnP{}(obj3, img3, make_K(), zero_dist()), std::invalid_argument);
+    EXPECT_THROW(SolvePnP{}(obj3, img3, make_K(), zero_dist()), improc::ParameterError);
 }
 
 TEST(SolvePnPTest, ThrowsOnMismatchedSizes) {
@@ -87,7 +87,7 @@ TEST(SolvePnPTest, ThrowsOnMismatchedSizes) {
     std::vector<cv::Point2f> img_pts;
     cv::projectPoints(obj, make_rvec(), make_tvec(), make_K(), zero_dist(), img_pts);
     img_pts.pop_back();
-    EXPECT_THROW(SolvePnP{}(obj, img_pts, make_K(), zero_dist()), std::invalid_argument);
+    EXPECT_THROW(SolvePnP{}(obj, img_pts, make_K(), zero_dist()), improc::ParameterError);
 }
 
 TEST(SolvePnPTest, FluentMethodReturnsThis) {
@@ -139,11 +139,11 @@ TEST(SolvePnPRansacTest, ThrowsOnMismatchedSizes) {
     std::vector<cv::Point2f> img_pts;
     cv::projectPoints(obj, make_rvec(), make_tvec(), make_K(), zero_dist(), img_pts);
     img_pts.pop_back();
-    EXPECT_THROW(SolvePnPRansac{}(obj, img_pts, make_K(), zero_dist()), std::invalid_argument);
+    EXPECT_THROW(SolvePnPRansac{}(obj, img_pts, make_K(), zero_dist()), improc::ParameterError);
 }
 
 TEST(SolvePnPRansacTest, ThrowsOnFewerThanFourPoints) {
     std::vector<cv::Point3f> obj3 = {{0,0,0},{1,0,0},{0,1,0}};
     std::vector<cv::Point2f> img3 = {{100,100},{200,100},{100,200}};
-    EXPECT_THROW(SolvePnPRansac{}(obj3, img3, make_K(), zero_dist()), std::invalid_argument);
+    EXPECT_THROW(SolvePnPRansac{}(obj3, img3, make_K(), zero_dist()), improc::ParameterError);
 }

--- a/tests/calib/test_stereo.cpp
+++ b/tests/calib/test_stereo.cpp
@@ -98,7 +98,7 @@ TEST(StereoCalibrateTest, ThrowsOnMismatchedVectorSizes) {
     auto pts2 = d.img_pts2;
     pts2.pop_back();
     EXPECT_THROW(StereoCalibrate{}(obj, d.img_pts1, pts2, d.image_size),
-                 std::invalid_argument);
+                 improc::ParameterError);
 }
 
 TEST(StereoCalibrateTest, ThrowsOnFewerThanThreeViews) {
@@ -106,13 +106,13 @@ TEST(StereoCalibrateTest, ThrowsOnFewerThanThreeViews) {
     std::vector<std::vector<cv::Point3f>> obj2 = {d.obj_pts[0], d.obj_pts[1]};
     std::vector<std::vector<cv::Point2f>> p1 = {d.img_pts1[0], d.img_pts1[1]};
     std::vector<std::vector<cv::Point2f>> p2 = {d.img_pts2[0], d.img_pts2[1]};
-    EXPECT_THROW(StereoCalibrate{}(obj2, p1, p2, d.image_size), std::invalid_argument);
+    EXPECT_THROW(StereoCalibrate{}(obj2, p1, p2, d.image_size), improc::ParameterError);
 }
 
 TEST(StereoCalibrateTest, ThrowsOnZeroImageSize) {
     auto d = make_stereo_data();
     EXPECT_THROW(StereoCalibrate{}(d.obj_pts, d.img_pts1, d.img_pts2, {0,0}),
-                 std::invalid_argument);
+                 improc::ParameterError);
 }
 
 TEST(StereoCalibrateTest, RmsLowOnSyntheticData) {
@@ -153,7 +153,7 @@ TEST(StereoRectifyTest, ThrowsOnEmptyMatrices) {
     EXPECT_THROW(
         StereoRectify{}(cv::Mat{}, cv::Mat{}, cv::Mat{}, cv::Mat{},
                         cv::Mat{}, cv::Mat{}, {640,480}),
-        std::invalid_argument);
+        improc::ParameterError);
 }
 
 TEST(StereoRectifyTest, OutputShapesAreCorrect) {
@@ -182,7 +182,7 @@ TEST(StereoRectifyTest, ValidROIsAreNonEmpty) {
 TEST(StereoBMTest, ThrowsOnSizeMismatch) {
     auto [left, right] = make_stereo_pair({9,6}, 20, 16);
     cv::Mat smaller(left.mat().rows / 2, left.mat().cols / 2, CV_8UC1);
-    EXPECT_THROW(StereoBM{}(left, Image<Gray>(smaller)), std::invalid_argument);
+    EXPECT_THROW(StereoBM{}(left, Image<Gray>(smaller)), improc::ParameterError);
 }
 
 TEST(StereoBMTest, OutputIsCV16SAndMatchesInputSize) {
@@ -211,7 +211,7 @@ TEST(StereoBMTest, FluentSettersReturnThis) {
 TEST(StereoSGBMTest, ThrowsOnSizeMismatch) {
     auto [left, right] = make_stereo_pair({9,6}, 20, 16);
     cv::Mat smaller(left.mat().rows / 2, left.mat().cols / 2, CV_8UC1);
-    EXPECT_THROW(StereoSGBM{}(left, Image<Gray>(smaller)), std::invalid_argument);
+    EXPECT_THROW(StereoSGBM{}(left, Image<Gray>(smaller)), improc::ParameterError);
 }
 
 TEST(StereoSGBMTest, OutputIsCV16SAndMatchesInputSize) {

--- a/tests/calib/test_undistort.cpp
+++ b/tests/calib/test_undistort.cpp
@@ -1,6 +1,7 @@
 // tests/calib/test_undistort.cpp
 #include <gtest/gtest.h>
 #include "improc/calib/pipeline.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::calib;
 using namespace improc::core;
@@ -43,12 +44,12 @@ TEST(UndistortTest, ZeroDistortionPreservesPixels) {
 
 TEST(UndistortTest, ThrowsWhenKNotSet) {
     Image<BGR> img(cv::Mat(120, 160, CV_8UC3, cv::Scalar(0)));
-    EXPECT_THROW(img | Undistort{}.dist(zero_dist()), std::invalid_argument);
+    EXPECT_THROW(img | Undistort{}.dist(zero_dist()), improc::ParameterError);
 }
 
 TEST(UndistortTest, ThrowsWhenDistNotSet) {
     Image<BGR> img(cv::Mat(120, 160, CV_8UC3, cv::Scalar(0)));
-    EXPECT_THROW(img | Undistort{}.K(make_K(160,120)), std::invalid_argument);
+    EXPECT_THROW(img | Undistort{}.K(make_K(160,120)), improc::ParameterError);
 }
 
 TEST(UndistortTest, FluentSettersReturnThis) {
@@ -76,15 +77,15 @@ TEST(UndistortMapTest, MapsAreUsableWithCoreRemap) {
 
 TEST(UndistortMapTest, ThrowsOnZeroImageSize) {
     EXPECT_THROW(UndistortMap{}.K(make_K(160,120)).dist(zero_dist())({0, 0}),
-                 std::invalid_argument);
+                 improc::ParameterError);
 }
 
 TEST(UndistortMapTest, ThrowsWhenKNotSet) {
-    EXPECT_THROW(UndistortMap{}.dist(zero_dist())({160, 120}), std::invalid_argument);
+    EXPECT_THROW(UndistortMap{}.dist(zero_dist())({160, 120}), improc::ParameterError);
 }
 
 TEST(UndistortMapTest, ThrowsWhenDistNotSet) {
-    EXPECT_THROW(UndistortMap{}.K(make_K(160,120))({160, 120}), std::invalid_argument);
+    EXPECT_THROW(UndistortMap{}.K(make_K(160,120))({160, 120}), improc::ParameterError);
 }
 
 TEST(UndistortMapTest, FluentSettersReturnThis) {

--- a/tests/core/ops/test_analysis.cpp
+++ b/tests/core/ops/test_analysis.cpp
@@ -1,4 +1,4 @@
-// tests/core/ops/test_analysis_v080.cpp
+// tests/core/ops/test_analysis.cpp
 #include <gtest/gtest.h>
 #include <opencv2/core.hpp>
 #include "improc/core/pipeline.hpp"

--- a/tests/core/ops/test_analysis_v080.cpp
+++ b/tests/core/ops/test_analysis_v080.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <opencv2/core.hpp>
 #include "improc/core/pipeline.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::core;
 
@@ -137,6 +138,6 @@ TEST(ReduceTest, MinAlongCols) {
 
 TEST(ReduceTest, InvalidDimThrows) {
     Image<Gray> img(cv::Mat(4, 4, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(Reduce{}.dim(2), std::invalid_argument);
-    EXPECT_THROW(Reduce{}.dim(-1), std::invalid_argument);
+    EXPECT_THROW(Reduce{}.dim(2), improc::ParameterError);
+    EXPECT_THROW(Reduce{}.dim(-1), improc::ParameterError);
 }

--- a/tests/core/ops/test_analysis_v080.cpp
+++ b/tests/core/ops/test_analysis_v080.cpp
@@ -74,12 +74,12 @@ TEST(CountNonZeroTest, HalfFilledMask) {
     cv::Mat m(100, 100, CV_8UC1, cv::Scalar(0));
     m.rowRange(0, 50).setTo(cv::Scalar(255));
     Image<Gray> img(m);
-    EXPECT_EQ(CountNonZero{}(img), 5000);
+    EXPECT_EQ(CountNonZero{}(img), 5000u);
 }
 
 TEST(CountNonZeroTest, AllZeroGivesZero) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_EQ(CountNonZero{}(img), 0);
+    EXPECT_EQ(CountNonZero{}(img), 0u);
 }
 
 // ── Reduce ────────────────────────────────────────────────────────────────────

--- a/tests/core/ops/test_arithmetic.cpp
+++ b/tests/core/ops/test_arithmetic.cpp
@@ -3,6 +3,7 @@
 #include <opencv2/core.hpp>
 #include "improc/core/ops/arithmetic.hpp"
 #include "improc/core/pipeline.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::core;
 
@@ -25,12 +26,12 @@ TEST(AbsDiffTest, KnownScalarDifference) {
 
 TEST(AbsDiffTest, SizeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | AbsDiff(cv::Mat(60, 60, CV_8UC1, cv::Scalar(0))), std::invalid_argument);
+    EXPECT_THROW(img | AbsDiff(cv::Mat(60, 60, CV_8UC1, cv::Scalar(0))), improc::ParameterError);
 }
 
 TEST(AbsDiffTest, TypeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | AbsDiff(cv::Mat(50, 50, CV_8UC3)), std::invalid_argument);
+    EXPECT_THROW(img | AbsDiff(cv::Mat(50, 50, CV_8UC3)), improc::ParameterError);
 }
 
 // ── BitwiseAnd ────────────────────────────────────────────────────────────────
@@ -55,7 +56,7 @@ TEST(BitwiseAndTest, AndWith255IsIdentity) {
 
 TEST(BitwiseAndTest, SizeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | BitwiseAnd(cv::Mat(60, 60, CV_8UC1, cv::Scalar(0))), std::invalid_argument);
+    EXPECT_THROW(img | BitwiseAnd(cv::Mat(60, 60, CV_8UC1, cv::Scalar(0))), improc::ParameterError);
 }
 
 // ── BitwiseOr ─────────────────────────────────────────────────────────────────
@@ -80,7 +81,7 @@ TEST(BitwiseOrTest, OrWith255GivesAllOnes) {
 
 TEST(BitwiseOrTest, SizeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | BitwiseOr(cv::Mat(60, 60, CV_8UC1, cv::Scalar(0))), std::invalid_argument);
+    EXPECT_THROW(img | BitwiseOr(cv::Mat(60, 60, CV_8UC1, cv::Scalar(0))), improc::ParameterError);
 }
 
 // ── BitwiseNot ────────────────────────────────────────────────────────────────
@@ -115,7 +116,7 @@ TEST(ConvolveTest, IdentityKernelPreservesImage) {
 
 TEST(ConvolveTest, EmptyKernelThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | Convolve(cv::Mat{}), std::invalid_argument);
+    EXPECT_THROW(img | Convolve(cv::Mat{}), improc::ParameterError);
 }
 
 TEST(ConvolveTest, FluentSettersReturnThis) {
@@ -186,7 +187,7 @@ TEST(AddTest, SaturationAtMax) {
 
 TEST(AddTest, SizeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | Add(cv::Mat(60, 60, CV_8UC1)), std::invalid_argument);
+    EXPECT_THROW(img | Add(cv::Mat(60, 60, CV_8UC1)), improc::ParameterError);
 }
 
 // ── Subtract ──────────────────────────────────────────────────────────────────
@@ -209,7 +210,7 @@ TEST(SubtractTest, SaturationAtZero) {
 
 TEST(SubtractTest, SizeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | Subtract(cv::Mat(60, 60, CV_8UC1)), std::invalid_argument);
+    EXPECT_THROW(img | Subtract(cv::Mat(60, 60, CV_8UC1)), improc::ParameterError);
 }
 
 // ── Pipeline syntax ───────────────────────────────────────────────────────────
@@ -247,7 +248,7 @@ TEST(MultiplyTest, ScaleParameterApplied) {
 
 TEST(MultiplyTest, SizeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | Multiply(cv::Mat(60, 60, CV_8UC1)), std::invalid_argument);
+    EXPECT_THROW(img | Multiply(cv::Mat(60, 60, CV_8UC1)), improc::ParameterError);
 }
 
 // ── Divide ────────────────────────────────────────────────────────────────────
@@ -270,5 +271,5 @@ TEST(DivideTest, DivideByZeroGivesZero) {
 
 TEST(DivideTest, SizeMismatchThrows) {
     Image<Gray> img(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(img | Divide(cv::Mat(60, 60, CV_8UC1)), std::invalid_argument);
+    EXPECT_THROW(img | Divide(cv::Mat(60, 60, CV_8UC1)), improc::ParameterError);
 }

--- a/tests/core/ops/test_axis.cpp
+++ b/tests/core/ops/test_axis.cpp
@@ -1,0 +1,61 @@
+// tests/core/ops/test_axis.cpp
+#include <gtest/gtest.h>
+#include <string>
+#include <opencv2/core.hpp>
+#include "improc/core/ops/axis.hpp"
+#include "improc/core/ops/flip.hpp"
+#include "improc/core/pipeline.hpp"
+
+using namespace improc::core;
+
+// ── Enum usability ────────────────────────────────────────────────────────────
+
+static std::string axis_name(Axis a) {
+    switch (a) {
+        case Axis::Horizontal: return "Horizontal";
+        case Axis::Vertical:   return "Vertical";
+        case Axis::Both:       return "Both";
+    }
+    return "unknown";
+}
+
+TEST(AxisTest, AllValuesAreNameable) {
+    EXPECT_EQ(axis_name(Axis::Horizontal), "Horizontal");
+    EXPECT_EQ(axis_name(Axis::Vertical),   "Vertical");
+    EXPECT_EQ(axis_name(Axis::Both),       "Both");
+}
+
+TEST(AxisTest, ThreeDistinctValues) {
+    EXPECT_NE(Axis::Horizontal, Axis::Vertical);
+    EXPECT_NE(Axis::Horizontal, Axis::Both);
+    EXPECT_NE(Axis::Vertical,   Axis::Both);
+}
+
+// ── Flip composition ──────────────────────────────────────────────────────────
+
+TEST(AxisTest, HorizontalFlipIsNotSameAsVertical) {
+    cv::Mat m(2, 2, CV_8UC3, cv::Scalar(0));
+    m.at<cv::Vec3b>(0, 0) = {255, 0, 0};
+    Image<BGR> img(m);
+
+    Image<BGR> h = img | Flip{Axis::Horizontal};
+    Image<BGR> v = img | Flip{Axis::Vertical};
+
+    // Horizontal: pixel moves to top-right
+    EXPECT_EQ(h.mat().at<cv::Vec3b>(0, 1), (cv::Vec3b{255, 0, 0}));
+    // Vertical: pixel moves to bottom-left
+    EXPECT_EQ(v.mat().at<cv::Vec3b>(1, 0), (cv::Vec3b{255, 0, 0}));
+    // Results differ
+    EXPECT_NE(cv::norm(h.mat(), v.mat(), cv::NORM_INF), 0.0);
+}
+
+TEST(AxisTest, BothAxesIsCompositionOfHorizontalAndVertical) {
+    cv::Mat m(2, 2, CV_8UC3, cv::Scalar(0));
+    m.at<cv::Vec3b>(0, 0) = {0, 128, 255};
+    Image<BGR> img(m);
+
+    Image<BGR> both      = img | Flip{Axis::Both};
+    Image<BGR> h_then_v  = img | Flip{Axis::Horizontal} | Flip{Axis::Vertical};
+
+    EXPECT_EQ(cv::norm(both.mat(), h_then_v.mat(), cv::NORM_INF), 0.0);
+}

--- a/tests/core/ops/test_background_subtract.cpp
+++ b/tests/core/ops/test_background_subtract.cpp
@@ -1,4 +1,4 @@
-// tests/core/test_background_subtract.cpp
+// tests/core/ops/test_background_subtract.cpp
 #include <gtest/gtest.h>
 #include <opencv2/core.hpp>
 #include "improc/core/ops/background_subtract.hpp"

--- a/tests/core/ops/test_channels.cpp
+++ b/tests/core/ops/test_channels.cpp
@@ -60,7 +60,7 @@ TEST(MergeChannelsTest, MismatchedSizesThrow) {
     Image<Gray> b(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
     Image<Gray> g(cv::Mat(60, 60, CV_8UC1, cv::Scalar(0)));
     Image<Gray> r(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(MergeChannels{}(b, g, r), std::invalid_argument);
+    EXPECT_THROW(MergeChannels{}(b, g, r), improc::ParameterError);
 }
 
 TEST(MergeChannelsTest, MismatchedAlphaThrows) {
@@ -68,5 +68,5 @@ TEST(MergeChannelsTest, MismatchedAlphaThrows) {
     Image<Gray> g(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
     Image<Gray> r(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
     Image<Gray> a(cv::Mat(60, 60, CV_8UC1, cv::Scalar(255)));
-    EXPECT_THROW(MergeChannels{}(b, g, r, a), std::invalid_argument);
+    EXPECT_THROW(MergeChannels{}(b, g, r, a), improc::ParameterError);
 }

--- a/tests/core/ops/test_connected_components.cpp
+++ b/tests/core/ops/test_connected_components.cpp
@@ -73,7 +73,7 @@ TEST(ComponentMapTest, MaskIsCorrectType) {
 TEST(ComponentMapTest, OutOfRangeLabelThrows) {
     Image<Gray> src = make_one_blob();
     ComponentMap result = src | ConnectedComponents{};
-    EXPECT_THROW(result.area(result.count()), std::out_of_range);
+    EXPECT_THROW(result.area(static_cast<int>(result.count())), std::out_of_range);
     EXPECT_THROW(result.area(-1), std::out_of_range);
 }
 
@@ -88,7 +88,7 @@ TEST(ConnectedComponentsTest, FindsComponentsInBinaryImage) {
 TEST(ConnectedComponentsTest, BlackImageHasOnlyBackground) {
     Image<Gray> src(cv::Mat(50, 50, CV_8UC1, cv::Scalar(0)));
     ComponentMap result = src | ConnectedComponents{};
-    EXPECT_EQ(result.count(), 1);
+    EXPECT_EQ(result.count(), 1u);
 }
 
 TEST(ConnectedComponentsTest, PipelineSyntax) {

--- a/tests/core/ops/test_face.cpp
+++ b/tests/core/ops/test_face.cpp
@@ -20,7 +20,7 @@ Image<BGR> make_blank_bgr_face() {
 TEST(DetectFaceYNTest, ThrowsIfModelNotSet) {
     Image<BGR> img = make_blank_bgr_face();
     DetectFaceYN op;
-    EXPECT_THROW(op(img), std::invalid_argument);
+    EXPECT_THROW(op(img), improc::ParameterError);
 }
 
 TEST(DetectFaceYNTest, ThrowsIfModelFileDoesNotExist) {
@@ -47,7 +47,7 @@ TEST(DetectFaceYNTest, DetectsNoFaceInBlankImage) {
 TEST(RecognizeFaceTest, ThrowsIfModelNotSet) {
     Image<BGR> img = make_blank_bgr_face();
     RecognizeFace op;
-    EXPECT_THROW(op.embed(img), std::invalid_argument);
+    EXPECT_THROW(op.embed(img), improc::ParameterError);
 }
 
 TEST(RecognizeFaceTest, ThrowsIfModelFileDoesNotExist) {

--- a/tests/core/ops/test_face.cpp
+++ b/tests/core/ops/test_face.cpp
@@ -62,14 +62,16 @@ TEST(RecognizeFaceTest, ThrowsIfModelFileDoesNotExist) {
 TEST(RecognizeFaceTest, MatchSameEmbeddingIsOne) {
     cv::Mat emb(1, 128, CV_32F);
     cv::randu(emb, 0.0, 1.0);
-    float sim = RecognizeFace::match(emb, emb);
+    FaceEmbedding fe{emb};
+    float sim = RecognizeFace::match(fe, fe);
     EXPECT_NEAR(sim, 1.0f, 1e-5f);
 }
 
 TEST(RecognizeFaceTest, MatchOppositeEmbeddingIsNegativeOne) {
     cv::Mat emb(1, 128, CV_32F, cv::Scalar(1.0f));
-    cv::Mat neg = -emb.clone();
-    float sim = RecognizeFace::match(emb, neg);
+    FaceEmbedding fe_pos{emb.clone()};
+    FaceEmbedding fe_neg{-emb.clone()};
+    float sim = RecognizeFace::match(fe_pos, fe_neg);
     EXPECT_NEAR(sim, -1.0f, 1e-5f);
 }
 
@@ -77,14 +79,15 @@ TEST(RecognizeFaceTest, MatchRangeIsNegOneToOne) {
     cv::Mat a(1, 128, CV_32F), b(1, 128, CV_32F);
     cv::randu(a, -1.0, 1.0);
     cv::randu(b, -1.0, 1.0);
-    float sim = RecognizeFace::match(a, b);
+    FaceEmbedding fe_a{a}, fe_b{b};
+    float sim = RecognizeFace::match(fe_a, fe_b);
     EXPECT_GE(sim, -1.0f);
     EXPECT_LE(sim, 1.0f);
 }
 
 // ── RecognizeFace::embed() — skipped without model ───────────────────────────
 
-TEST(RecognizeFaceTest, EmbedReturnsNonEmptyMat) {
+TEST(RecognizeFaceTest, EmbedReturnsFaceEmbedding) {
     if (!std::filesystem::exists(kRecogModel))
         GTEST_SKIP() << "model not present: " << kRecogModel;
     Image<BGR> img = make_blank_bgr_face();
@@ -92,5 +95,25 @@ TEST(RecognizeFaceTest, EmbedReturnsNonEmptyMat) {
     op.model(kRecogModel);
     auto emb = op.embed(img);
     EXPECT_FALSE(emb.empty());
-    EXPECT_EQ(emb.cols, 128);
+    EXPECT_EQ(emb.descriptor.cols, 128);
+}
+
+// ── FaceEmbedding unit tests ───────────────────────────────────────────────────
+
+TEST(FaceEmbeddingTest, DefaultConstructedIsEmpty) {
+    FaceEmbedding fe;
+    EXPECT_TRUE(fe.empty());
+    EXPECT_TRUE(fe.descriptor.empty());
+}
+
+TEST(FaceEmbeddingTest, CosineSimilarityReturnsZeroForEmpty) {
+    FaceEmbedding fe1, fe2;
+    EXPECT_FLOAT_EQ(fe1.cosine_similarity(fe2), 0.0f);
+}
+
+TEST(FaceEmbeddingTest, CosineSimilarityOfIdenticalVectorsIsOne) {
+    cv::Mat v = (cv::Mat_<float>(1, 4) << 1.0f, 0.0f, 0.0f, 0.0f);
+    FaceEmbedding fe1{v.clone()};
+    FaceEmbedding fe2{v.clone()};
+    EXPECT_NEAR(fe1.cosine_similarity(fe2), 1.0f, 1e-5f);
 }

--- a/tests/core/ops/test_flood_fill.cpp
+++ b/tests/core/ops/test_flood_fill.cpp
@@ -39,10 +39,10 @@ TEST(FloodFillTest, OriginalImageUnmodified) {
 
 TEST(FloodFillTest, SeedOutsideBoundsThrows) {
     Image<BGR> img(cv::Mat(50, 50, CV_8UC3, cv::Scalar(0)));
-    EXPECT_THROW(FloodFill{}(img, {-1,  0}, cv::Scalar(0)), std::invalid_argument);
-    EXPECT_THROW(FloodFill{}(img, {50,  0}, cv::Scalar(0)), std::invalid_argument);
-    EXPECT_THROW(FloodFill{}(img, { 0, -1}, cv::Scalar(0)), std::invalid_argument);
-    EXPECT_THROW(FloodFill{}(img, { 0, 50}, cv::Scalar(0)), std::invalid_argument);
+    EXPECT_THROW(FloodFill{}(img, {-1,  0}, cv::Scalar(0)), improc::ParameterError);
+    EXPECT_THROW(FloodFill{}(img, {50,  0}, cv::Scalar(0)), improc::ParameterError);
+    EXPECT_THROW(FloodFill{}(img, { 0, -1}, cv::Scalar(0)), improc::ParameterError);
+    EXPECT_THROW(FloodFill{}(img, { 0, 50}, cv::Scalar(0)), improc::ParameterError);
 }
 
 TEST(FloodFillTest, LoUpDiffToleranceLimitsSpread) {

--- a/tests/core/ops/test_grabcut.cpp
+++ b/tests/core/ops/test_grabcut.cpp
@@ -39,12 +39,12 @@ TEST(GrabCutTest, EmptyRectThrows) {
     auto img = make_test_image();
     cv::Rect roi{20, 20, 0, 0};
     GrabCut op;
-    EXPECT_THROW(op(img, roi), std::invalid_argument);
+    EXPECT_THROW(op(img, roi), improc::ParameterError);
 }
 
 TEST(GrabCutTest, RectOutsideBoundsThrows) {
     auto img = make_test_image();
     cv::Rect roi{50, 50, 80, 80};  // 50+80=130 > 100
     GrabCut op;
-    EXPECT_THROW(op(img, roi), std::invalid_argument);
+    EXPECT_THROW(op(img, roi), improc::ParameterError);
 }

--- a/tests/core/ops/test_hist.cpp
+++ b/tests/core/ops/test_hist.cpp
@@ -33,44 +33,44 @@ TEST(CalcHistTest, FluentSetterReturnsThis) {
 }
 
 TEST(CalcHistTest, GrayOutputShape) {
-    cv::Mat h = CalcHist{}(make_gray_rand(32, 32));
-    EXPECT_EQ(h.rows, 256);
-    EXPECT_EQ(h.cols, 1);
-    EXPECT_EQ(h.type(), CV_32FC1);
+    HistogramData h = CalcHist{}(make_gray_rand(32, 32));
+    EXPECT_EQ(h.data.rows, 256);
+    EXPECT_EQ(h.data.cols, 1);
+    EXPECT_EQ(h.data.type(), CV_32FC1);
 }
 
 TEST(CalcHistTest, GraySumEqualsPixelCount) {
     auto img = make_gray_rand(16, 16);
-    cv::Mat h = CalcHist{}(img);
-    double total = cv::sum(h)[0];
+    HistogramData h = CalcHist{}(img);
+    double total = cv::sum(h.data)[0];
     EXPECT_NEAR(total, static_cast<double>(16 * 16), 0.5);
 }
 
 TEST(CalcHistTest, GrayAllBinsNonNegative) {
-    cv::Mat h = CalcHist{}(make_gray_rand(32, 32));
+    HistogramData h = CalcHist{}(make_gray_rand(32, 32));
     double mn;
-    cv::minMaxLoc(h, &mn);
+    cv::minMaxLoc(h.data, &mn);
     EXPECT_GE(mn, 0.0);
 }
 
 TEST(CalcHistTest, BGROutputShape) {
-    cv::Mat h = CalcHist{}(make_bgr_rand(32, 32));
-    EXPECT_EQ(h.rows, 3 * 256);
-    EXPECT_EQ(h.cols, 1);
-    EXPECT_EQ(h.type(), CV_32FC1);
+    HistogramData h = CalcHist{}(make_bgr_rand(32, 32));
+    EXPECT_EQ(h.data.rows, 256);
+    EXPECT_EQ(h.data.cols, 3);
+    EXPECT_EQ(h.data.type(), CV_32FC1);
 }
 
 TEST(CalcHistTest, BGRSumEqualsThreeTimesPixelCount) {
     auto img = make_bgr_rand(16, 16);
-    cv::Mat h = CalcHist{}(img);
-    double total = cv::sum(h)[0];
+    HistogramData h = CalcHist{}(img);
+    double total = cv::sum(h.data)[0];
     EXPECT_NEAR(total, static_cast<double>(3 * 16 * 16), 0.5);
 }
 
 TEST(CalcHistTest, CustomBinsChangesOutputRows) {
-    cv::Mat h = CalcHist{}.bins(128)(make_gray_rand(32, 32));
-    EXPECT_EQ(h.rows, 128);
-    EXPECT_EQ(h.cols, 1);
+    HistogramData h = CalcHist{}.bins(128)(make_gray_rand(32, 32));
+    EXPECT_EQ(h.data.rows, 128);
+    EXPECT_EQ(h.data.cols, 1);
 }
 
 // --- CompareHist ---
@@ -80,7 +80,7 @@ TEST(CompareHistTest, DefaultConstruction) {
 }
 
 TEST(CompareHistTest, IdenticalHistogramsScoreNearOne) {
-    cv::Mat h = CalcHist{}(make_gray_rand(64, 64));
+    HistogramData h = CalcHist{}(make_gray_rand(64, 64));
     double score = CompareHist{}(h, h);
     EXPECT_NEAR(score, 1.0, 1e-5);
 }
@@ -89,8 +89,44 @@ TEST(CompareHistTest, IdenticalHistogramsScoreNearOne) {
 
 TEST(CalcHistTest, ConstantGrayImageSingleNonZeroBin) {
     auto img = make_gray_solid(8, 8, 42);
-    cv::Mat h = CalcHist{}(img);
-    int nonzero = cv::countNonZero(h);
+    HistogramData h = CalcHist{}(img);
+    int nonzero = cv::countNonZero(h.data);
     EXPECT_EQ(nonzero, 1);
-    EXPECT_NEAR(h.at<float>(42, 0), 64.0f, 1e-3f);
+    EXPECT_NEAR(h.data.at<float>(42, 0), 64.0f, 1e-3f);
+}
+
+// --- HistogramData type tests ---
+
+TEST(CalcHistTest, ReturnsHistogramDataForGray) {
+    cv::Mat m(100, 100, CV_8UC1, cv::Scalar(128));
+    Image<Gray> img(m);
+    HistogramData h = CalcHist{}(img);
+    EXPECT_FALSE(h.empty());
+    EXPECT_EQ(h.bins, 256);
+    EXPECT_EQ(h.channels, 1);
+}
+
+TEST(CalcHistTest, ReturnsHistogramDataForBGR) {
+    cv::Mat m(100, 100, CV_8UC3, cv::Scalar(50, 100, 150));
+    Image<BGR> img(m);
+    HistogramData h = CalcHist{}(img);
+    EXPECT_FALSE(h.empty());
+    EXPECT_EQ(h.bins, 256);
+    EXPECT_EQ(h.channels, 3);
+}
+
+TEST(CalcHistTest, HistogramDataMetadataMatchesCustomSettings) {
+    HistogramData h = CalcHist{}.bins(128).range(0.0f, 128.0f)(make_gray_rand(32, 32));
+    EXPECT_EQ(h.bins, 128);
+    EXPECT_FLOAT_EQ(h.range_min, 0.0f);
+    EXPECT_FLOAT_EQ(h.range_max, 128.0f);
+    EXPECT_EQ(h.channels, 1);
+}
+
+TEST(CompareHistTest, AcceptsHistogramData) {
+    cv::Mat m(100, 100, CV_8UC1, cv::Scalar(100));
+    Image<Gray> img(m);
+    HistogramData h = CalcHist{}(img);
+    double corr = CompareHist{}(h, h);
+    EXPECT_NEAR(corr, 1.0, 1e-5);
 }

--- a/tests/core/ops/test_img_hash.cpp
+++ b/tests/core/ops/test_img_hash.cpp
@@ -31,12 +31,12 @@ std::pair<Image<BGR>, Image<BGR>> make_distinct_pair() {
 #define HASH_TESTS(OpName)                                                       \
 TEST(OpName##Test, SameImageSameHash) {                                          \
     auto img = make_bgr();                                                       \
-    auto h1 = OpName{}(img);                                                     \
-    auto h2 = OpName{}(img);                                                     \
-    EXPECT_NEAR(cv::norm(h1, h2), 0.0, 1e-9);                                   \
+    ImageHash h1 = OpName{}(img);                                                \
+    ImageHash h2 = OpName{}(img);                                                \
+    EXPECT_EQ(h1, h2);                                                           \
 }                                                                                \
 TEST(OpName##Test, SelfDistanceIsZero) {                                         \
-    auto h = OpName{}(make_bgr());                                               \
+    ImageHash h = OpName{}(make_bgr());                                          \
     EXPECT_NEAR(OpName::distance(h, h), 0.0, 1e-9);                             \
 }                                                                                \
 TEST(OpName##Test, DifferentImagesPositiveDistance) {                            \
@@ -53,3 +53,26 @@ HASH_TESTS(MarrHildrethHash)
 HASH_TESTS(RadialVarianceHash)
 HASH_TESTS(ColorMomentHash)
 HASH_TESTS(BlockMeanHash)
+
+TEST(AverageHashTest, ReturnsImageHash) {
+    cv::Mat m(64, 64, CV_8UC3, cv::Scalar(100, 150, 200));
+    Image<BGR> img(m);
+    ImageHash h = AverageHash{}(img);
+    EXPECT_FALSE(h.empty());
+}
+
+TEST(AverageHashTest, SameImageProducesZeroDistance) {
+    cv::Mat m(64, 64, CV_8UC3, cv::Scalar(100, 150, 200));
+    Image<BGR> img(m);
+    ImageHash h1 = AverageHash{}(img);
+    ImageHash h2 = AverageHash{}(img);
+    EXPECT_DOUBLE_EQ(AverageHash::distance(h1, h2), 0.0);
+}
+
+TEST(AverageHashTest, EqualHashesCompareEqual) {
+    cv::Mat m(64, 64, CV_8UC3, cv::Scalar(50, 100, 150));
+    Image<BGR> img(m);
+    ImageHash h1 = AverageHash{}(img);
+    ImageHash h2 = AverageHash{}(img);
+    EXPECT_EQ(h1, h2);
+}

--- a/tests/core/ops/test_lut.cpp
+++ b/tests/core/ops/test_lut.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <opencv2/core.hpp>
 #include "improc/core/pipeline.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::core;
 
@@ -26,12 +27,12 @@ TEST(LUTTest, DefaultConstructionFromValidTable) {
 
 TEST(LUTTest, InvalidTableSizeThrows) {
     cv::Mat bad(1, 128, CV_8UC1, cv::Scalar(0));
-    EXPECT_THROW(LUT{bad}, std::invalid_argument);
+    EXPECT_THROW(LUT{bad}, improc::ParameterError);
 }
 
 TEST(LUTTest, InvalidTableDepthThrows) {
     cv::Mat bad(1, 256, CV_16UC1, cv::Scalar(0));
-    EXPECT_THROW(LUT{bad}, std::invalid_argument);
+    EXPECT_THROW(LUT{bad}, improc::ParameterError);
 }
 
 TEST(LUTTest, InvertsGrayImageValues) {

--- a/tests/core/ops/test_match_template.cpp
+++ b/tests/core/ops/test_match_template.cpp
@@ -46,13 +46,13 @@ TEST(MatchTemplateTest, FindsEmbeddedPatchLocation) {
 TEST(MatchTemplateTest, ThrowsWhenTemplateWiderThanImage) {
     Image<BGR> img(cv::Mat(64, 64, CV_8UC3, cv::Scalar(0)));
     Image<BGR> templ(cv::Mat(32, 128, CV_8UC3, cv::Scalar(0)));
-    EXPECT_THROW(MatchTemplate{}(img, templ), std::invalid_argument);
+    EXPECT_THROW(MatchTemplate{}(img, templ), improc::ParameterError);
 }
 
 TEST(MatchTemplateTest, ThrowsWhenTemplateTallerThanImage) {
     Image<BGR> img(cv::Mat(64, 64, CV_8UC3, cv::Scalar(0)));
     Image<BGR> templ(cv::Mat(128, 32, CV_8UC3, cv::Scalar(0)));
-    EXPECT_THROW(MatchTemplate{}(img, templ), std::invalid_argument);
+    EXPECT_THROW(MatchTemplate{}(img, templ), improc::ParameterError);
 }
 
 TEST(MatchTemplateTest, ExactMatchScoreNearOne) {

--- a/tests/core/ops/test_optical_flow.cpp
+++ b/tests/core/ops/test_optical_flow.cpp
@@ -43,14 +43,14 @@ TEST(SparseLKFlowTest, TracksKnownTranslation) {
 TEST(SparseLKFlowTest, EmptyPointsThrows) {
     auto prev = make_circle_gray({80, 100});
     auto next = make_circle_gray({90, 100});
-    EXPECT_THROW(SparseLKFlow{}(prev, next, {}), std::invalid_argument);
+    EXPECT_THROW(SparseLKFlow{}(prev, next, {}), improc::ParameterError);
 }
 
 TEST(SparseLKFlowTest, MismatchedSizesThrow) {
     Image<Gray> prev(cv::Mat(100, 100, CV_8UC1, cv::Scalar(0)));
     Image<Gray> next(cv::Mat(200, 200, CV_8UC1, cv::Scalar(0)));
     std::vector<cv::Point2f> pts = {{50.f, 50.f}};
-    EXPECT_THROW(SparseLKFlow{}(prev, next, pts), std::invalid_argument);
+    EXPECT_THROW(SparseLKFlow{}(prev, next, pts), improc::ParameterError);
 }
 
 // ── DenseFarnebackFlow ────────────────────────────────────────────────────────
@@ -96,7 +96,7 @@ TEST(DenseFarnebackFlowTest, DetectsHorizontalTranslation) {
 TEST(DenseFarnebackFlowTest, MismatchedSizesThrow) {
     Image<Gray> prev(cv::Mat(100, 100, CV_8UC1, cv::Scalar(0)));
     Image<Gray> next(cv::Mat(200, 200, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(DenseFarnebackFlow{}(prev, next), std::invalid_argument);
+    EXPECT_THROW(DenseFarnebackFlow{}(prev, next), improc::ParameterError);
 }
 
 // ── DenseDISFlow ──────────────────────────────────────────────────────────────
@@ -124,5 +124,5 @@ TEST(DenseDISFlowTest, ReturnsFlowSameSize) {
 TEST(DenseDISFlowTest, MismatchedSizesThrow) {
     Image<Gray> prev(cv::Mat(100, 100, CV_8UC1, cv::Scalar(0)));
     Image<Gray> next(cv::Mat(200, 200, CV_8UC1, cv::Scalar(0)));
-    EXPECT_THROW(DenseDISFlow{}(prev, next), std::invalid_argument);
+    EXPECT_THROW(DenseDISFlow{}(prev, next), improc::ParameterError);
 }

--- a/tests/core/ops/test_phase_correlate.cpp
+++ b/tests/core/ops/test_phase_correlate.cpp
@@ -43,5 +43,5 @@ TEST(PhaseCorrelateTest, DetectsHorizontalShift) {
 TEST(PhaseCorrelateTest, MismatchedSizesThrow) {
     Image<Float32> prev(cv::Mat(100, 100, CV_32FC1, cv::Scalar(0.f)));
     Image<Float32> next(cv::Mat(200, 200, CV_32FC1, cv::Scalar(0.f)));
-    EXPECT_THROW(PhaseCorrelate{}(prev, next), std::invalid_argument);
+    EXPECT_THROW(PhaseCorrelate{}(prev, next), improc::ParameterError);
 }

--- a/tests/core/ops/test_remap.cpp
+++ b/tests/core/ops/test_remap.cpp
@@ -3,6 +3,7 @@
 #include <opencv2/imgproc.hpp>
 #include "improc/core/ops/remap.hpp"
 #include "improc/core/pipeline.hpp"
+#include "improc/exceptions.hpp"
 
 using namespace improc::core;
 
@@ -43,13 +44,13 @@ TEST(RemapTest, IdentityMapsPreserveImage) {
 TEST(RemapTest, EmptyMapThrows) {
     cv::Mat m1(50, 50, CV_32FC1);
     cv::Mat m2;
-    EXPECT_THROW(Remap(m1, m2), std::invalid_argument);
+    EXPECT_THROW(Remap(m1, m2), improc::ParameterError);
 }
 
 TEST(RemapTest, MismatchedMapSizesThrow) {
     cv::Mat m1(50, 50, CV_32FC1);
     cv::Mat m2(60, 60, CV_32FC1);
-    EXPECT_THROW(Remap(m1, m2), std::invalid_argument);
+    EXPECT_THROW(Remap(m1, m2), improc::ParameterError);
 }
 
 TEST(RemapTest, OutputSizeMatchesMapSize) {

--- a/tests/core/ops/test_to_bgr.cpp
+++ b/tests/core/ops/test_to_bgr.cpp
@@ -1,0 +1,94 @@
+// tests/core/ops/test_to_bgr.cpp
+#include <gtest/gtest.h>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include "improc/core/pipeline.hpp"
+
+using namespace improc::core;
+
+// ── Gray → BGR ───────────────────────────────────────────────────────────────
+
+TEST(ToBGRTest, GrayToBGRProducesThreeChannels) {
+    cv::Mat m(10, 10, CV_8UC1, cv::Scalar(128));
+    Image<Gray> gray(m);
+    Image<BGR> result = gray | ToBGR{};
+    EXPECT_EQ(result.mat().channels(), 3);
+    EXPECT_EQ(result.rows(), 10);
+    EXPECT_EQ(result.cols(), 10);
+}
+
+TEST(ToBGRTest, GrayToBGRReplicatesValueAcrossChannels) {
+    cv::Mat m(1, 1, CV_8UC1, cv::Scalar(100));
+    Image<Gray> gray(m);
+    Image<BGR> result = gray | ToBGR{};
+    cv::Vec3b pixel = result.mat().at<cv::Vec3b>(0, 0);
+    EXPECT_EQ(pixel[0], 100);
+    EXPECT_EQ(pixel[1], 100);
+    EXPECT_EQ(pixel[2], 100);
+}
+
+TEST(ToBGRTest, GrayToBGROutputTypeIsCV_8UC3) {
+    cv::Mat m(4, 4, CV_8UC1, cv::Scalar(200));
+    Image<Gray> gray(m);
+    Image<BGR> result = gray | ToBGR{};
+    EXPECT_EQ(result.mat().type(), CV_8UC3);
+}
+
+// ── HSV → BGR ────────────────────────────────────────────────────────────────
+
+TEST(ToBGRTest, HSVToBGROutputTypeIsCV_8UC3) {
+    cv::Mat m(4, 4, CV_8UC3, cv::Scalar(0, 255, 255));
+    Image<HSV> hsv(m);
+    Image<BGR> result = hsv | ToBGR{};
+    EXPECT_EQ(result.mat().type(), CV_8UC3);
+    EXPECT_EQ(result.rows(), 4);
+    EXPECT_EQ(result.cols(), 4);
+}
+
+TEST(ToBGRTest, HSVToBGRMatchesFreeFunction) {
+    cv::Mat m(4, 4, CV_8UC3, cv::Scalar(30, 200, 180));
+    Image<HSV> hsv(m);
+    Image<BGR> via_op       = hsv | ToBGR{};
+    Image<BGR> via_function = convert<BGR, HSV>(hsv);
+    EXPECT_EQ(cv::norm(via_op.mat(), via_function.mat(), cv::NORM_INF), 0.0);
+}
+
+// ── LAB → BGR ────────────────────────────────────────────────────────────────
+
+TEST(ToBGRTest, LABToBGROutputTypeIsCV_8UC3) {
+    // L=100 (white), a=128 (neutral), b=128 (neutral) in 8-bit LAB
+    cv::Mat m(4, 4, CV_8UC3, cv::Scalar(255, 128, 128));
+    Image<LAB> lab(m);
+    Image<BGR> result = lab | ToBGR{};
+    EXPECT_EQ(result.mat().type(), CV_8UC3);
+    EXPECT_EQ(result.rows(), 4);
+    EXPECT_EQ(result.cols(), 4);
+}
+
+TEST(ToBGRTest, LABToBGRMatchesFreeFunction) {
+    cv::Mat m(4, 4, CV_8UC3, cv::Scalar(100, 128, 128));
+    Image<LAB> lab(m);
+    Image<BGR> via_op       = lab | ToBGR{};
+    Image<BGR> via_function = convert<BGR, LAB>(lab);
+    EXPECT_EQ(cv::norm(via_op.mat(), via_function.mat(), cv::NORM_INF), 0.0);
+}
+
+// ── YCrCb → BGR ──────────────────────────────────────────────────────────────
+
+TEST(ToBGRTest, YCrCbToBGROutputTypeIsCV_8UC3) {
+    // Y=128, Cr=128, Cb=128 (neutral gray in YCrCb)
+    cv::Mat m(4, 4, CV_8UC3, cv::Scalar(128, 128, 128));
+    Image<YCrCb> ycrcb(m);
+    Image<BGR> result = ycrcb | ToBGR{};
+    EXPECT_EQ(result.mat().type(), CV_8UC3);
+    EXPECT_EQ(result.rows(), 4);
+    EXPECT_EQ(result.cols(), 4);
+}
+
+TEST(ToBGRTest, YCrCbToBGRMatchesFreeFunction) {
+    cv::Mat m(4, 4, CV_8UC3, cv::Scalar(128, 128, 128));
+    Image<YCrCb> ycrcb(m);
+    Image<BGR> via_op       = ycrcb | ToBGR{};
+    Image<BGR> via_function = convert<BGR, YCrCb>(ycrcb);
+    EXPECT_EQ(cv::norm(via_op.mat(), via_function.mat(), cv::NORM_INF), 0.0);
+}

--- a/tests/core/ops/test_tracking.cpp
+++ b/tests/core/ops/test_tracking.cpp
@@ -36,7 +36,7 @@ TEST(CamShiftTest, ConvergesOnBrightRegion) {
 TEST(CamShiftTest, OutOfBoundsWindowThrows) {
     auto back_proj = make_prob_map(cv::Rect(80, 80, 40, 40));
     cv::Rect window(-10, -10, 50, 50);
-    EXPECT_THROW(CamShift{}(back_proj, window), std::invalid_argument);
+    EXPECT_THROW(CamShift{}(back_proj, window), improc::ParameterError);
 }
 
 // ── MeanShift ─────────────────────────────────────────────────────────────────
@@ -64,5 +64,5 @@ TEST(MeanShiftTest, ConvergesOnBrightRegion) {
 TEST(MeanShiftTest, OutOfBoundsWindowThrows) {
     auto back_proj = make_prob_map(cv::Rect(80, 80, 40, 40));
     cv::Rect window(250, 250, 50, 50);
-    EXPECT_THROW(MeanShift{}(back_proj, window), std::invalid_argument);
+    EXPECT_THROW(MeanShift{}(back_proj, window), improc::ParameterError);
 }

--- a/tests/core/ops/test_watershed.cpp
+++ b/tests/core/ops/test_watershed.cpp
@@ -36,13 +36,13 @@ TEST(WatershedTest, ValidMarkersNoThrow) {
 TEST(WatershedTest, WrongTypeMarkersThrows) {
     auto img = make_two_region_image();
     cv::Mat markers(50, 50, CV_8UC1, cv::Scalar(0));
-    EXPECT_THROW(Watershed{}(img, markers), std::invalid_argument);
+    EXPECT_THROW(Watershed{}(img, markers), improc::ParameterError);
 }
 
 TEST(WatershedTest, WrongSizeMarkersThrows) {
     auto img = make_two_region_image();
     cv::Mat markers(30, 30, CV_32SC1, cv::Scalar(0));
-    EXPECT_THROW(Watershed{}(img, markers), std::invalid_argument);
+    EXPECT_THROW(Watershed{}(img, markers), improc::ParameterError);
 }
 
 TEST(WatershedTest, BothLabelsPresentAfterCall) {

--- a/tests/ml/test_segmentation_eval.cpp
+++ b/tests/ml/test_segmentation_eval.cpp
@@ -42,7 +42,7 @@ TEST(PixelIouTest, DimensionMismatchThrows) {
     cv::Mat pred_m(4, 4, CV_8U, cv::Scalar(1));
     cv::Mat gt_m(8, 8, CV_8U, cv::Scalar(1));
     EXPECT_THROW(pixel_iou(Image<Gray>(pred_m), Image<Gray>(gt_m), 1),
-                 std::invalid_argument);
+                 improc::ParameterError);
 }
 
 // ── dice ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four milestones closing all known API gaps before the v1.0.0 freeze.

**v0.15.0 — Breaking API changes**
- Replaced all `throw std::invalid_argument(...)` with `throw improc::ParameterError{...}` throughout the library (all headers + all `.cpp` files)
- Moved `DrawContours`, `DrawKeypoints`, `DrawMatches` from `improc::core` → `improc::visualization`; backward-compat using-aliases left in `improc::core` via `pipeline.hpp`
- Renamed `Dataset::set_shuffle_seed(seed)` → `Dataset::shuffle_seed(seed)` (fluent-setter style)
- Added `[[nodiscard]]` to all 310 result-returning `operator()` across core, calib, ml, visualization, onnx
- Removed empty `include/improc/cuda/` placeholder directory

**v0.16.0 — API ergonomics**
- `CalcHist` returns `HistogramData`; `CompareHist` accepts `HistogramData`
- All 6 hash ops return `ImageHash` with `operator==`/`operator!=`; `distance()` takes `ImageHash`
- `RecognizeFace::embed()` returns `FaceEmbedding` with `cosine_similarity()`; `match()` takes `FaceEmbedding`
- `CountNonZero::operator()` and `ComponentMap::num_labels`/`count()` use `std::size_t`

**v0.17.0 — Fisheye ops**
- Added 6 new ops to `improc::calib`: `FisheyeCalibrate`, `FisheyeUndistort`, `FisheyeUndistortPoints`, `FisheyeInitRectifyMap`, `FisheyeStereoCalibrate`, `FisheyeStereoRectify`
- All wrap `cv::fisheye::*` and reuse existing result types (`CalibrationResult`, `UndistortMapResult`, `StereoCalibrationResult`, `StereoRectifyResult`)
- 13 new tests using synthetic data via `cv::fisheye::projectPoints`

**v0.18.0 — Test/doc cleanup**
- Renamed `test_analysis_v080.cpp` → `test_analysis.cpp`
- Moved `test_background_subtract.cpp` into `tests/core/ops/`
- Added `test_to_bgr.cpp` (Gray/HSV/LAB/YCrCb → BGR)
- Added `test_axis.cpp` (enum usability + Flip composition)

## Test Plan
- [ ] CI green on all platforms
- [ ] 1135 tests pass locally (`--gtest_filter='*:-VideoWriterTest.*'`)
- [ ] Review breaking changes in v0.15.0 and v0.16.0 for any missed call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)