### PR TITLE
chore(packaging): bump to v1.0.3 — fix GLOB_RECURSE and recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.30)
-project(improc VERSION 1.0.2)
+project(improc VERSION 1.0.3)
 
 if(APPLE)
     string(REPLACE "--as-needed" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
@@ -37,8 +37,8 @@ option(IMPROC_BUILD_TESTS    "Build improc unit tests"       ON)
 option(IMPROC_BUILD_EXAMPLES "Build improc demo executables" OFF)
 
 # === improc LIBRARY ===
-file(GLOB_RECURSE IMPROC_HEADERS CONFIGURE_DEPENDS include/improc/**/*.hpp)
-file(GLOB_RECURSE IMPROC_SOURCES CONFIGURE_DEPENDS src/**/*.cpp)
+file(GLOB_RECURSE IMPROC_HEADERS CONFIGURE_DEPENDS include/improc/*.hpp)
+file(GLOB_RECURSE IMPROC_SOURCES CONFIGURE_DEPENDS src/*.cpp)
 
 if(NOT IMPROC_WITH_ONNX)
     file(GLOB_RECURSE _ONNX_SOURCES CONFIGURE_DEPENDS src/onnx/*.cpp)

--- a/include/improc/version.hpp
+++ b/include/improc/version.hpp
@@ -3,7 +3,7 @@
 
 #define IMPROC_VERSION_MAJOR 1
 #define IMPROC_VERSION_MINOR 0
-#define IMPROC_VERSION_PATCH 2
+#define IMPROC_VERSION_PATCH 3
 
 /// Encoded as MAJOR*10000 + MINOR*100 + PATCH — use for compile-time comparisons:
 /// @code
@@ -11,7 +11,7 @@
 /// @endcode
 #define IMPROC_VERSION (IMPROC_VERSION_MAJOR * 10000 + IMPROC_VERSION_MINOR * 100 + IMPROC_VERSION_PATCH)
 
-#define IMPROC_VERSION_STRING "1.0.2"
+#define IMPROC_VERSION_STRING "1.0.3"
 
 namespace improc {
 /// Returns the library version string, e.g. "1.0.2". Defined in src/version.cpp — links a real symbol.

--- a/recipes/improc/all/conandata.yml
+++ b/recipes/improc/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.0.2":
-    url: "https://github.com/michalmaj/improc/archive/refs/tags/v1.0.2.tar.gz"
-    sha256: "607493b8e107c733be6e76466781cb2d0feaf1b26b4e2f1004a949459874af26"
+  "1.0.3":
+    url: "https://github.com/michalmaj/improc/archive/refs/tags/v1.0.3.tar.gz"
+    sha256: "PLACEHOLDER_UPDATE_AFTER_TAG"

--- a/recipes/improc/all/test_package/CMakeLists.txt
+++ b/recipes/improc/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
 
-find_package(improc 1.0.2 CONFIG REQUIRED)
+find_package(improc 1.0.3 CONFIG REQUIRED)
 
 add_executable(test_package src/test_package.cpp)
 target_link_libraries(test_package PRIVATE improc::improc)

--- a/recipes/improc/all/test_package/src/test_package.cpp
+++ b/recipes/improc/all/test_package/src/test_package.cpp
@@ -2,7 +2,7 @@
 #include <string_view>
 
 int main() {
-    static_assert(IMPROC_VERSION >= 10002, "improc >= 1.0.2 required");
+    static_assert(IMPROC_VERSION >= 10003, "improc >= 1.0.3 required");
     std::string_view v = improc::version_string();
     return v.empty() ? 1 : 0;
 }

--- a/recipes/improc/config.yml
+++ b/recipes/improc/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0.2":
+  "1.0.3":
     folder: all


### PR DESCRIPTION
Two bugs fixed:

1. CMakeLists.txt: `file(GLOB_RECURSE ... src/**/*.cpp)` does not match files directly under src/ (only subdirectories). Changed to `src/*.cpp` which with GLOB_RECURSE correctly picks up all .cpp files recursively, including src/version.cpp that provides the version_string() linker symbol.

2. Same fix applied to IMPROC_HEADERS glob for completeness.

Version bump 1.0.2 → 1.0.3 because the v1.0.2 tarball on GitHub contains the broken glob; a new tag is needed to ship the corrected CMakeLists.txt. Conandata sha256 is a placeholder pending the new tag.

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
