### PR TITLE
chore(recipe): set v1.0.3 sha256 in conandata.yml

### DIFF
--- a/recipes/improc/all/conandata.yml
+++ b/recipes/improc/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "1.0.3":
     url: "https://github.com/michalmaj/improc/archive/refs/tags/v1.0.3.tar.gz"
-    sha256: "PLACEHOLDER_UPDATE_AFTER_TAG"
+    sha256: "9c7beda81dca86d3b0737f25bb411c94af30a348c6e8d7aa05dae8db88499455"


### PR DESCRIPTION
## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
