### PR TITLE
chore(packaging): align OpenCV to 4.10.0, improve CCI recipe details

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -4,6 +4,6 @@
 requirements:
   - "gtest/1.16.0"
   - "eigen/5.0.1"
-  - "opencv/4.8.1"
+  - "opencv/4.10.0"
   - "onnxruntime/1.24.4"
   - "nlohmann_json/3.11.3"

--- a/recipes/improc/all/conanfile.py
+++ b/recipes/improc/all/conanfile.py
@@ -64,7 +64,10 @@ class ImprocConan(ConanFile):
         if compiler == "clang" and version < "18":
             raise ConanInvalidConfiguration("improc requires Clang >= 18 for full C++23 support")
         if compiler == "apple-clang" and version < "16":
-            raise ConanInvalidConfiguration("improc requires Apple-Clang >= 16 (Xcode 16) for C++23 support")
+            raise ConanInvalidConfiguration(
+                "improc requires Apple-Clang >= 16 (Xcode 16); "
+                "older Apple-Clang versions are not validated for this C++23 codebase"
+            )
         if compiler == "msvc":
             raise ConanInvalidConfiguration(
                 "improc C++23 support with MSVC is not validated in this recipe"

--- a/recipes/improc/all/test_package/src/test_package.cpp
+++ b/recipes/improc/all/test_package/src/test_package.cpp
@@ -1,5 +1,4 @@
-#include <improc/version.hpp>
-#include <improc/core/pipeline.hpp>
+#include <improc/improc.hpp>
 #include <string_view>
 
 int main() {


### PR DESCRIPTION
- conandata.yml: opencv 4.8.1 → 4.10.0 (aligns with README and recipe)
- recipe validate(): clearer Apple-Clang rejection message (not validated, not a language minimum claim)
- test_package: #include <improc/improc.hpp> instead of partial headers — exercises full umbrella include and real dependency exposure

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
