### PR TITLE
chore: BUILD_SHARED_LIBS support + Conan Center Index recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,10 @@ if(NOT IMPROC_WITH_ONNX)
     list(REMOVE_ITEM IMPROC_SOURCES ${_ONNX_SOURCES})
 endif()
 
-add_library(improc STATIC ${IMPROC_HEADERS} ${IMPROC_SOURCES})
+add_library(improc ${IMPROC_HEADERS} ${IMPROC_SOURCES})
+set_target_properties(improc PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
 
 target_include_directories(improc PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/conan/conandata.yml
+++ b/conan/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/michalmaj/improc++/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "PLACEHOLDER_UPDATE_AFTER_GITHUB_RELEASE"

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,0 +1,103 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.build import check_min_cppstd
+import os
+
+
+class ImprocppConan(ConanFile):
+    name = "improcpp"
+    description = (
+        "Type-safe C++23 image processing library built on OpenCV. "
+        "Provides a composable pipeline API, geometric/filter/morphological ops, "
+        "camera I/O, ML model loaders, camera calibration, and optional ONNX Runtime inference."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/michalmaj/improc++"
+    topics = ("image-processing", "opencv", "computer-vision", "cpp23", "pipeline")
+    package_type = "library"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared":     [True, False],
+        "fPIC":       [True, False],
+        "with_onnx":  [True, False],
+    }
+    default_options = {
+        "shared":    False,
+        "fPIC":      True,
+        "with_onnx": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.options["opencv"].with_protobuf = False
+        try:
+            self.options["opencv"].with_eigen = False
+        except Exception:
+            pass
+
+    def layout(self):
+        cmake_layout(self, src_folder=".")
+
+    def validate(self):
+        check_min_cppstd(self, "23")
+
+    def requirements(self):
+        self.requires("opencv/4.10.0")
+        self.requires("nlohmann_json/3.11.3")
+        if self.options.with_onnx:
+            self.requires("onnxruntime/1.17.1")
+            # Force Eigen >= 5.0.1 to satisfy onnxruntime; opencv defaults to 3.4.0
+            self.requires("eigen/5.0.1", override=True)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.variables["IMPROC_WITH_ONNX"]      = self.options.with_onnx
+        tc.variables["IMPROC_BUILD_TESTS"]    = False
+        tc.variables["IMPROC_BUILD_EXAMPLES"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp",
+             src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+        copy(self, "*.a",
+             src=self.build_folder,
+             dst=os.path.join(self.package_folder, "lib"),
+             keep_path=False)
+        copy(self, "*.so*",
+             src=self.build_folder,
+             dst=os.path.join(self.package_folder, "lib"),
+             keep_path=False)
+        copy(self, "*.dylib*",
+             src=self.build_folder,
+             dst=os.path.join(self.package_folder, "lib"),
+             keep_path=False)
+        copy(self, "*.dll",
+             src=self.build_folder,
+             dst=os.path.join(self.package_folder, "bin"),
+             keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["improc"]
+        if self.options.with_onnx:
+            self.cpp_info.defines = ["IMPROC_WITH_ONNX"]


### PR DESCRIPTION
## Summary

- **`BUILD_SHARED_LIBS` support**: replaced `add_library(improc STATIC ...)` with a plain `add_library(improc)` so `BUILD_SHARED_LIBS=ON` produces a shared library; added `POSITION_INDEPENDENT_CODE ON` unconditionally (required for shared builds on Linux)
- **Conan Center Index recipe** (`conan/conanfile.py`): proper CCI producer recipe with `shared`/`fPIC`/`with_onnx` options, C++23 validation, and all required metadata (`name`, `description`, `license`, `url`, `homepage`, `topics`)
- **`conan/conandata.yml`**: SHA256 placeholder for v1.0.0 tarball — fill in after GitHub Release is created

## What's NOT changed

The existing `conanfile.py` at the repo root remains unchanged — it is a consumer recipe used to install dependencies for local development and is separate from the CCI recipe.

## After merge

1. Tag `v1.0.0` → create GitHub Release
2. `curl -sL <tarball-url> | sha256sum` → update `conan/conandata.yml`
3. Fork `conan-center-index` → open PR

## Test plan

- [ ] `cmake -DBUILD_SHARED_LIBS=ON ...` produces `.dylib`/`.so` (not tested locally — requires full Conan reconfiguration)
- [ ] `cmake -DBUILD_SHARED_LIBS=OFF ...` (default) still produces `.a` — existing behavior preserved
- [ ] `conan/conanfile.py` syntax: `python3 -c "import ast; ast.parse(open('conan/conanfile.py').read())"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)