### PR TITLE
feat(v0.20.0): API completeness — HaarDetect, BRISK/KAZE, DnnSegmentor, HOGDetector, umbrella headers

### DIFF
--- a/include/improc/core/ops/detectors.hpp
+++ b/include/improc/core/ops/detectors.hpp
@@ -6,6 +6,7 @@
 #include "improc/core/image.hpp"
 #include "improc/core/ops/feature_detection.hpp"  // KeypointSet
 #include "improc/core/ops/detector_types.hpp"
+#include "improc/core/ops/haar_detect.hpp"
 
 namespace improc::core {
 

--- a/include/improc/core/ops/feature_detection.hpp
+++ b/include/improc/core/ops/feature_detection.hpp
@@ -119,7 +119,7 @@ private:
  */
 struct DescriptorSet {
     KeypointSet keypoints;
-    cv::Mat     descriptors;  // CV_32F for SIFT; CV_8U for ORB/AKAZE
+    cv::Mat     descriptors;  // CV_32F for SIFT/KAZE; CV_8U for ORB/AKAZE/BRISK
 
     std::size_t size()  const { return keypoints.size(); }
     bool        empty() const { return keypoints.empty(); }
@@ -156,6 +156,88 @@ struct DescribeAKAZE {
     [[nodiscard]] DescriptorSet operator()(Image<BGR>  img) const;
 private:
     KeypointSet kps_;
+};
+
+/**
+ * @brief Pipeline op: detects BRISK keypoints in `Image<Gray>`.
+ *
+ * Returns `KeypointSet`. Wraps `cv::BRISK`. Binary descriptor algorithm —
+ * fast detection, rotation and scale invariant.
+ * Defaults: `threshold=30`, `octaves=3`, `pattern_scale=1.0f`.
+ *
+ * @code
+ * KeypointSet ks = gray | DetectBRISK{}.threshold(20);
+ * @endcode
+ */
+struct DetectBRISK {
+    DetectBRISK& threshold(int t)       { threshold_     = t; return *this; }
+    DetectBRISK& octaves(int n)         { octaves_       = n; return *this; }
+    DetectBRISK& pattern_scale(float s) { pattern_scale_ = s; return *this; }
+
+    [[nodiscard]] KeypointSet operator()(Image<Gray> img) const;
+
+private:
+    int   threshold_     {30};
+    int   octaves_       {3};
+    float pattern_scale_ {1.0f};
+};
+
+/// @brief Pipeline op: computes BRISK descriptors (CV_8U) for a given `KeypointSet`.
+struct DescribeBRISK {
+    explicit DescribeBRISK(KeypointSet kps) : kps_(std::move(kps)) {}
+    DescribeBRISK& threshold(int t)       { threshold_     = t; return *this; }
+    DescribeBRISK& octaves(int n)         { octaves_       = n; return *this; }
+    DescribeBRISK& pattern_scale(float s) { pattern_scale_ = s; return *this; }
+
+    [[nodiscard]] DescriptorSet operator()(Image<Gray> img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<BGR>  img) const;
+
+private:
+    KeypointSet kps_;
+    int   threshold_     {30};
+    int   octaves_       {3};
+    float pattern_scale_ {1.0f};
+};
+
+/**
+ * @brief Pipeline op: detects KAZE keypoints in `Image<Gray>`.
+ *
+ * Returns `KeypointSet`. Wraps `cv::KAZE`. Nonlinear scale space detector
+ * producing float descriptors (CV_32F, 64-dim). Slower but more accurate than AKAZE.
+ * Defaults: `threshold=0.001f`, `octaves=4`, `sublevels=4`.
+ *
+ * @code
+ * KeypointSet ks = gray | DetectKAZE{}.threshold(0.005f);
+ * @endcode
+ */
+struct DetectKAZE {
+    DetectKAZE& threshold(float t) { threshold_ = t; return *this; }
+    DetectKAZE& octaves(int n)     { octaves_   = n; return *this; }
+    DetectKAZE& sublevels(int n)   { sublevels_ = n; return *this; }
+
+    [[nodiscard]] KeypointSet operator()(Image<Gray> img) const;
+
+private:
+    float threshold_ {0.001f};
+    int   octaves_   {4};
+    int   sublevels_ {4};
+};
+
+/// @brief Pipeline op: computes KAZE descriptors (CV_32F, 64-dim) for a given `KeypointSet`.
+struct DescribeKAZE {
+    explicit DescribeKAZE(KeypointSet kps) : kps_(std::move(kps)) {}
+    DescribeKAZE& threshold(float t) { threshold_ = t; return *this; }
+    DescribeKAZE& octaves(int n)     { octaves_   = n; return *this; }
+    DescribeKAZE& sublevels(int n)   { sublevels_ = n; return *this; }
+
+    [[nodiscard]] DescriptorSet operator()(Image<Gray> img) const;
+    [[nodiscard]] DescriptorSet operator()(Image<BGR>  img) const;
+
+private:
+    KeypointSet kps_;
+    float threshold_ {0.001f};
+    int   octaves_   {4};
+    int   sublevels_ {4};
 };
 
 struct GoodFeaturesToTrack {

--- a/include/improc/core/ops/haar_detect.hpp
+++ b/include/improc/core/ops/haar_detect.hpp
@@ -1,0 +1,52 @@
+// include/improc/core/ops/haar_detect.hpp
+#pragma once
+#include <vector>
+#include <opencv2/objdetect.hpp>
+#include "improc/core/image.hpp"
+#include "improc/exceptions.hpp"
+
+namespace improc::core {
+
+/**
+ * @brief Pipeline functor: detects objects in `Image<BGR>` using a pre-loaded
+ *        `cv::CascadeClassifier`. Returns bounding boxes in pixel coordinates.
+ *
+ * Converts the image to Gray internally. Returns an empty vector when no
+ * objects are found. Does not throw during inference.
+ *
+ * @code
+ * cv::CascadeClassifier cc;
+ * cc.load("haarcascade_frontalface_default.xml");
+ * std::vector<cv::Rect> faces = DetectHaar{}(img, cc);
+ * @endcode
+ */
+struct DetectHaar {
+    /// @brief Scale factor between pyramid levels. Must be > 1.0; default 1.1.
+    DetectHaar& scale_factor(double f) {
+        if (f <= 1.0) throw ParameterError{"scale_factor", "must be > 1.0", "DetectHaar"};
+        scale_factor_ = f; return *this;
+    }
+
+    /// @brief Minimum number of neighbouring rectangles to retain a detection. Default 3.
+    DetectHaar& min_neighbors(int n) {
+        if (n < 0) throw ParameterError{"min_neighbors", "must be >= 0", "DetectHaar"};
+        min_neighbors_ = n; return *this;
+    }
+
+    /// @brief Minimum object size. Default (0,0) = no minimum.
+    DetectHaar& min_size(cv::Size s) { min_size_ = s; return *this; }
+
+    /// @brief Maximum object size. Default (0,0) = no maximum.
+    DetectHaar& max_size(cv::Size s) { max_size_ = s; return *this; }
+
+    [[nodiscard]] std::vector<cv::Rect>
+    operator()(const Image<BGR>& img, const cv::CascadeClassifier& cc) const;
+
+private:
+    double   scale_factor_  = 1.1;
+    int      min_neighbors_ = 3;
+    cv::Size min_size_      = {};
+    cv::Size max_size_      = {};
+};
+
+} // namespace improc::core

--- a/include/improc/ml/dnn_segmentor.hpp
+++ b/include/improc/ml/dnn_segmentor.hpp
@@ -1,0 +1,124 @@
+// include/improc/ml/dnn_segmentor.hpp
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <opencv2/dnn.hpp>
+#include "improc/core/image.hpp"
+#include "improc/ml/result_types.hpp"
+#include "improc/exceptions.hpp"
+#include "improc/error.hpp"
+
+namespace improc::ml {
+
+using improc::core::Image;
+using improc::core::BGR;
+using improc::core::Gray;
+
+/**
+ * @brief OpenCV DNN-backed semantic segmentation op.
+ *
+ * Accepts any model that `cv::dnn::readNet` can load (ONNX, Caffe, TF, Darknet)
+ * and produces a `[1,C,H,W]` output blob. Argmax over C gives a per-pixel class
+ * mask at the original input resolution (via INTER_NEAREST resize).
+ *
+ * @code
+ * auto mask = DnnSegmentor{"deeplabv3.onnx"}.input_size(512, 512)(frame);
+ * @endcode
+ */
+struct DnnSegmentor {
+    /**
+     * @brief Loads the model from disk.
+     * @param model  Path to the model file (ONNX, Caffe, TF, Darknet, etc.).
+     * @param config Optional config file path (e.g. `.prototxt` for Caffe).
+     * @throws improc::ModelError if the file does not exist or OpenCV fails to parse it.
+     */
+    explicit DnnSegmentor(const std::filesystem::path& model,
+                          const std::filesystem::path& config = "");
+
+    /**
+     * @brief Sets the spatial dimensions of the input blob.
+     * @param w Width in pixels; must be positive.
+     * @param h Height in pixels; must be positive.
+     * @return Reference to this segmentor for method chaining.
+     * @throws improc::ParameterError if either dimension is not positive.
+     */
+    DnnSegmentor& input_size(int w, int h) {
+        if (w <= 0 || h <= 0)
+            throw ParameterError{"input_size", "dimensions must be positive", "DnnSegmentor"};
+        input_w_ = w; input_h_ = h; return *this;
+    }
+
+    /**
+     * @brief Sets the per-channel mean subtracted from the input blob.
+     * @param b Blue channel mean.
+     * @param g Green channel mean.
+     * @param r Red channel mean.
+     * @return Reference to this segmentor for method chaining.
+     */
+    DnnSegmentor& mean(float b, float g, float r) {
+        mean_b_ = b; mean_g_ = g; mean_r_ = r; return *this;
+    }
+
+    /**
+     * @brief Sets the pixel value scaling factor applied to the input blob.
+     * @param s Scale factor; must be positive (default: 1/255).
+     * @return Reference to this segmentor for method chaining.
+     * @throws improc::ParameterError if @p s <= 0.
+     */
+    DnnSegmentor& scale(float s) {
+        if (s <= 0.0f)
+            throw ParameterError{"scale", "must be positive", "DnnSegmentor"};
+        scale_ = s; return *this;
+    }
+
+    /**
+     * @brief Controls whether R and B channels are swapped when building the blob.
+     * @param v `true` to swap (BGR -> RGB); default is `true`.
+     * @return Reference to this segmentor for method chaining.
+     */
+    DnnSegmentor& swap_rb(bool v) { swap_rb_ = v; return *this; }
+
+    /**
+     * @brief Sets the name of the output layer to forward through.
+     * @param name Layer name as reported by the model; empty means the last output layer.
+     * @return Reference to this segmentor for method chaining.
+     */
+    DnnSegmentor& output_layer(std::string name) { output_layer_ = std::move(name); return *this; }
+
+    /**
+     * @brief Sets the class label strings used to populate `SegmentationMask::labels`.
+     * @param lbls Vector of label strings ordered by class index.
+     * @return Reference to this segmentor for method chaining.
+     */
+    DnnSegmentor& labels(std::vector<std::string> lbls) { labels_ = std::move(lbls); return *this; }
+
+    /**
+     * @brief Runs segmentation inference on the given image.
+     *
+     * The network output `[1,C,H,W]` is argmax-reduced over C to produce a
+     * per-pixel class mask, then resized (INTER_NEAREST) back to the original
+     * input image dimensions.
+     *
+     * @param img Input image in BGR format.
+     * @return `SegmentationMask` on success, or `improc::Error` on inference failure.
+     */
+    [[nodiscard]] std::expected<SegmentationMask, improc::Error>
+    operator()(const Image<BGR>& img) const;
+
+private:
+    mutable cv::dnn::Net     net_;
+    int                      input_w_       = 512;
+    int                      input_h_       = 512;
+    float                    mean_b_        = 0.0f;
+    float                    mean_g_        = 0.0f;
+    float                    mean_r_        = 0.0f;
+    float                    scale_         = 1.0f / 255.0f;
+    bool                     swap_rb_       = true;
+    std::string              output_layer_;
+    std::vector<std::string> labels_;
+};
+
+} // namespace improc::ml

--- a/include/improc/ml/hog_detector.hpp
+++ b/include/improc/ml/hog_detector.hpp
@@ -1,0 +1,59 @@
+// include/improc/ml/hog_detector.hpp
+#pragma once
+
+#include <vector>
+#include <opencv2/objdetect.hpp>
+#include "improc/core/image.hpp"
+#include "improc/ml/result_types.hpp"
+#include "improc/exceptions.hpp"
+
+namespace improc::ml {
+
+using improc::core::Image;
+using improc::core::BGR;
+
+/**
+ * @brief People detector using `cv::HOGDescriptor` with the default SVM.
+ *
+ * Returns `std::vector<Detection>` with `class_id=0`, `label="person"`, and
+ * `confidence` computed via sigmoid of the raw HOG weight.
+ *
+ * @code
+ * HOGDetector det;
+ * auto people = det(frame);
+ * @endcode
+ */
+struct HOGDetector {
+    /// @brief Construct with the default OpenCV people detector SVM.
+    HOGDetector();
+
+    /// @brief Construct with a custom SVM descriptor vector. Must be non-empty.
+    explicit HOGDetector(const std::vector<float>& svm);
+
+    /// @brief Sliding window stride. Default (8,8).
+    HOGDetector& win_stride(cv::Size s)  { win_stride_    = s; return *this; }
+
+    /// @brief Detection window padding. Default (4,4).
+    HOGDetector& padding(cv::Size s)     { padding_       = s; return *this; }
+
+    /// @brief Scale step between pyramid levels. Must be > 1.0; default 1.05.
+    HOGDetector& scale(double s) {
+        if (s <= 1.0)
+            throw ParameterError{"scale", "must be > 1.0", "HOGDetector"};
+        scale_ = s; return *this;
+    }
+
+    /// @brief Classifier hit threshold. Higher = stricter. Default 0.0.
+    HOGDetector& hit_threshold(double t) { hit_threshold_ = t; return *this; }
+
+    [[nodiscard]] std::vector<Detection> operator()(const Image<BGR>& img) const;
+
+private:
+    cv::HOGDescriptor hog_;
+    cv::Size win_stride_    = {8, 8};
+    cv::Size padding_       = {4, 4};
+    double   scale_         = 1.05;
+    double   hit_threshold_ = 0.0;
+};
+
+} // namespace improc::ml

--- a/include/improc/ml/ml.hpp
+++ b/include/improc/ml/ml.hpp
@@ -5,6 +5,7 @@
 #include "improc/ml/dataset.hpp"
 #include "improc/ml/dnn_classifier.hpp"
 #include "improc/ml/dnn_detector.hpp"
+#include "improc/ml/dnn_segmentor.hpp"
 #include "improc/ml/dnn_forward.hpp"
 #include "improc/ml/haar_cascade_loader.hpp"
 #include "improc/ml/image_loader.hpp"

--- a/include/improc/ml/ml.hpp
+++ b/include/improc/ml/ml.hpp
@@ -16,3 +16,4 @@
 #include "improc/ml/voc_seg_dataset.hpp"
 #include "improc/ml/eval/eval.hpp"
 #include "improc/ml/tracking/tracking.hpp"
+#include "improc/ml/hog_detector.hpp"

--- a/include/improc/threading/threading.hpp
+++ b/include/improc/threading/threading.hpp
@@ -1,0 +1,10 @@
+// include/improc/threading/threading.hpp
+#pragma once
+
+/** @file threading.hpp
+ *  @brief Convenience header — includes all `improc::threading` types
+ *         (ThreadPool, FramePipeline).
+ */
+
+#include "improc/threading/thread_pool.hpp"
+#include "improc/threading/frame_pipeline.hpp"

--- a/include/improc/visualization/visualization.hpp
+++ b/include/improc/visualization/visualization.hpp
@@ -4,7 +4,7 @@
 /** @file visualization.hpp
  *  @brief Convenience header — includes all `improc::visualization` rendering types
  *         (Histogram, LinePlot, Scatter, Show, Draw, DrawTracks, Montage,
- *          DrawContours, DrawKeypoints, DrawMatches).
+ *          DrawContours, DrawKeypoints, DrawMatches, and all ML charts).
  */
 
 #include "improc/visualization/histogram.hpp"
@@ -16,3 +16,4 @@
 #include "improc/visualization/montage.hpp"
 #include "improc/visualization/draw_contours.hpp"
 #include "improc/visualization/draw_matches.hpp"
+#include "improc/visualization/ml_charts.hpp"

--- a/src/core/ops/feature_detection.cpp
+++ b/src/core/ops/feature_detection.cpp
@@ -77,6 +77,56 @@ DescriptorSet DescribeAKAZE::operator()(Image<BGR> img) const {
     return result;
 }
 
+// ── BRISK ────────────────────────────────────────────────────────────────────
+
+KeypointSet DetectBRISK::operator()(Image<Gray> img) const {
+    KeypointSet result;
+    cv::BRISK::create(threshold_, octaves_, pattern_scale_)
+        ->detect(img.mat(), result.keypoints);
+    return result;
+}
+
+DescriptorSet DescribeBRISK::operator()(Image<Gray> img) const {
+    DescriptorSet result;
+    result.keypoints = kps_;
+    cv::BRISK::create(threshold_, octaves_, pattern_scale_)
+        ->compute(img.mat(), result.keypoints.keypoints, result.descriptors);
+    return result;
+}
+
+DescriptorSet DescribeBRISK::operator()(Image<BGR> img) const {
+    DescriptorSet result;
+    result.keypoints = kps_;
+    cv::BRISK::create(threshold_, octaves_, pattern_scale_)
+        ->compute(to_gray(img.mat()), result.keypoints.keypoints, result.descriptors);
+    return result;
+}
+
+// ── KAZE ─────────────────────────────────────────────────────────────────────
+
+KeypointSet DetectKAZE::operator()(Image<Gray> img) const {
+    KeypointSet result;
+    cv::KAZE::create(false, false, threshold_, octaves_, sublevels_)
+        ->detect(img.mat(), result.keypoints);
+    return result;
+}
+
+DescriptorSet DescribeKAZE::operator()(Image<Gray> img) const {
+    DescriptorSet result;
+    result.keypoints = kps_;
+    cv::KAZE::create(false, false, threshold_, octaves_, sublevels_)
+        ->compute(img.mat(), result.keypoints.keypoints, result.descriptors);
+    return result;
+}
+
+DescriptorSet DescribeKAZE::operator()(Image<BGR> img) const {
+    DescriptorSet result;
+    result.keypoints = kps_;
+    cv::KAZE::create(false, false, threshold_, octaves_, sublevels_)
+        ->compute(to_gray(img.mat()), result.keypoints.keypoints, result.descriptors);
+    return result;
+}
+
 std::vector<cv::Point2f> GoodFeaturesToTrack::operator()(const Image<Gray>& img) const {
     std::vector<cv::Point2f> corners;
     cv::goodFeaturesToTrack(img.mat(), corners, max_corners_,

--- a/src/core/ops/haar_detect.cpp
+++ b/src/core/ops/haar_detect.cpp
@@ -1,0 +1,19 @@
+// src/core/ops/haar_detect.cpp
+#include "improc/core/ops/haar_detect.hpp"
+#include <opencv2/imgproc.hpp>
+
+namespace improc::core {
+
+std::vector<cv::Rect> DetectHaar::operator()(
+    const Image<BGR>& img, const cv::CascadeClassifier& cc) const
+{
+    cv::Mat gray;
+    cv::cvtColor(img.mat(), gray, cv::COLOR_BGR2GRAY);
+
+    std::vector<cv::Rect> rects;
+    const_cast<cv::CascadeClassifier&>(cc).detectMultiScale(
+        gray, rects, scale_factor_, min_neighbors_, 0, min_size_, max_size_);
+    return rects;
+}
+
+} // namespace improc::core

--- a/src/ml/dnn_segmentor.cpp
+++ b/src/ml/dnn_segmentor.cpp
@@ -1,0 +1,78 @@
+// src/ml/dnn_segmentor.cpp
+#include "improc/ml/dnn_segmentor.hpp"
+#include <format>
+#include <opencv2/imgproc.hpp>
+
+using improc::ModelError;
+
+namespace improc::ml {
+
+DnnSegmentor::DnnSegmentor(const std::filesystem::path& model,
+                           const std::filesystem::path& config)
+{
+    if (!std::filesystem::exists(model))
+        throw ModelError{model.string(), "file not found"};
+
+    try {
+        net_ = cv::dnn::readNet(model.string(),
+                                config.empty() ? "" : config.string());
+    } catch (const cv::Exception& e) {
+        throw ModelError{model.string(), "cv::dnn failed to load: " + std::string(e.what())};
+    }
+    if (net_.empty())
+        throw ModelError{model.string(), "loaded model is empty"};
+}
+
+std::expected<SegmentationMask, improc::Error>
+DnnSegmentor::operator()(const Image<BGR>& img) const
+{
+    const int orig_w = img.cols();
+    const int orig_h = img.rows();
+
+    cv::Mat blob = cv::dnn::blobFromImage(
+        img.mat(), scale_, {input_w_, input_h_},
+        {mean_b_, mean_g_, mean_r_}, swap_rb_);
+    net_.setInput(blob);
+
+    cv::Mat output;
+    try {
+        output = output_layer_.empty()
+            ? net_.forward()
+            : net_.forward(output_layer_);
+    } catch (const cv::Exception& e) {
+        return std::unexpected(improc::Error{
+            improc::Error::Code::OnnxInferenceFailed,
+            std::format("DnnSegmentor: forward pass failed: {}", e.what())});
+    }
+
+    if (output.dims != 4) {
+        return std::unexpected(improc::Error{
+            improc::Error::Code::OnnxInferenceFailed,
+            std::format("DnnSegmentor: expected 4-D output [1,C,H,W], got {} dims",
+                        output.dims)});
+    }
+
+    const int C    = output.size[1];
+    const int H    = output.size[2];
+    const int W    = output.size[3];
+    const auto* data = reinterpret_cast<const float*>(output.data);
+
+    cv::Mat mask(H, W, CV_8UC1);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            int   best_c   = 0;
+            float best_val = data[y * W + x];          // c=0
+            for (int c = 1; c < C; ++c) {
+                float val = data[c * H * W + y * W + x];
+                if (val > best_val) { best_val = val; best_c = c; }
+            }
+            mask.at<uchar>(y, x) = static_cast<uchar>(best_c);
+        }
+    }
+
+    cv::Mat mask_resized;
+    cv::resize(mask, mask_resized, {orig_w, orig_h}, 0, 0, cv::INTER_NEAREST);
+    return SegmentationMask{Image<Gray>{mask_resized}, labels_};
+}
+
+} // namespace improc::ml

--- a/src/ml/hog_detector.cpp
+++ b/src/ml/hog_detector.cpp
@@ -1,0 +1,34 @@
+// src/ml/hog_detector.cpp
+#include "improc/ml/hog_detector.hpp"
+#include <cmath>
+
+namespace improc::ml {
+
+HOGDetector::HOGDetector() {
+    hog_.setSVMDetector(cv::HOGDescriptor::getDefaultPeopleDetector());
+}
+
+HOGDetector::HOGDetector(const std::vector<float>& svm) {
+    if (svm.empty())
+        throw ParameterError{"svm", "must not be empty", "HOGDetector"};
+    hog_.setSVMDetector(svm);
+}
+
+std::vector<Detection> HOGDetector::operator()(const Image<BGR>& img) const {
+    std::vector<cv::Rect>  locations;
+    std::vector<double>    weights;
+
+    hog_.detectMultiScale(img.mat(), locations, weights,
+                          hit_threshold_, win_stride_, padding_, scale_);
+
+    std::vector<Detection> result;
+    result.reserve(locations.size());
+    for (std::size_t i = 0; i < locations.size(); ++i) {
+        // HOG weights are unbounded; sigmoid maps them to (0, 1)
+        float conf = 1.0f / (1.0f + static_cast<float>(std::exp(-weights[i])));
+        result.push_back({cv::Rect2f{locations[i]}, 0, conf, "person"});
+    }
+    return result;
+}
+
+} // namespace improc::ml

--- a/tests/core/ops/test_feature_detection.cpp
+++ b/tests/core/ops/test_feature_detection.cpp
@@ -135,3 +135,85 @@ TEST(GoodFeaturesToTrackTest, QualityLevelNegativeThrows) {
 TEST(GoodFeaturesToTrackTest, MinDistanceNegativeThrows) {
     EXPECT_THROW(GoodFeaturesToTrack{}.min_distance(-1.0), improc::ParameterError);
 }
+
+// ── DetectBRISK ───────────────────────────────────────────────────────────────
+
+TEST(DetectBRISKTest, FindsKeypointsInTexturedImage) {
+    Image<Gray> src = make_textured();
+    KeypointSet ks = src | DetectBRISK{};
+    EXPECT_GT(ks.size(), 0u);
+}
+
+TEST(DetectBRISKTest, ThresholdSetterChangesCount) {
+    Image<Gray> src = make_textured();
+    // higher threshold → stricter → fewer keypoints
+    std::size_t n_low  = (src | DetectBRISK{}.threshold(10)).size();
+    std::size_t n_high = (src | DetectBRISK{}.threshold(100)).size();
+    EXPECT_GE(n_low, n_high);
+}
+
+TEST(DetectBRISKTest, BlankImageHasNoKeypoints) {
+    Image<Gray> blank(cv::Mat(200, 200, CV_8UC1, cv::Scalar(0)));
+    KeypointSet ks = blank | DetectBRISK{};
+    EXPECT_EQ(ks.size(), 0u);
+}
+
+// ── DescribeBRISK ─────────────────────────────────────────────────────────────
+
+TEST(DescribeBRISKTest, DescriptorsAreCV8U) {
+    Image<Gray> src = make_textured();
+    KeypointSet kps = src | DetectBRISK{};
+    if (kps.empty()) GTEST_SKIP() << "no BRISK keypoints detected";
+    DescriptorSet ds = src | DescribeBRISK{kps};
+    EXPECT_FALSE(ds.empty());
+    EXPECT_EQ(ds.descriptors.type(), CV_8U);
+    EXPECT_EQ(ds.size(), ds.keypoints.size());
+}
+
+TEST(DescribeBRISKTest, AcceptsBGRImage) {
+    Image<BGR> src{cv::Mat(200, 200, CV_8UC3, cv::Scalar(128, 64, 200))};
+    cv::rectangle(src.mat(), {10,10}, {90,90}, cv::Scalar(0,0,255), -1);
+    KeypointSet kps = make_textured() | DetectBRISK{};
+    DescriptorSet ds = src | DescribeBRISK{kps};
+    SUCCEED();  // must not throw; result may be empty
+}
+
+// ── DetectKAZE ────────────────────────────────────────────────────────────────
+
+TEST(DetectKAZETest, FindsKeypointsInTexturedImage) {
+    Image<Gray> src = make_textured();
+    KeypointSet ks = src | DetectKAZE{};
+    EXPECT_GT(ks.size(), 0u);
+}
+
+TEST(DetectKAZETest, ThresholdSetterChangesCount) {
+    Image<Gray> src = make_textured();
+    std::size_t n_low  = (src | DetectKAZE{}.threshold(0.0001f)).size();
+    std::size_t n_high = (src | DetectKAZE{}.threshold(0.01f)).size();
+    EXPECT_GE(n_low, n_high);
+}
+
+TEST(DetectKAZETest, BlankImageHasNoKeypoints) {
+    Image<Gray> blank(cv::Mat(200, 200, CV_8UC1, cv::Scalar(0)));
+    KeypointSet ks = blank | DetectKAZE{};
+    EXPECT_EQ(ks.size(), 0u);
+}
+
+// ── DescribeKAZE ──────────────────────────────────────────────────────────────
+
+TEST(DescribeKAZETest, DescriptorsAreCV32F) {
+    Image<Gray> src = make_textured();
+    KeypointSet kps = src | DetectKAZE{};
+    if (kps.empty()) GTEST_SKIP() << "no KAZE keypoints detected";
+    DescriptorSet ds = src | DescribeKAZE{kps};
+    EXPECT_FALSE(ds.empty());
+    EXPECT_EQ(ds.descriptors.type(), CV_32F);
+    EXPECT_EQ(ds.size(), ds.keypoints.size());
+}
+
+TEST(DescribeKAZETest, AcceptsBGRImage) {
+    Image<BGR> src{cv::Mat(200, 200, CV_8UC3, cv::Scalar(100, 150, 200))};
+    KeypointSet kps = make_textured() | DetectKAZE{};
+    DescriptorSet ds = src | DescribeKAZE{kps};
+    SUCCEED();
+}

--- a/tests/core/ops/test_haar_detect.cpp
+++ b/tests/core/ops/test_haar_detect.cpp
@@ -1,0 +1,52 @@
+// tests/core/ops/test_haar_detect.cpp
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <opencv2/objdetect.hpp>
+#include "improc/core/pipeline.hpp"
+#include "improc/exceptions.hpp"
+
+using namespace improc::core;
+namespace fs = std::filesystem;
+
+// Path to existing Haar cascade test model
+static const fs::path CASCADE =
+    fs::path{__FILE__}.parent_path().parent_path().parent_path()
+    / "ml" / "testdata" / "haarcascade_frontalface_default.xml";
+
+static Image<BGR> make_black(int rows = 100, int cols = 100) {
+    return Image<BGR>(cv::Mat(rows, cols, CV_8UC3, cv::Scalar(0,0,0)));
+}
+
+TEST(DetectHaarTest, ScaleFactorBelowOneThrows) {
+    EXPECT_THROW(DetectHaar{}.scale_factor(0.9), improc::ParameterError);
+}
+
+TEST(DetectHaarTest, ScaleFactorExactlyOneThrows) {
+    EXPECT_THROW(DetectHaar{}.scale_factor(1.0), improc::ParameterError);
+}
+
+TEST(DetectHaarTest, NegativeMinNeighborsThrows) {
+    EXPECT_THROW(DetectHaar{}.min_neighbors(-1), improc::ParameterError);
+}
+
+TEST(DetectHaarTest, InferenceOnBlackImageReturnsEmptyVector) {
+    cv::CascadeClassifier cc;
+    ASSERT_TRUE(cc.load(CASCADE.string())) << "failed to load: " << CASCADE;
+    auto rects = DetectHaar{}(make_black(), cc);
+    EXPECT_TRUE(rects.empty());   // no faces in a black image
+}
+
+TEST(DetectHaarTest, AllRectsWithinImageBounds) {
+    cv::CascadeClassifier cc;
+    ASSERT_TRUE(cc.load(CASCADE.string()));
+    auto img = make_black(200, 200);
+    auto rects = DetectHaar{}(img, cc);
+    // A black image never yields detections, so this loop is a no-op here.
+    // The bounds check guards against regressions if a real cascade fires unexpectedly.
+    for (const auto& r : rects) {
+        EXPECT_GE(r.x, 0);
+        EXPECT_GE(r.y, 0);
+        EXPECT_LE(r.x + r.width,  img.cols());
+        EXPECT_LE(r.y + r.height, img.rows());
+    }
+}

--- a/tests/ml/test_dnn_segmentor.cpp
+++ b/tests/ml/test_dnn_segmentor.cpp
@@ -1,0 +1,125 @@
+// tests/ml/test_dnn_segmentor.cpp
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <opencv2/core.hpp>
+#include "improc/ml/dnn_segmentor.hpp"
+#include "improc/exceptions.hpp"
+
+using namespace improc::ml;
+namespace fs = std::filesystem;
+
+// Reuse the tiny ONNX model created for OnnxSegmentor — cv::dnn can read it
+// when OpenCV is built with Protobuf support.
+static const fs::path TINY_ONNX =
+    fs::path{__FILE__}.parent_path().parent_path()
+    / "onnx" / "testdata" / "tiny_segmentor_semantic.onnx";
+
+static Image<BGR> make_img(int rows = 8, int cols = 8) {
+    return Image<BGR>(cv::Mat(rows, cols, CV_8UC3, cv::Scalar(100, 150, 200)));
+}
+
+// Helper: attempt to load TINY_ONNX; skip the test if cv::dnn lacks Protobuf support.
+static std::optional<DnnSegmentor> try_load_segmentor(int w = 8, int h = 8) {
+    try {
+        return DnnSegmentor{TINY_ONNX}.input_size(w, h);
+    } catch (const improc::ModelError& e) {
+        std::string msg = e.what();
+        if (msg.find("Protobuf") != std::string::npos ||
+            msg.find("protobuf") != std::string::npos ||
+            msg.find("onnx_importer") != std::string::npos) {
+            return std::nullopt;   // cv::dnn built without Protobuf — skip inference tests
+        }
+        throw;
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Error-path tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST(DnnSegmentorTest, NonExistentPathThrows) {
+    EXPECT_THROW(DnnSegmentor{"nonexistent/model.onnx"}, improc::ModelError);
+}
+
+TEST(DnnSegmentorTest, CorruptModelThrows) {
+    fs::path p = fs::temp_directory_path() / "improc_dnn_seg_dummy.onnx";
+    { std::ofstream f(p); f << "not a real onnx"; }
+    EXPECT_THROW(DnnSegmentor{p.string()}, improc::ModelError);
+    fs::remove(p);
+}
+
+TEST(DnnSegmentorTest, ZeroScaleThrows) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available";
+    EXPECT_THROW(seg->scale(0.0f), improc::ParameterError);
+}
+
+TEST(DnnSegmentorTest, NegativeScaleThrows) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available";
+    EXPECT_THROW(seg->scale(-1.0f), improc::ParameterError);
+}
+
+TEST(DnnSegmentorTest, ZeroInputWidthThrows) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available";
+    EXPECT_THROW(seg->input_size(0, 8), improc::ParameterError);
+}
+
+TEST(DnnSegmentorTest, ZeroInputHeightThrows) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available";
+    EXPECT_THROW(seg->input_size(8, 0), improc::ParameterError);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Inference tests — skipped when cv::dnn was built without Protobuf support
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST(DnnSegmentorTest, InferenceReturnsExpected) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available (built without Protobuf)";
+    auto result = (*seg)(make_img());
+    EXPECT_TRUE(result.has_value()) << result.error().message;
+}
+
+TEST(DnnSegmentorTest, MaskSizeMatchesInput) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available (built without Protobuf)";
+    auto img    = make_img(200, 200);
+    auto result = (*seg)(img);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->class_mask.rows(), img.rows());
+    EXPECT_EQ(result->class_mask.cols(), img.cols());
+}
+
+TEST(DnnSegmentorTest, MaskPixelsInClassRange) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available (built without Protobuf)";
+    auto result = (*seg)(make_img());
+    ASSERT_TRUE(result.has_value());
+    double minVal, maxVal;
+    cv::minMaxLoc(result->class_mask.mat(), &minVal, &maxVal);
+    EXPECT_GE(minVal, 0.0);
+    EXPECT_LE(maxVal, 3.0);   // 4-class model -> max class id = 3
+}
+
+TEST(DnnSegmentorTest, LabelAtReturnsCorrectLabel) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available (built without Protobuf)";
+    auto result = DnnSegmentor{TINY_ONNX}
+        .input_size(8, 8)
+        .labels({"bg", "cat", "dog", "bird"})
+        (make_img());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->label_at(1), "cat");
+}
+
+TEST(DnnSegmentorTest, LabelAtOutOfRangeReturnsEmpty) {
+    auto seg = try_load_segmentor();
+    if (!seg) GTEST_SKIP() << "cv::dnn ONNX support not available (built without Protobuf)";
+    auto result = (*seg)(make_img());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->label_at(99), "");
+}

