### PR TITLE
fix(test_package): explicitly require opencv to get headers in shared…

### DIFF
--- a/recipes/improc/all/test_package/CMakeLists.txt
+++ b/recipes/improc/all/test_package/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
 
 find_package(improc 1.0.3 CONFIG REQUIRED)
+# improc's public headers include opencv2 headers; consumers must find OpenCV.
+# For shared-library builds, CMakeDeps does not propagate transitive cmake configs,
+# so we add include dirs directly without linking (improc already carries opencv at
+# runtime for shared builds; linking here would cause duplicate symbols with static opencv).
+find_package(OpenCV CONFIG REQUIRED COMPONENTS core)
 
 add_executable(test_package src/test_package.cpp)
 target_link_libraries(test_package PRIVATE improc::improc)
+target_include_directories(test_package PRIVATE
+    $<TARGET_PROPERTY:opencv::opencv_core,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/recipes/improc/all/test_package/conanfile.py
+++ b/recipes/improc/all/test_package/conanfile.py
@@ -10,6 +10,10 @@ class TestPackage(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+        # improc's public headers expose opencv2 types; consumers must find OpenCV.
+        # For shared-library builds CMakeDeps does not propagate transitive deps'
+        # cmake configs, so we declare it here so CMakeDeps generates the files.
+        self.requires("opencv/4.10.0")
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.15 <4]")


### PR DESCRIPTION
… builds

For shared-library builds of improc, Conan 2's CMakeDeps intentionally omits cmake configs for transitive deps (the shared lib handles runtime linking itself). This means opencv headers are not reachable through the improc::improc cmake target alone, and test_package fails to compile.

Fix: declare opencv/4.10.0 as a direct requirement so CMakeDeps always generates OpenCV cmake files. In CMakeLists.txt pull in only the include directories (via generator expression) without linking, to avoid duplicate symbols when opencv is static and improc is shared.

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
