### PR TITLE
fix(test_package): use opencv::opencv root target (not opencv::opencv…

### DIFF
--- a/recipes/improc/all/test_package/CMakeLists.txt
+++ b/recipes/improc/all/test_package/CMakeLists.txt
@@ -6,9 +6,9 @@ find_package(improc 1.0.3 CONFIG REQUIRED)
 # For shared-library builds, CMakeDeps does not propagate transitive cmake configs,
 # so we add include dirs directly without linking (improc already carries opencv at
 # runtime for shared builds; linking here would cause duplicate symbols with static opencv).
-find_package(OpenCV CONFIG REQUIRED COMPONENTS core)
+find_package(OpenCV CONFIG REQUIRED)
 
 add_executable(test_package src/test_package.cpp)
 target_link_libraries(test_package PRIVATE improc::improc)
 target_include_directories(test_package PRIVATE
-    $<TARGET_PROPERTY:opencv::opencv_core,INTERFACE_INCLUDE_DIRECTORIES>)
+    $<TARGET_PROPERTY:opencv::opencv,INTERFACE_INCLUDE_DIRECTORIES>)


### PR DESCRIPTION
…_core)

CCI's CMakeDeps generates 'opencv::opencv' as the root INTERFACE target. Component targets use the bare name 'opencv_core' (no namespace prefix). The target 'opencv::opencv_core' does not exist, causing cmake to error in the generator-expression evaluation.

## Summary

<!-- 2-4 bullets: what changed and why -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new op / feature
- [ ] `fix` — bug fix
- [ ] `docs` — tutorial, example, or doc comment
- [ ] `bench` — benchmark
- [ ] `chore` — version bump, CI, build system, release

## Ops / APIs added or changed

<!-- List new or modified op names, or "n/a" for pure docs/chore -->

| Op | Namespace | Header |
|---|---|---|
| | | |

## Test plan

- [ ] `cmake --build build --parallel` — no errors
- [ ] `cd build && ctest --output-on-failure` — all tests pass (or pre-existing failures documented below)
- [ ] New ops have GTest coverage in `tests/`
- [ ] New examples build and run without crashing

## Pre-existing test failures (if any)

<!-- List any failing tests that are NOT caused by this PR, with a brief reason -->

None

## CHANGELOG updated?

- [ ] Yes — new entry under `## [Unreleased]` (or version section for releases)
- [ ] N/a — docs / chore only
