### PR TITLE
feat: v1.0.0 — API freeze, umbrella headers, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [[Unreleased]](#unreleased)
+- [[1.0.0]](#100--2026-06-08) — 2026-06-08 · API freeze: `improc/improc.hpp` top-level umbrella, `calib/calib.hpp`, version bump to 1.0.0
+- [[0.20.0]](#0200--2026-06-04) — 2026-06-04 · API completeness: `DetectHaar`, BRISK/KAZE detectors, `DnnSegmentor`, `HOGDetector`, umbrella header fixes
 - [[0.19.0]](#0190--2026-06-03) — 2026-06-03 · OnnxSegmentor + OnnxInstanceSegmentor: semantic and instance segmentation inference in `improc::onnx`
 - [[0.18.0]](#0180--2026-06-02) — 2026-06-02 · Test improvements: renamed/moved test files, added `test_to_bgr.cpp` and `test_axis.cpp`
 - [[0.17.0]](#0170--2026-06-02) — 2026-06-02 · Fisheye camera ops: `FisheyeCalibrate`, `FisheyeUndistort`, `FisheyeUndistortPoints`, `FisheyeInitRectifyMap`, `FisheyeStereoCalibrate`, `FisheyeStereoRectify`
@@ -29,6 +31,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ---
 
 ## [Unreleased]
+
+---
+
+## [1.0.0] — 2026-06-08
+
+### Added
+- `include/improc/improc.hpp` — top-level umbrella header; single-include convenience for all `improc` namespaces
+- `include/improc/calib/calib.hpp` — umbrella header for `improc::calib` (delegates to `calib/pipeline.hpp`), consistent with `ml/ml.hpp`, `onnx/onnx.hpp`, `threading/threading.hpp`, etc.
+
+### Changed
+- Version bumped to **1.0.0** in `version.hpp` and `CMakeLists.txt`; `IMPROC_VERSION` macro encodes `10000` (i.e. `1*10000 + 0*100 + 0`)
+- **API freeze** — public API is now stable; breaking changes deferred to v2.0.0
+
+---
+
+## [0.20.0] — 2026-06-04
+
+### Added
+- `DetectHaar` pipeline op in `improc::core` — wraps `cv::CascadeClassifier::detectMultiScale`; returns `std::vector<cv::Rect>`; converts BGR→Gray internally; fluent setters: `scale_factor`, `min_neighbors`, `min_size`, `max_size`
+- `DetectBRISK` / `DescribeBRISK` in `improc::core` — binary descriptor (CV_8U); same pattern as ORB/AKAZE
+- `DetectKAZE` / `DescribeKAZE` in `improc::core` — float descriptor (CV_32F, 64-dim); non-accelerated KAZE variant
+- `DnnSegmentor` in `improc::ml` — `cv::dnn`-backed semantic segmentation; accepts ONNX, Caffe, TF, Darknet; returns `std::expected<SegmentationMask, improc::Error>`; fluent setters: `input_size`, `scale`, `mean`, `swap_rb`, `output_layer`, `labels`
+- `HOGDetector` in `improc::ml` — `cv::HOGDescriptor` people detector; returns `std::vector<Detection>` with sigmoid-mapped confidence; fluent setters: `win_stride`, `padding`, `scale`, `hit_threshold`
+
+### Fixed
+- `visualization/visualization.hpp` now includes `ml_charts.hpp` (previously `ConfusionMatrixPlot`, `PRCurvePlot`, `ROCCurvePlot`, `ClassBarChart`, `IoUHistogram` were silently omitted)
+- `threading/threading.hpp` umbrella header added (previously `improc::threading` had no `<namespace>.hpp` umbrella unlike all other namespaces)
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.30)
-project(improc VERSION 0.18.0)
+project(improc VERSION 1.0.0)
 
 if(APPLE)
     string(REPLACE "--as-needed" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")

--- a/include/improc/calib/calib.hpp
+++ b/include/improc/calib/calib.hpp
@@ -1,0 +1,10 @@
+// include/improc/calib/calib.hpp
+#pragma once
+
+/** @file calib.hpp
+ *  @brief Convenience header — includes all `improc::calib` types
+ *         (calibration, chessboard, undistort, projection, stereo,
+ *          epipolar geometry, ArUco, and fisheye ops).
+ */
+
+#include "improc/calib/pipeline.hpp"

--- a/include/improc/improc.hpp
+++ b/include/improc/improc.hpp
@@ -1,0 +1,28 @@
+// include/improc/improc.hpp
+#pragma once
+
+/** @file improc.hpp
+ *  @brief Top-level convenience header — includes all `improc` namespaces.
+ *
+ *  Pull in everything with a single include:
+ *  @code
+ *  #include "improc/improc.hpp"
+ *  @endcode
+ *
+ *  For production builds prefer the individual namespace headers
+ *  (`improc/core/pipeline.hpp`, `improc/ml/ml.hpp`, …) to keep
+ *  compile times low.
+ */
+
+#include "improc/version.hpp"
+#include "improc/error.hpp"
+#include "improc/exceptions.hpp"
+
+#include "improc/core/pipeline.hpp"
+#include "improc/views/views.hpp"
+#include "improc/io/io.hpp"
+#include "improc/calib/calib.hpp"
+#include "improc/ml/ml.hpp"
+#include "improc/onnx/onnx.hpp"
+#include "improc/threading/threading.hpp"
+#include "improc/visualization/visualization.hpp"

--- a/include/improc/version.hpp
+++ b/include/improc/version.hpp
@@ -1,19 +1,19 @@
 // include/improc/version.hpp
 #pragma once
 
-#define IMPROC_VERSION_MAJOR 0
-#define IMPROC_VERSION_MINOR 18
+#define IMPROC_VERSION_MAJOR 1
+#define IMPROC_VERSION_MINOR 0
 #define IMPROC_VERSION_PATCH 0
 
 /// Encoded as MAJOR*10000 + MINOR*100 + PATCH — use for compile-time comparisons:
 /// @code
-/// #if IMPROC_VERSION >= 1800  // >= 0.18.0
+/// #if IMPROC_VERSION >= 10000  // >= 1.0.0
 /// @endcode
 #define IMPROC_VERSION (IMPROC_VERSION_MAJOR * 10000 + IMPROC_VERSION_MINOR * 100 + IMPROC_VERSION_PATCH)
 
-#define IMPROC_VERSION_STRING "0.18.0"
+#define IMPROC_VERSION_STRING "1.0.0"
 
 namespace improc {
-/// Returns the library version string, e.g. "0.18.0".
+/// Returns the library version string, e.g. "1.0.0".
 inline constexpr const char* version_string() noexcept { return IMPROC_VERSION_STRING; }
 } // namespace improc


### PR DESCRIPTION
## Summary

- Add `include/improc/improc.hpp` — top-level single-include header pulling in all 8 namespaces (`core`, `views`, `io`, `calib`, `ml`, `onnx`, `threading`, `visualization`)
- Add `include/improc/calib/calib.hpp` — convenience umbrella for the calib namespace
- Bump version to `1.0.0` in `version.hpp` and `CMakeLists.txt` (`IMPROC_VERSION_MAJOR=1`)
- Add CHANGELOG entries for v0.20.0 and v1.0.0

## Test Plan

- [ ] `include/improc/improc.hpp` compiles without errors (syntax-checked with clang++ -fsyntax-only ✅)
- [ ] CI passes all existing tests (no code logic changed)
- [ ] Version string returns `"1.0.0"` at compile time via `IMPROC_VERSION_STRING` and `improc::version_string()`
