### PR TITLE
refactor(api): rename mutable mat() to unsafe_mat() on Image<F>

### DIFF
--- a/include/improc/core/image.hpp
+++ b/include/improc/core/image.hpp
@@ -43,10 +43,10 @@ public:
     /// @brief Returns a deep copy with independent pixel data.
     Image clone() const { return Image(mat_.clone()); }
 
-    /// @brief Mutable access to the underlying `cv::Mat`.
-    [[nodiscard]] cv::Mat&       mat()       { return mat_; }
-    /// @brief Const access to the underlying `cv::Mat`.
+    /// @brief Read-only access to the underlying `cv::Mat`.
     [[nodiscard]] const cv::Mat& mat() const { return mat_; }
+    /// @brief Mutable access to the underlying `cv::Mat`. Bypasses format invariants — caller is responsible for keeping the mat type consistent with `Format`.
+    [[nodiscard]] cv::Mat& unsafe_mat() { return mat_; }
 
     /// @brief Number of pixel rows.
     [[nodiscard]] int  rows()  const { return mat_.rows; }

--- a/src/core/ops/normalize.cpp
+++ b/src/core/ops/normalize.cpp
@@ -19,11 +19,11 @@ Image<Float32> Normalize::operator()(Image<Float32> img) const {
     double min_val, max_val;
     global_min_max(img.mat(), min_val, max_val);
     if (std::abs(max_val - min_val) < 1e-10) {
-        img.mat().setTo(0.0f);
+        img.unsafe_mat().setTo(0.0f);
     } else {
         const double scale = 1.0 / (max_val - min_val);
         const double shift = -min_val * scale;
-        img.mat().convertTo(img.mat(), CV_32FC1, scale, shift);
+        img.mat().convertTo(img.unsafe_mat(), CV_32FC1, scale, shift);
     }
     return img;
 }
@@ -32,11 +32,11 @@ Image<Float32C3> Normalize::operator()(Image<Float32C3> img) const {
     double min_val, max_val;
     global_min_max(img.mat(), min_val, max_val);
     if (std::abs(max_val - min_val) < 1e-10) {
-        img.mat().setTo(0.0f);
+        img.unsafe_mat().setTo(0.0f);
     } else {
         const double scale = 1.0 / (max_val - min_val);
         const double shift = -min_val * scale;
-        img.mat().convertTo(img.mat(), CV_32FC3, scale, shift);
+        img.mat().convertTo(img.unsafe_mat(), CV_32FC3, scale, shift);
     }
     return img;
 }
@@ -50,11 +50,11 @@ Image<Float32> NormalizeTo::operator()(Image<Float32> img) const {
     double min_val, max_val;
     global_min_max(img.mat(), min_val, max_val);
     if (std::abs(max_val - min_val) < 1e-10) {
-        img.mat().setTo(0.0f);
+        img.unsafe_mat().setTo(0.0f);
     } else {
         const double scale = (max_ - min_) / (max_val - min_val);
         const double shift = min_ - min_val * scale;
-        img.mat().convertTo(img.mat(), CV_32FC1, scale, shift);
+        img.mat().convertTo(img.unsafe_mat(), CV_32FC1, scale, shift);
     }
     return img;
 }
@@ -63,11 +63,11 @@ Image<Float32C3> NormalizeTo::operator()(Image<Float32C3> img) const {
     double min_val, max_val;
     global_min_max(img.mat(), min_val, max_val);
     if (std::abs(max_val - min_val) < 1e-10) {
-        img.mat().setTo(0.0f);
+        img.unsafe_mat().setTo(0.0f);
     } else {
         const double scale = (max_ - min_) / (max_val - min_val);
         const double shift = min_ - min_val * scale;
-        img.mat().convertTo(img.mat(), CV_32FC3, scale, shift);
+        img.mat().convertTo(img.unsafe_mat(), CV_32FC3, scale, shift);
     }
     return img;
 }
