### PR TITLE
fix(recipe): make nlohmann_json conditional on with_onnx

### DIFF
--- a/recipes/improc/all/conanfile.py
+++ b/recipes/improc/all/conanfile.py
@@ -78,8 +78,8 @@ class ImprocConan(ConanFile):
 
     def requirements(self):
         self.requires("opencv/4.10.0")
-        self.requires("nlohmann_json/3.11.3", visible=False)
         if self.options.with_onnx:
+            self.requires("nlohmann_json/3.11.3", visible=False)
             self.requires("onnxruntime/1.24.4")
             # Force Eigen >= 5.0.1 to satisfy onnxruntime; opencv defaults to 3.4.0
             self.requires("eigen/5.0.1", override=True)
@@ -150,10 +150,11 @@ class ImprocConan(ConanFile):
             "opencv::opencv_photo",
             "opencv::opencv_stitching",
             "opencv::opencv_video",
-            # nlohmann_json is used internally (visible=False); must appear here so
-            # Conan 2's package_info() validator sees all direct deps accounted for.
-            "nlohmann_json::nlohmann_json",
         ]
         if self.options.with_onnx:
             self.cpp_info.defines = ["IMPROC_WITH_ONNX"]
             self.cpp_info.requires.append("onnxruntime::onnxruntime")
+            # nlohmann_json is a private build-time dep (visible=False) used only
+            # in the ONNX code path; must appear here so Conan 2's package_info()
+            # validator sees all direct deps accounted for.
+            self.cpp_info.requires.append("nlohmann_json::nlohmann_json")


### PR DESCRIPTION
nlohmann_json is only used in the ONNX code path. When with_onnx=False it is absent from the resolved dependency graph, so listing it in cpp_info.requires causes Conan 2 to error ("not a direct requirement"). Moving both the requires() and the cpp_info.requires entry inside the with_onnx guard makes all three build matrix combinations pass:
- static + no_onnx
- static + with_onnx
- shared + no_onnx

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
