### PR TITLE
fix(recipe): restore unconditional nlohmann_json; gate cpp_info entry…

### DIFF
--- a/recipes/improc/all/conanfile.py
+++ b/recipes/improc/all/conanfile.py
@@ -78,8 +78,10 @@ class ImprocConan(ConanFile):
 
     def requirements(self):
         self.requires("opencv/4.10.0")
+        # nlohmann_json is used unconditionally by the COCO dataset loader (src/ml/coco_dataset.cpp).
+        # visible=False: it is a private impl dep — not exposed in improc's public headers.
+        self.requires("nlohmann_json/3.11.3", visible=False)
         if self.options.with_onnx:
-            self.requires("nlohmann_json/3.11.3", visible=False)
             self.requires("onnxruntime/1.24.4")
             # Force Eigen >= 5.0.1 to satisfy onnxruntime; opencv defaults to 3.4.0
             self.requires("eigen/5.0.1", override=True)
@@ -154,7 +156,9 @@ class ImprocConan(ConanFile):
         if self.options.with_onnx:
             self.cpp_info.defines = ["IMPROC_WITH_ONNX"]
             self.cpp_info.requires.append("onnxruntime::onnxruntime")
-            # nlohmann_json is a private build-time dep (visible=False) used only
-            # in the ONNX code path; must appear here so Conan 2's package_info()
-            # validator sees all direct deps accounted for.
+            # When onnxruntime is present it also depends on nlohmann_json, making it
+            # visible in the resolved graph. Conan 2's package_info() validator then
+            # requires it to be listed here. Without onnxruntime the visible=False dep
+            # stays quiet and must NOT appear in cpp_info.requires (shared-lib builds
+            # fail with "not a direct requirement" if it does).
             self.cpp_info.requires.append("nlohmann_json::nlohmann_json")


### PR DESCRIPTION
… on with_onnx

nlohmann_json is used unconditionally by src/ml/coco_dataset.cpp so it must always be in requirements(). However Conan 2's package_info() validation behaves differently across configurations:

- static + with_onnx: onnxruntime also depends on nlohmann_json, making it visible in the graph; Conan requires it listed in cpp_info.requires.
- static/shared + no_onnx: visible=False keeps it quiet; adding it to cpp_info.requires causes "not a direct requirement" on shared builds.

Solution: keep nlohmann_json unconditional in requirements(), but only append "nlohmann_json::nlohmann_json" to cpp_info.requires inside the with_onnx guard.

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