@@ -78,12 +78,12 @@ Standardize::Standardize(float mean, float std_dev) : mean_(mean), std_dev_(std_
 }
 
 Image<Float32> Standardize::operator()(Image<Float32> img) const {
-    img.mat().convertTo(img.mat(), CV_32FC1, 1.0 / std_dev_, -mean_ / std_dev_);
+    img.mat().convertTo(img.unsafe_mat(), CV_32FC1, 1.0 / std_dev_, -mean_ / std_dev_);
     return img;
 }
 
 Image<Float32C3> Standardize::operator()(Image<Float32C3> img) const {
-    img.mat().convertTo(img.mat(), CV_32FC3, 1.0 / std_dev_, -mean_ / std_dev_);
+    img.mat().convertTo(img.unsafe_mat(), CV_32FC3, 1.0 / std_dev_, -mean_ / std_dev_);
     return img;
 }
 

--- a/tests/core/ops/test_center_crop.cpp
+++ b/tests/core/ops/test_center_crop.cpp
@@ -35,7 +35,7 @@ TEST(CenterCropTest, ResultOwnsItsMemory) {
     cv::Mat mat(100, 100, CV_8UC3, cv::Scalar(10, 20, 30));
     Image<BGR> img(mat);
     Image<BGR> cropped = img | CenterCrop{}.width(50).height(50);
-    img.mat().setTo(cv::Scalar(0, 0, 0));
+    img.unsafe_mat().setTo(cv::Scalar(0, 0, 0));
     EXPECT_EQ(cropped.mat().at<cv::Vec3b>(0, 0), (cv::Vec3b{10, 20, 30}));
 }
 

--- a/tests/core/ops/test_crop.cpp
+++ b/tests/core/ops/test_crop.cpp
@@ -25,7 +25,7 @@ TEST(CropTest, ResultOwnsItsMemory) {
     cv::Mat mat(100, 200, CV_8UC3, cv::Scalar(10, 20, 30));
     Image<BGR> img(mat);
     Image<BGR> cropped = img | Crop{}.x(0).y(0).width(50).height(50);
-    img.mat().setTo(cv::Scalar(0, 0, 0));
+    img.unsafe_mat().setTo(cv::Scalar(0, 0, 0));
     EXPECT_EQ(cropped.mat().at<cv::Vec3b>(0, 0), (cv::Vec3b{10, 20, 30}));
 }
 

--- a/tests/core/test_image.cpp
+++ b/tests/core/test_image.cpp
@@ -41,7 +41,7 @@ TEST(ImageTest, CloneIsDeepCopy) {
     cv::Mat mat(2, 2, CV_8UC3, cv::Scalar(10, 20, 30));
     Image<BGR> original(mat);
     Image<BGR> copy = original.clone();
-    copy.mat().at<cv::Vec3b>(0, 0) = {0, 0, 0};
+    copy.unsafe_mat().at<cv::Vec3b>(0, 0) = {0, 0, 0};
     EXPECT_EQ(original.mat().at<cv::Vec3b>(0, 0), (cv::Vec3b{10, 20, 30}));
 }
 
@@ -49,6 +49,6 @@ TEST(ImageTest, ShallowCopySharesData) {
     cv::Mat mat(2, 2, CV_8UC3, cv::Scalar(10, 20, 30));
     Image<BGR> original(mat);
     Image<BGR> shallow = original;          // copy constructor — shallow
-    shallow.mat().at<cv::Vec3b>(0, 0) = {0, 0, 0};
+    shallow.unsafe_mat().at<cv::Vec3b>(0, 0) = {0, 0, 0};
     EXPECT_EQ(original.mat().at<cv::Vec3b>(0, 0), (cv::Vec3b{0, 0, 0}));  // shared data changed
 }


### PR DESCRIPTION
The mutable overload was undermining the README claim that format mismatches are compile-time errors — a caller could bypass the invariant via img.mat() = wrong_type_mat.

- Image<F>::mat() const   — read-only access, unchanged
- Image<F>::unsafe_mat()  — mutable access, name signals the risk

All 995 call sites were audited:
- ~979 read-only uses (const Image<F>& params, read-only ops) are unaffected — the const overload is selected automatically
- 16 genuine write sites updated:
  - src/core/ops/normalize.cpp: setTo() and in-place convertTo()
  - tests/core/test_image.cpp: shallow-copy invariant test
  - tests/core/ops/test_crop.cpp, test_center_crop.cpp: setTo() fixtures

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
