### PR TITLE
docs: fix Eigen misrepresentation in README and conanfile.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 # 1. Detect your compiler profile (run once)
 conan profile detect --force
 
-# 2. Configure — Conan installs OpenCV, GTest, Eigen automatically
+# 2. Configure — Conan installs OpenCV, GTest automatically
 cmake \
   -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="conan_provider.cmake" \
   -DCONAN_COMMAND=$(which conan) \
@@ -653,7 +653,6 @@ cmake --build cmake-build-debug --target improc_tests
 
 - **Compilers:** GCC 14.2, Clang 19.1.7
 - **OpenCV:** 4.8.1
-- **Eigen:** 3.4.0
 - **GoogleTest:** 1.16.0
 
 ## Benchmarks

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,8 +21,10 @@ class ConanApplication(ConanFile):
 
     def configure(self):
         self.options["opencv"].with_protobuf = False
-        # Disable opencv's eigen to resolve conflict with onnxruntime which needs eigen >= 5.0.1
-        # We use eigen/5.0.1 as an explicit requirement instead
+        # Disable opencv's bundled Eigen to resolve Conan graph conflict:
+        # onnxruntime requires Eigen >= 5.0.1; OpenCV defaults to 3.4.0.
+        # eigen/5.0.1 is listed in conandata.yml as an explicit dep to force
+        # the correct version — improc++ itself does not use Eigen directly.
         try:
             self.options["opencv"].with_eigen = False
         except Exception:


### PR DESCRIPTION
improc++ does not use Eigen directly — it appears in conandata.yml only to force eigen/5.0.1 in the Conan graph and avoid a version conflict between opencv's bundled Eigen (3.4.0) and onnxruntime's minimum requirement (>= 5.0.1).

- Remove "Eigen: 3.4.0" from README Tested With section
- Fix misleading "We use eigen/5.0.1" comment in conanfile.py

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
