### PR TITLE
fix(recipe): add nlohmann_json to cpp_info.requires

### DIFF
--- a/recipes/improc/all/conanfile.py
+++ b/recipes/improc/all/conanfile.py
@@ -150,6 +150,9 @@ class ImprocConan(ConanFile):
             "opencv::opencv_photo",
             "opencv::opencv_stitching",
             "opencv::opencv_video",
+            # nlohmann_json is used internally (visible=False); must appear here so
+            # Conan 2's package_info() validator sees all direct deps accounted for.
+            "nlohmann_json::nlohmann_json",
         ]
         if self.options.with_onnx:
             self.cpp_info.defines = ["IMPROC_WITH_ONNX"]


### PR DESCRIPTION
Conan 2 validates that every direct dependency declared in requirements() appears in cpp_info.requires. nlohmann_json (visible=False, private dep) was missing, causing package_info() to error when with_onnx=True built a fresh binary.

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