--- a/tests/ml/test_hog_detector.cpp
+++ b/tests/ml/test_hog_detector.cpp
@@ -1,0 +1,58 @@
+// tests/ml/test_hog_detector.cpp
+#include <gtest/gtest.h>
+#include <opencv2/core.hpp>
+#include "improc/ml/hog_detector.hpp"
+#include "improc/exceptions.hpp"
+
+using namespace improc::ml;
+
+static Image<BGR> make_grey(int rows = 400, int cols = 400) {
+    return Image<BGR>(cv::Mat(rows, cols, CV_8UC3, cv::Scalar(128, 128, 128)));
+}
+
+TEST(HOGDetectorTest, DefaultConstructorSucceeds) {
+    EXPECT_NO_THROW(HOGDetector{});
+}
+
+TEST(HOGDetectorTest, EmptySvmThrows) {
+    EXPECT_THROW(HOGDetector{std::vector<float>{}}, improc::ParameterError);
+}
+
+TEST(HOGDetectorTest, ScaleBelowOneThrows) {
+    EXPECT_THROW(HOGDetector{}.scale(0.9), improc::ParameterError);
+}
+
+TEST(HOGDetectorTest, ScaleExactlyOneThrows) {
+    EXPECT_THROW(HOGDetector{}.scale(1.0), improc::ParameterError);
+}
+
+TEST(HOGDetectorTest, InferenceOnGreyImageReturnsVector) {
+    // grey 400x400 has no people — must return empty without throwing
+    auto result = HOGDetector{}(make_grey());
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(HOGDetectorTest, ConfidenceInZeroOne) {
+    auto result = HOGDetector{}.hit_threshold(-5.0)(make_grey());
+    if (result.empty()) GTEST_SKIP() << "no HOG detections on grey image — property untestable";
+    for (const auto& det : result) {
+        EXPECT_GE(det.confidence, 0.0f);
+        EXPECT_LE(det.confidence, 1.0f);
+    }
+}
+
+TEST(HOGDetectorTest, ClassIdIsZero) {
+    auto result = HOGDetector{}.hit_threshold(-5.0)(make_grey());
+    if (result.empty()) GTEST_SKIP() << "no HOG detections on grey image — property untestable";
+    for (const auto& det : result) {
+        EXPECT_EQ(det.class_id, 0);
+    }
+}
+
+TEST(HOGDetectorTest, LabelIsPerson) {
+    auto result = HOGDetector{}.hit_threshold(-5.0)(make_grey());
+    if (result.empty()) GTEST_SKIP() << "no HOG detections on grey image — property untestable";
+    for (const auto& det : result) {
+        EXPECT_EQ(det.label, "person");
+    }
+}


### PR DESCRIPTION
## Summary

- **fix(visualization,threading):** add `ml_charts.hpp` to `visualization/visualization.hpp` umbrella; create `threading/threading.hpp` umbrella (closes silent omission of `ConfusionMatrixPlot`, `PRCurvePlot`, `ROCCurvePlot`, `ClassBarChart`, `IoUHistogram`, `ThreadPool`, `FramePipeline`)
- **feat(core):** add `DetectHaar` op wrapping `cv::CascadeClassifier::detectMultiScale`; returns `std::vector<cv::Rect>`, converts BGR→Gray internally
- **feat(core):** add `DetectBRISK`, `DescribeBRISK` (CV_8U binary descriptors) and `DetectKAZE`, `DescribeKAZE` (CV_32F float descriptors) — same pattern as existing ORB/SIFT/AKAZE ops
- **feat(ml):** add `DnnSegmentor` — `cv::dnn`-backed semantic segmentation returning `std::expected<SegmentationMask, improc::Error>`; supports ONNX, Caffe, TF, Darknet via `cv::dnn::readNet`
- **feat(ml):** add `HOGDetector` — `cv::HOGDescriptor` people detector returning `std::vector<Detection>` with sigmoid-mapped confidence; lives in `improc::ml` to avoid `core → ml` dependency

This is the last feature milestone before the v1.0.0 API freeze. All identified gaps closed except `version.hpp` bump and top-level `improc/improc.hpp` (deferred to v1.0.0).

## Test Plan

- [ ] `DetectHaarTest.*` — 5 tests: parameter validation, inference on black image, bounds check
- [ ] `DetectBRISKTest.*` / `DescribeBRISKTest.*` — 5 tests: keypoints, threshold setter, CV_8U descriptors, BGR overload, blank image
- [ ] `DetectKAZETest.*` / `DescribeKAZETest.*` — 5 tests: keypoints, threshold setter, CV_32F descriptors, BGR overload, blank image
- [ ] `DnnSegmentorTest.*` — 11 tests: ModelError on bad path, ParameterError on bad setters, inference, mask size/range, labels (some skip when cv::dnn built without Protobuf)
- [ ] `HOGDetectorTest.*` — 8 tests: construction, ParameterError on empty SVM / bad scale, inference, confidence/class/label properties
- [ ] Full suite: no regressions (pre-existing `VideoWriterTest` failures are codec/env, unrelated)
