### PR TITLE
chore(packaging): v1.0.2 — packaging sanity release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [[Unreleased]](#unreleased)
+- [[1.0.2]](#102--2026-06-09) — 2026-06-09 · Packaging sanity: CMake version sync, validate() toolchain guards, build_requirements, defensive CMake variables
 - [[1.0.1]](#101--2026-06-09) — 2026-06-09 · Packaging hardening: Conan Center Index recipe, `cmake.install()`, `cmake_target_name`, `BUILD_SHARED_LIBS`, onnxruntime 1.24.4
 - [[1.0.0]](#100--2026-06-08) — 2026-06-08 · API freeze: `improc/improc.hpp` top-level umbrella, `calib/calib.hpp`, optional ONNX build, version bump to 1.0.0
 - [[0.20.0]](#0200--2026-06-04) — 2026-06-04 · API completeness: `DetectHaar`, BRISK/KAZE detectors, `DnnSegmentor`, `HOGDetector`, umbrella header fixes
@@ -32,6 +33,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ---
 
 ## [Unreleased]
+
+---
+
+## [1.0.2] — 2026-06-09
+
+### Fixed
+- `CMakeLists.txt`: `project(improc VERSION ...)` now matches `version.hpp` — `improcConfigVersion.cmake` will correctly advertise `1.0.2`
+- Conan recipe: `validate()` now checks compiler version explicitly — GCC < 14, Clang < 18, Apple-Clang < 15 raise `ConanInvalidConfiguration`; MSVC raises until validated
+- Conan recipe: added `build_requirements()` with `cmake/[>=3.30 <4]` — recipe enforces the same CMake floor as the library
+- Conan recipe: `generate()` now defensively sets `IMPROC_WITH_DEPTHAI=False` and `IMPROC_BENCHMARKS=False` to prevent accidental network access during CCI builds
+- `recipes/improc/all/test_package/CMakeLists.txt`: `find_package(improc 1.0.2 CONFIG REQUIRED)` — version check now catches CMake/header mismatch at test time
+- `recipes/improc/all/conandata.yml` and `conan/conandata.yml`: both kept in sync with all released versions
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.30)
-project(improc VERSION 1.0.0)
+project(improc VERSION 1.0.2)
 
 if(APPLE)
     string(REPLACE "--as-needed" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")

--- a/conan/conandata.yml
+++ b/conan/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.2":
+    url: "https://github.com/michalmaj/improc/archive/refs/tags/v1.0.2.tar.gz"
+    sha256: "PLACEHOLDER_UPDATE_AFTER_GITHUB_RELEASE"
   "1.0.1":
     url: "https://github.com/michalmaj/improc/archive/refs/tags/v1.0.1.tar.gz"
     sha256: "1f51df6e0781b4913871e86cc6742e280aec71dc1222dff1e188b9716de585df"

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,7 +1,9 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import copy, get
 from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 import os
 
 
@@ -48,6 +50,23 @@ class ImprocConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, "23")
 
+        compiler = str(self.settings.compiler)
+        version = Version(str(self.settings.compiler.version))
+
+        if compiler == "gcc" and version < "14":
+            raise ConanInvalidConfiguration("improc requires GCC >= 14 for full C++23 support")
+        if compiler == "clang" and version < "18":
+            raise ConanInvalidConfiguration("improc requires Clang >= 18 for full C++23 support")
+        if compiler == "apple-clang" and version < "15":
+            raise ConanInvalidConfiguration("improc requires Apple-Clang >= 15 (Xcode 15) for C++23 support")
+        if compiler == "msvc":
+            raise ConanInvalidConfiguration(
+                "improc C++23 support with MSVC is not validated in this recipe"
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.30 <4]")
+
     def requirements(self):
         self.requires("opencv/4.10.0")
         self.requires("nlohmann_json/3.11.3")
@@ -68,6 +87,8 @@ class ImprocConan(ConanFile):
         tc.variables["IMPROC_WITH_ONNX"]                = self.options.with_onnx
         tc.variables["IMPROC_BUILD_TESTS"]              = False
         tc.variables["IMPROC_BUILD_EXAMPLES"]           = False
+        tc.variables["IMPROC_WITH_DEPTHAI"]             = False
+        tc.variables["IMPROC_BENCHMARKS"]               = False
         tc.generate()
 
     def build(self):

--- a/include/improc/version.hpp
+++ b/include/improc/version.hpp
@@ -3,7 +3,7 @@
 
 #define IMPROC_VERSION_MAJOR 1
 #define IMPROC_VERSION_MINOR 0
-#define IMPROC_VERSION_PATCH 1
+#define IMPROC_VERSION_PATCH 2
 
 /// Encoded as MAJOR*10000 + MINOR*100 + PATCH — use for compile-time comparisons:
 /// @code
@@ -11,7 +11,7 @@
 /// @endcode
 #define IMPROC_VERSION (IMPROC_VERSION_MAJOR * 10000 + IMPROC_VERSION_MINOR * 100 + IMPROC_VERSION_PATCH)
 
-#define IMPROC_VERSION_STRING "1.0.1"
+#define IMPROC_VERSION_STRING "1.0.2"
 
 namespace improc {
 /// Returns the library version string, e.g. "1.0.0".

--- a/recipes/improc/all/conandata.yml
+++ b/recipes/improc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.2":
+    url: "https://github.com/michalmaj/improc/archive/refs/tags/v1.0.2.tar.gz"
+    sha256: "PLACEHOLDER_UPDATE_AFTER_GITHUB_RELEASE"
   "1.0.1":
     url: "https://github.com/michalmaj/improc/archive/refs/tags/v1.0.1.tar.gz"
     sha256: "1f51df6e0781b4913871e86cc6742e280aec71dc1222dff1e188b9716de585df"

--- a/recipes/improc/all/conanfile.py
+++ b/recipes/improc/all/conanfile.py
@@ -1,7 +1,9 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import copy, get
 from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 import os
 
 
@@ -48,6 +50,23 @@ class ImprocConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, "23")
 
+        compiler = str(self.settings.compiler)
+        version = Version(str(self.settings.compiler.version))
+
+        if compiler == "gcc" and version < "14":
+            raise ConanInvalidConfiguration("improc requires GCC >= 14 for full C++23 support")
+        if compiler == "clang" and version < "18":
+            raise ConanInvalidConfiguration("improc requires Clang >= 18 for full C++23 support")
+        if compiler == "apple-clang" and version < "15":
+            raise ConanInvalidConfiguration("improc requires Apple-Clang >= 15 (Xcode 15) for C++23 support")
+        if compiler == "msvc":
+            raise ConanInvalidConfiguration(
+                "improc C++23 support with MSVC is not validated in this recipe"
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.30 <4]")
+
     def requirements(self):
         self.requires("opencv/4.10.0")
         self.requires("nlohmann_json/3.11.3")
@@ -68,6 +87,8 @@ class ImprocConan(ConanFile):
         tc.variables["IMPROC_WITH_ONNX"]                = self.options.with_onnx
         tc.variables["IMPROC_BUILD_TESTS"]              = False
         tc.variables["IMPROC_BUILD_EXAMPLES"]           = False
+        tc.variables["IMPROC_WITH_DEPTHAI"]             = False
+        tc.variables["IMPROC_BENCHMARKS"]               = False
         tc.generate()
 
     def build(self):

--- a/recipes/improc/all/test_package/CMakeLists.txt
+++ b/recipes/improc/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
 
-find_package(improc REQUIRED)
+find_package(improc 1.0.2 CONFIG REQUIRED)
 
 add_executable(test_package src/test_package.cpp)
 target_link_libraries(test_package PRIVATE improc::improc)

--- a/recipes/improc/all/test_package/src/test_package.cpp
+++ b/recipes/improc/all/test_package/src/test_package.cpp
@@ -2,6 +2,6 @@
 #include <improc/core/pipeline.hpp>
 
 int main() {
-    static_assert(IMPROC_VERSION >= 10001, "improc >= 1.0.1 required");
+    static_assert(IMPROC_VERSION >= 10002, "improc >= 1.0.2 required");
     return 0;
 }

--- a/recipes/improc/config.yml
+++ b/recipes/improc/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.2":
+    folder: all
   "1.0.1":
     folder: all


### PR DESCRIPTION
## Summary

Pure packaging patch — zero API changes. Addresses all P0 issues from second audit.

### Fixes

- **`CMakeLists.txt`**: `project(improc VERSION 1.0.2)` — was `1.0.0`, meaning `improcConfigVersion.cmake` advertised wrong version
- **`validate()`**: explicit compiler guards — GCC < 14, Clang < 18, Apple-Clang < 15 → `ConanInvalidConfiguration`; MSVC → error until validated
- **`build_requirements()`**: `cmake/[>=3.30 <4]` in both recipe files
- **`generate()`**: defensive `IMPROC_WITH_DEPTHAI=False`, `IMPROC_BENCHMARKS=False` to prevent accidental network access in CCI
- **`test_package/CMakeLists.txt`**: `find_package(improc 1.0.2 CONFIG REQUIRED)` — version mismatch now caught at test time
- **Both `conandata.yml` files**: kept in sync (1.0.2 placeholder + 1.0.1 + 1.0.0 history)

## After merge
1. Tag `v1.0.2` → GitHub Release → `curl | sha256sum`
2. Update `conan/conandata.yml` and `recipes/improc/all/conandata.yml` with real SHA256
3. Commit + push → then CCI PR

## Test plan
- [ ] `python3 -c "import ast; ast.parse(open('conan/conanfile.py').read())"` — syntax OK
- [ ] `python3 -c "import ast; ast.parse(open('recipes/improc/all/conanfile.py').read())"` — syntax OK
- [ ] CI green
